### PR TITLE
Refine Accessories

### DIFF
--- a/ArmoryInventory.xcodeproj/project.pbxproj
+++ b/ArmoryInventory.xcodeproj/project.pbxproj
@@ -53,24 +53,6 @@
 		};
 /* End PBXFrameworksBuildPhase section */
 
-/* Begin PBXShellScriptBuildPhase section */
-		B5A1A1003C1B100000000001 /* Update Build Number */ = {
-			isa = PBXShellScriptBuildPhase;
-			alwaysOutOfDate = 1;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "Update Build Number";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "set -eu\n\nbuild_number=\"$(date +%Y%m%d.%H%M)\"\ninfo_plist=\"${TARGET_BUILD_DIR}/${INFOPLIST_PATH}\"\n\nif ! /usr/libexec/PlistBuddy -c \"Set :CFBundleVersion ${build_number}\" \"$info_plist\"; then\n  /usr/libexec/PlistBuddy -c \"Add :CFBundleVersion string ${build_number}\" \"$info_plist\"\nfi\n\necho \"Updated CFBundleVersion to ${build_number}\"\n";
-		};
-/* End PBXShellScriptBuildPhase section */
-
 /* Begin PBXGroup section */
 		B5025A8A2F7F44CA003069A9 = {
 			isa = PBXGroup;
@@ -196,6 +178,24 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXResourcesBuildPhase section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		B5A1A1003C1B100000000001 /* Update Build Number */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Update Build Number";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "set -eu\n\nbuild_number=\"$(date +%Y%m%d.%H%M)\"\ninfo_plist=\"${TARGET_BUILD_DIR}/${INFOPLIST_PATH}\"\n\nif ! /usr/libexec/PlistBuddy -c \"Set :CFBundleVersion ${build_number}\" \"$info_plist\"; then\n  /usr/libexec/PlistBuddy -c \"Add :CFBundleVersion string ${build_number}\" \"$info_plist\"\nfi\n\necho \"Updated CFBundleVersion to ${build_number}\"\n";
+		};
+/* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
 		B5025A8F2F7F44CA003069A9 /* Sources */ = {

--- a/ArmoryInventory/Accessories/AccessoriesView.swift
+++ b/ArmoryInventory/Accessories/AccessoriesView.swift
@@ -12,6 +12,7 @@ struct AccessoriesView: View {
     @Query private var optics: [Optic]
     @Query private var magazines: [Magazine]
     @Query private var attachments: [Attachment]
+    @Query private var parts: [Part]
     @AppStorage(InventorySettingsKeys.showTotalValue) private var showTotalValue = true
     private let topLevelCategories = AccessoryCategory.topLevelCategories
 
@@ -51,6 +52,8 @@ struct AccessoriesView: View {
             MagazinesView()
         case "attachments":
             AttachmentsView()
+        case "parts":
+            PartsView()
         default:
             AccessoryCategoryDetailView(category: category)
         }
@@ -60,7 +63,8 @@ struct AccessoriesView: View {
         let totalCents =
             optics.reduce(0) { $0 + max(0, $1.purchasePriceCents) } +
             magazines.reduce(0) { $0 + max(0, $1.purchasePriceCents) } +
-            attachments.reduce(0) { $0 + max(0, $1.purchasePriceCents) }
+            attachments.reduce(0) { $0 + max(0, $1.purchasePriceCents) } +
+            parts.reduce(0) { $0 + max(0, $1.purchasePriceCents) }
         let amount = Decimal(totalCents) / 100
         return amount.formatted(.currency(code: Locale.current.currency?.identifier ?? "USD"))
     }
@@ -146,6 +150,14 @@ private struct AccessoryCategory: Identifiable {
             shortDescription: "Mounted accessories grouped by attachment type",
             detailDescription: "Attachments include mounted accessories such as stocks, grips, lasers, lights, hand stops, and similar hardware. They can be categorized later using an Attachment Type field instead of separate screens.",
             examples: ["Stock", "Grip", "Laser", "Light", "Hand Stop", "Bipod"]
+        ),
+        AccessoryCategory(
+            id: "parts",
+            name: "Parts",
+            systemImage: "gearshape.2.fill",
+            shortDescription: "Core components and replacement assemblies",
+            detailDescription: "Parts cover major firearm components you install, swap, or keep on hand, such as barrels, triggers, receivers, recoil systems, and other internal assemblies.",
+            examples: ["Barrel", "Trigger", "Bolt Carrier Group", "Charging Handle", "Slide", "Recoil System"]
         ),
     ]
 }

--- a/ArmoryInventory/Accessories/Attachments/AddAttachmentView.swift
+++ b/ArmoryInventory/Accessories/Attachments/AddAttachmentView.swift
@@ -94,8 +94,14 @@ struct AddAttachmentView: View {
                 if showsPurchaseSection {
                     Section("Purchase") {
                         DatePicker("Purchase date", selection: $purchaseDate, displayedComponents: .date)
-                        TextField("Purchase price (USD)", text: $purchasePriceText)
-                            .keyboardType(.decimalPad)
+                        LabeledContent("Purchase Price") {
+                            SelectAllTextField(
+                                placeholder: "",
+                                text: $purchasePriceText,
+                                keyboardType: .decimalPad,
+                                textAlignment: .right
+                            )
+                        }
                         Text("With \(accessoriesTaxRate.formatted(.number.precision(.fractionLength(0...2))))% accessories tax: \(purchasePriceWithTaxText)")
                             .font(.footnote)
                             .foregroundStyle(.secondary)

--- a/ArmoryInventory/Accessories/Attachments/AddAttachmentView.swift
+++ b/ArmoryInventory/Accessories/Attachments/AddAttachmentView.swift
@@ -49,18 +49,27 @@ struct AddAttachmentView: View {
         NavigationStack {
             Form {
                 Section("Basic Info") {
-                    TextField("Brand", text: $brand)
-                        .textInputAutocapitalization(.words)
-                    TextField("Model name", text: $modelName)
-                        .textInputAutocapitalization(.words)
+                    LabeledContent("Brand") {
+                        TextField("", text: $brand)
+                            .textInputAutocapitalization(.words)
+                            .multilineTextAlignment(.trailing)
+                    }
+                    LabeledContent("Model Name") {
+                        TextField("", text: $modelName)
+                            .textInputAutocapitalization(.words)
+                            .multilineTextAlignment(.trailing)
+                    }
                     Picker("Attachment Type", selection: $selectedType) {
                         ForEach(AttachmentType.allCases) { type in
                             Text(type.displayName).tag(type)
                         }
                     }
                     if selectedType == .other {
-                        TextField("Type details", text: $customType)
-                            .textInputAutocapitalization(.words)
+                        LabeledContent("Type Details") {
+                            TextField("", text: $customType)
+                                .textInputAutocapitalization(.words)
+                                .multilineTextAlignment(.trailing)
+                        }
                     }
                 }
                 .disabled(isReadOnly)
@@ -74,7 +83,10 @@ struct AddAttachmentView: View {
                     }
 
                     if selectedColor == .other {
-                        TextField("Color details", text: $customColor)
+                        LabeledContent("Color Details") {
+                            TextField("", text: $customColor)
+                                .multilineTextAlignment(.trailing)
+                        }
                     }
                 }
                 .disabled(isReadOnly)

--- a/ArmoryInventory/Accessories/Magazines/AddMagazineView.swift
+++ b/ArmoryInventory/Accessories/Magazines/AddMagazineView.swift
@@ -58,12 +58,17 @@ struct AddMagazineView: View {
         NavigationStack {
             Form {
                 Section("Basic Info") {
-                    TextField("Brand", text: $brand)
-                        .textInputAutocapitalization(.words)
-                    TextField("Model name", text: $modelName)
-                        .textInputAutocapitalization(.words)
-                    HStack {
-                        Text("Count")
+                    LabeledContent("Brand") {
+                        TextField("", text: $brand)
+                            .textInputAutocapitalization(.words)
+                            .multilineTextAlignment(.trailing)
+                    }
+                    LabeledContent("Model Name") {
+                        TextField("", text: $modelName)
+                            .textInputAutocapitalization(.words)
+                            .multilineTextAlignment(.trailing)
+                    }
+                    LabeledContent("Count") {
                         TextField("1", text: $countText)
                             .keyboardType(.numberPad)
                             .multilineTextAlignment(.trailing)
@@ -79,8 +84,11 @@ struct AddMagazineView: View {
                         }
                     }
 
-                    TextField("Capacity", text: $capacityText)
-                        .keyboardType(.numberPad)
+                    LabeledContent("Capacity") {
+                        TextField("", text: $capacityText)
+                            .keyboardType(.numberPad)
+                            .multilineTextAlignment(.trailing)
+                    }
 
                     Picker("Color", selection: $selectedColor) {
                         Text("None").tag(nil as FirearmColor?)
@@ -90,7 +98,10 @@ struct AddMagazineView: View {
                     }
 
                     if selectedColor == .other {
-                        TextField("Color details", text: $customColor)
+                        LabeledContent("Color Details") {
+                            TextField("", text: $customColor)
+                                .multilineTextAlignment(.trailing)
+                        }
                     }
                 }
                 .disabled(isReadOnly)

--- a/ArmoryInventory/Accessories/Magazines/AddMagazineView.swift
+++ b/ArmoryInventory/Accessories/Magazines/AddMagazineView.swift
@@ -109,8 +109,14 @@ struct AddMagazineView: View {
                 if showsPurchaseSection {
                     Section("Purchase") {
                         DatePicker("Purchase date", selection: $purchaseDate, displayedComponents: .date)
-                        TextField("Purchase price (USD)", text: $purchasePriceText)
-                            .keyboardType(.decimalPad)
+                        LabeledContent("Purchase Price") {
+                            SelectAllTextField(
+                                placeholder: "",
+                                text: $purchasePriceText,
+                                keyboardType: .decimalPad,
+                                textAlignment: .right
+                            )
+                        }
                         Text("With \(accessoriesTaxRate.formatted(.number.precision(.fractionLength(0...2))))% accessories tax: \(purchasePriceWithTaxText)")
                             .font(.footnote)
                             .foregroundStyle(.secondary)

--- a/ArmoryInventory/Accessories/Optics/AddOpticView.swift
+++ b/ArmoryInventory/Accessories/Optics/AddOpticView.swift
@@ -210,8 +210,14 @@ struct AddOpticView: View {
                 if showsPurchaseSection {
                     Section("Purchase") {
                         DatePicker("Purchase date", selection: $purchaseDate, displayedComponents: .date)
-                        TextField("Purchase price (USD)", text: $purchasePriceText)
-                            .keyboardType(.decimalPad)
+                        LabeledContent("Purchase Price") {
+                            SelectAllTextField(
+                                placeholder: "",
+                                text: $purchasePriceText,
+                                keyboardType: .decimalPad,
+                                textAlignment: .right
+                            )
+                        }
                         Text("With \(accessoriesTaxRate.formatted(.number.precision(.fractionLength(0...2))))% accessories tax: \(purchasePriceWithTaxText)")
                             .font(.footnote)
                             .foregroundStyle(.secondary)

--- a/ArmoryInventory/Accessories/Optics/AddOpticView.swift
+++ b/ArmoryInventory/Accessories/Optics/AddOpticView.swift
@@ -86,13 +86,22 @@ struct AddOpticView: View {
         NavigationStack {
             Form {
                 Section("Basic Info") {
-                    TextField("Brand", text: $brand)
-                        .textInputAutocapitalization(.words)
-                    TextField("Model name", text: $modelName)
-                        .textInputAutocapitalization(.words)
-                    TextField("Serial number (optional)", text: $serialNumber)
-                        .textInputAutocapitalization(.characters)
-                        .autocorrectionDisabled()
+                    LabeledContent("Brand") {
+                        TextField("", text: $brand)
+                            .textInputAutocapitalization(.words)
+                            .multilineTextAlignment(.trailing)
+                    }
+                    LabeledContent("Model Name") {
+                        TextField("", text: $modelName)
+                            .textInputAutocapitalization(.words)
+                            .multilineTextAlignment(.trailing)
+                    }
+                    LabeledContent("Serial Number") {
+                        TextField("Optional", text: $serialNumber)
+                            .textInputAutocapitalization(.characters)
+                            .autocorrectionDisabled()
+                            .multilineTextAlignment(.trailing)
+                    }
                     if duplicateExists {
                         Text("That serial number already exists in your inventory.")
                             .font(.footnote)
@@ -117,23 +126,28 @@ struct AddOpticView: View {
                         customFootprint = updatedSelection.customFootprint
                     }
 
-                    Picker("Magnification", selection: $isFixedMagnification) {
-                        Text("Fixed").tag(true)
-                        Text("Variable").tag(false)
-                    }
-                    .pickerStyle(.segmented)
+                    if showsMagnificationFields {
+                        Picker("Magnification", selection: $isFixedMagnification) {
+                            Text("Fixed").tag(true)
+                            Text("Variable").tag(false)
+                        }
+                        .pickerStyle(.segmented)
 
-                    if isFixedMagnification {
-                        TextField("Magnification", text: $fixedMagnificationText)
-                            .keyboardType(.decimalPad)
-                    } else {
-                        HStack(spacing: 12) {
-                            TextField("Min", text: $minMagnificationText)
-                                .keyboardType(.decimalPad)
-                            Divider()
-                                .frame(height: 24)
-                            TextField("Max", text: $maxMagnificationText)
-                                .keyboardType(.decimalPad)
+                        if isFixedMagnification {
+                            LabeledContent("Magnification") {
+                                TextField("", text: $fixedMagnificationText)
+                                    .keyboardType(.decimalPad)
+                                    .multilineTextAlignment(.trailing)
+                            }
+                        } else {
+                            HStack(spacing: 12) {
+                                TextField("Min", text: $minMagnificationText)
+                                    .keyboardType(.decimalPad)
+                                Divider()
+                                    .frame(height: 24)
+                                TextField("Max", text: $maxMagnificationText)
+                                    .keyboardType(.decimalPad)
+                            }
                         }
                     }
 
@@ -146,19 +160,35 @@ struct AddOpticView: View {
                         }
                     }
 
-                    TextField("Reticle (optional)", text: $reticle)
-                        .textInputAutocapitalization(.words)
+                    LabeledContent("Reticle") {
+                        TextField("Optional", text: $reticle)
+                            .textInputAutocapitalization(.words)
+                            .multilineTextAlignment(.trailing)
+                    }
                     Picker("Footprint", selection: $selectedFootprint) {
                         ForEach(OpticFootprint.allCases) { footprint in
                             Text(footprint.displayName).tag(footprint)
                         }
                     }
                     if selectedFootprint == .other {
-                        TextField("Footprint details", text: $customFootprint)
-                            .textInputAutocapitalization(.words)
+                        LabeledContent("Footprint Details") {
+                            TextField("", text: $customFootprint)
+                                .textInputAutocapitalization(.words)
+                                .multilineTextAlignment(.trailing)
+                        }
                     }
-                    TextField("Tube size in mm (optional)", text: $tubeSizeText)
-                        .keyboardType(.decimalPad)
+                    if showsTubeSizeField {
+                        LabeledContent("Tube Size") {
+                            HStack(spacing: 6) {
+                                TextField("Optional", text: $tubeSizeText)
+                                    .keyboardType(.decimalPad)
+                                    .multilineTextAlignment(.trailing)
+
+                                Text("mm")
+                                    .foregroundStyle(.secondary)
+                            }
+                        }
+                    }
                     Toggle("Illuminated", isOn: $isIlluminated)
 
                     Picker("Color", selection: $selectedColor) {
@@ -169,7 +199,10 @@ struct AddOpticView: View {
                     }
 
                     if selectedColor == .other {
-                        TextField("Color details", text: $customColor)
+                        LabeledContent("Color Details") {
+                            TextField("", text: $customColor)
+                                .multilineTextAlignment(.trailing)
+                        }
                     }
                 }
                 .disabled(isReadOnly)
@@ -232,7 +265,11 @@ struct AddOpticView: View {
     }
 
     private var resolvedMagnification: (min: Double, max: Double)? {
-        viewModel.resolvedMagnification(
+        guard showsMagnificationFields else {
+            return (1, 1)
+        }
+
+        return viewModel.resolvedMagnification(
             isFixed: isFixedMagnification,
             fixedText: fixedMagnificationText,
             minText: minMagnificationText,
@@ -257,7 +294,11 @@ struct AddOpticView: View {
     }
 
     private var resolvedTubeSizeMillimeters: Double? {
-        viewModel.tubeSizeMillimeters(from: tubeSizeText)
+        guard showsTubeSizeField else {
+            return nil
+        }
+
+        return viewModel.tubeSizeMillimeters(from: tubeSizeText)
     }
 
     private var resolvedFocalPlane: OpticFocalPlane? {
@@ -280,7 +321,15 @@ struct AddOpticView: View {
     }
 
     private var showsFocalPlane: Bool {
-        viewModel.showsFocalPlane(isFixedMagnification: isFixedMagnification)
+        showsMagnificationFields && viewModel.showsFocalPlane(isFixedMagnification: isFixedMagnification)
+    }
+
+    private var showsMagnificationFields: Bool {
+        viewModel.showsMagnificationFields(for: selectedType)
+    }
+
+    private var showsTubeSizeField: Bool {
+        viewModel.showsTubeSizeField(for: selectedType)
     }
 
     private var purchasePriceWithTaxText: String {

--- a/ArmoryInventory/Accessories/Optics/AddOpticViewModel.swift
+++ b/ArmoryInventory/Accessories/Optics/AddOpticViewModel.swift
@@ -140,6 +140,19 @@ final class AddOpticViewModel {
         return (minValue, maxValue)
     }
 
+    func showsMagnificationFields(for selectedType: OpticType) -> Bool {
+        switch selectedType {
+        case .redDot, .holographic:
+            return false
+        default:
+            return true
+        }
+    }
+
+    func showsTubeSizeField(for selectedType: OpticType) -> Bool {
+        showsMagnificationFields(for: selectedType)
+    }
+
     func duplicateExists(serialNumber: String, excluding optic: Optic?, in existingOptics: [Optic]) -> Bool {
         guard let normalizedSerialNumber = optionalSerialNumber(serialNumber) else {
             return false
@@ -192,18 +205,22 @@ final class AddOpticViewModel {
         if selectedFootprint == .other, footprintDetail == nil {
             return false
         }
-        guard resolvedMagnification(
-            isFixed: isFixedMagnification,
-            fixedText: fixedMagnificationText,
-            minText: minMagnificationText,
-            maxText: maxMagnificationText
-        ) != nil else {
+        if showsMagnificationFields(for: selectedType) {
+            guard resolvedMagnification(
+                isFixed: isFixedMagnification,
+                fixedText: fixedMagnificationText,
+                minText: minMagnificationText,
+                maxText: maxMagnificationText
+            ) != nil else {
+                return false
+            }
+        }
+        if showsTubeSizeField(for: selectedType),
+           !trimmedValue(tubeSizeText).isEmpty,
+           tubeSizeMillimeters(from: tubeSizeText) == nil {
             return false
         }
-        if !trimmedValue(tubeSizeText).isEmpty && tubeSizeMillimeters(from: tubeSizeText) == nil {
-            return false
-        }
-        if !isFixedMagnification, focalPlane == nil {
+        if showsMagnificationFields(for: selectedType), !isFixedMagnification, focalPlane == nil {
             return false
         }
         if selectedColor == .other, colorDetail == nil {

--- a/ArmoryInventory/Accessories/Parts/AddPartView.swift
+++ b/ArmoryInventory/Accessories/Parts/AddPartView.swift
@@ -1,0 +1,253 @@
+//
+//  AddPartView.swift
+//  Armory Inventory
+//
+//  Created by Codex on 4/5/26.
+//
+
+import SwiftUI
+import SwiftData
+
+struct AddPartView: View {
+    @Environment(\.dismiss) private var dismiss
+    @Environment(\.modelContext) private var context
+    @AppStorage(InventorySettingsKeys.accessoriesSalesTaxRate) private var accessoriesTaxRate = 0.0
+    @AppStorage(InventorySettingsKeys.showValueInDetails) private var showValueInDetails = true
+
+    let part: Part?
+    @State private var brand = ""
+    @State private var modelName = ""
+    @State private var selectedType: PartType = .barrel
+    @State private var customType = ""
+    @State private var selectedColor: FirearmColor?
+    @State private var customColor = ""
+    @State private var purchaseDate = Date.now
+    @State private var purchasePriceText = "0.00"
+    @State private var notes = ""
+    @State private var unlinkFirearm = false
+    @State private var isEditing = false
+
+    let viewModel: AddPartViewModel
+
+    init(part: Part? = nil, viewModel: AddPartViewModel) {
+        self.part = part
+        self.viewModel = viewModel
+        _brand = State(initialValue: part?.brand ?? "")
+        _modelName = State(initialValue: part?.modelName ?? "")
+        _selectedType = State(initialValue: part?.partType ?? .barrel)
+        _customType = State(initialValue: part?.partType == .other ? part?.typeDetail ?? "" : "")
+        _selectedColor = State(initialValue: part?.partColor)
+        _customColor = State(initialValue: part?.partColor == .other ? part?.colorDetail ?? "" : "")
+        _purchaseDate = State(initialValue: part?.purchaseDate ?? .now)
+        _purchasePriceText = State(initialValue: viewModel.initialPurchasePriceText(for: part))
+        _notes = State(initialValue: part?.notes ?? "")
+        _unlinkFirearm = State(initialValue: false)
+        _isEditing = State(initialValue: part == nil)
+    }
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section("Basic Info") {
+                    LabeledContent("Brand") {
+                        TextField("", text: $brand)
+                            .textInputAutocapitalization(.words)
+                            .multilineTextAlignment(.trailing)
+                    }
+                    LabeledContent("Model Name") {
+                        TextField("", text: $modelName)
+                            .textInputAutocapitalization(.words)
+                            .multilineTextAlignment(.trailing)
+                    }
+                    Picker("Part Type", selection: $selectedType) {
+                        ForEach(PartType.allCases) { type in
+                            Text(type.displayName).tag(type)
+                        }
+                    }
+                    if selectedType == .other {
+                        LabeledContent("Type Details") {
+                            TextField("", text: $customType)
+                                .textInputAutocapitalization(.words)
+                                .multilineTextAlignment(.trailing)
+                        }
+                    }
+                }
+                .disabled(isReadOnly)
+
+                Section("Configuration") {
+                    Picker("Color", selection: $selectedColor) {
+                        Text("None").tag(nil as FirearmColor?)
+                        ForEach(FirearmColor.allCases) { color in
+                            Text(color.displayName).tag(Optional(color))
+                        }
+                    }
+
+                    if selectedColor == .other {
+                        LabeledContent("Color Details") {
+                            TextField("", text: $customColor)
+                                .multilineTextAlignment(.trailing)
+                        }
+                    }
+                }
+                .disabled(isReadOnly)
+
+                if showsPurchaseSection {
+                    Section("Purchase") {
+                        DatePicker("Purchase date", selection: $purchaseDate, displayedComponents: .date)
+                        LabeledContent("Purchase Price") {
+                            SelectAllTextField(
+                                placeholder: "",
+                                text: $purchasePriceText,
+                                keyboardType: .decimalPad,
+                                textAlignment: .right
+                            )
+                        }
+                        Text("With \(accessoriesTaxRate.formatted(.number.precision(.fractionLength(0...2))))% accessories tax: \(purchasePriceWithTaxText)")
+                            .font(.footnote)
+                            .foregroundStyle(.secondary)
+                    }
+                    .disabled(isReadOnly)
+                }
+
+                Section("Notes") {
+                    TextField("Notes (optional)", text: $notes, axis: .vertical)
+                        .lineLimit(3...6)
+                }
+                .disabled(isReadOnly)
+
+                if let linkedFirearm = linkedFirearm {
+                    Section("Linked Firearm") {
+                        Text(linkedFirearm.displayName)
+                        if isEditing {
+                            Button(role: .destructive) {
+                                unlinkFirearm = true
+                            } label: {
+                                Text("Unlink Firearm")
+                            }
+                        }
+                    }
+                }
+            }
+            .navigationTitle(part == nil ? "New Part" : "Part Details")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") { dismiss() }
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button(primaryButtonTitle) { handlePrimaryAction() }
+                        .disabled(isEditing && !canAdd)
+                }
+            }
+        }
+    }
+
+    private var resolvedTypeDetail: String? {
+        viewModel.resolvedTypeDetail(selectedType: selectedType, customType: customType)
+    }
+
+    private var resolvedColorDetail: String? {
+        viewModel.resolvedColorDetail(selectedColor: selectedColor, customColor: customColor)
+    }
+
+    private var resolvedPurchasePriceCents: Int? {
+        viewModel.purchasePriceCents(from: purchasePriceText)
+    }
+
+    private var resolvedNotes: String? {
+        viewModel.optionalValue(notes)
+    }
+
+    private var linkedFirearm: Firearm? {
+        viewModel.linkedFirearm(for: part, unlinkFirearm: unlinkFirearm)
+    }
+
+    private var purchasePriceWithTaxText: String {
+        viewModel.purchasePriceWithTaxText(
+            purchasePriceCents: resolvedPurchasePriceCents,
+            taxRate: accessoriesTaxRate
+        )
+    }
+
+    private var isReadOnly: Bool {
+        viewModel.isReadOnly(hasPart: part != nil, isEditing: isEditing)
+    }
+
+    private var showsPurchaseSection: Bool {
+        viewModel.showsPurchaseSection(showValueInDetails: showValueInDetails, isReadOnly: isReadOnly)
+    }
+
+    private var primaryButtonTitle: String {
+        viewModel.primaryButtonTitle(hasPart: part != nil, isEditing: isEditing)
+    }
+
+    private var canAdd: Bool {
+        viewModel.canAdd(
+            brand: brand,
+            modelName: modelName,
+            selectedType: selectedType,
+            typeDetail: resolvedTypeDetail,
+            selectedColor: selectedColor,
+            colorDetail: resolvedColorDetail,
+            purchasePriceText: purchasePriceText
+        )
+    }
+
+    private func savePart() {
+        guard let purchasePriceCents = resolvedPurchasePriceCents else {
+            return
+        }
+
+        let didSave: Bool
+        if let part {
+            didSave = viewModel.updatePart(
+                part,
+                brand: brand,
+                modelName: modelName,
+                type: selectedType,
+                typeDetail: resolvedTypeDetail,
+                color: selectedColor,
+                colorDetail: resolvedColorDetail,
+                purchaseDate: purchaseDate,
+                purchasePriceCents: purchasePriceCents,
+                notes: resolvedNotes,
+                firearm: linkedFirearm,
+                canSave: canAdd,
+                in: context
+            )
+        } else {
+            didSave = viewModel.addPart(
+                brand: brand,
+                modelName: modelName,
+                type: selectedType,
+                typeDetail: resolvedTypeDetail,
+                color: selectedColor,
+                colorDetail: resolvedColorDetail,
+                purchaseDate: purchaseDate,
+                purchasePriceCents: purchasePriceCents,
+                notes: resolvedNotes,
+                firearm: nil,
+                canAdd: canAdd,
+                to: context
+            )
+        }
+
+        guard didSave else {
+            return
+        }
+
+        if part == nil {
+            dismiss()
+        } else {
+            isEditing = false
+        }
+    }
+
+    private func handlePrimaryAction() {
+        if part != nil && !isEditing {
+            isEditing = true
+            return
+        }
+        savePart()
+    }
+}

--- a/ArmoryInventory/Accessories/Parts/AddPartViewModel.swift
+++ b/ArmoryInventory/Accessories/Parts/AddPartViewModel.swift
@@ -1,0 +1,202 @@
+//
+//  AddPartViewModel.swift
+//  Armory Inventory
+//
+//  Created by Codex on 4/5/26.
+//
+
+import Foundation
+import SwiftData
+
+final class AddPartViewModel {
+    func initialPurchasePriceText(for part: Part?) -> String {
+        part.map {
+            (Decimal($0.purchasePriceCents) / 100).formatted(.number.precision(.fractionLength(2)))
+        } ?? "0.00"
+    }
+
+    func trimmedValue(_ value: String) -> String {
+        value.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    func optionalValue(_ value: String) -> String? {
+        let trimmedValue = trimmedValue(value)
+        return trimmedValue.isEmpty ? nil : trimmedValue
+    }
+
+    func purchasePriceCents(from text: String) -> Int? {
+        let trimmedText = trimmedValue(text)
+        guard !trimmedText.isEmpty else {
+            return nil
+        }
+
+        let normalizedText = trimmedText.replacingOccurrences(of: "$", with: "")
+        guard let amount = Decimal(string: normalizedText), amount >= 0 else {
+            return nil
+        }
+
+        let cents = (amount * 100 as NSDecimalNumber).rounding(accordingToBehavior: nil).intValue
+        return cents
+    }
+
+    func resolvedTypeDetail(selectedType: PartType, customType: String) -> String? {
+        guard selectedType == .other else {
+            return nil
+        }
+
+        let typeDetail = trimmedValue(customType)
+        return typeDetail.isEmpty ? nil : typeDetail
+    }
+
+    func resolvedColorDetail(selectedColor: FirearmColor?, customColor: String) -> String? {
+        guard selectedColor == .other else {
+            return nil
+        }
+
+        let colorDetail = trimmedValue(customColor)
+        return colorDetail.isEmpty ? nil : colorDetail
+    }
+
+    func linkedFirearm(for part: Part?, unlinkFirearm: Bool) -> Firearm? {
+        unlinkFirearm ? nil : part?.firearm
+    }
+
+    func purchasePriceWithTaxText(purchasePriceCents: Int?, taxRate: Double) -> String {
+        guard let purchasePriceCents else {
+            return "--"
+        }
+
+        let multiplier = 1 + (taxRate / 100)
+        let total = (Decimal(purchasePriceCents) / 100) * Decimal(multiplier)
+        return total.formatted(.currency(code: Locale.current.currency?.identifier ?? "USD"))
+    }
+
+    func isReadOnly(hasPart: Bool, isEditing: Bool) -> Bool {
+        hasPart && !isEditing
+    }
+
+    func showsPurchaseSection(showValueInDetails: Bool, isReadOnly: Bool) -> Bool {
+        showValueInDetails || !isReadOnly
+    }
+
+    func primaryButtonTitle(hasPart: Bool, isEditing: Bool) -> String {
+        if !hasPart {
+            return "Add"
+        }
+
+        return isEditing ? "Save" : "Edit"
+    }
+
+    func nextSortOrder(in context: ModelContext) -> Int {
+        var descriptor = FetchDescriptor<Part>(
+            sortBy: [SortDescriptor(\.sortOrder, order: .reverse)]
+        )
+        descriptor.fetchLimit = 1
+        let highestSortOrder = (try? context.fetch(descriptor).first?.sortOrder) ?? -1
+        return highestSortOrder + 1
+    }
+
+    func canAdd(
+        brand: String,
+        modelName: String,
+        selectedType: PartType,
+        typeDetail: String?,
+        selectedColor: FirearmColor?,
+        colorDetail: String?,
+        purchasePriceText: String
+    ) -> Bool {
+        guard !trimmedValue(brand).isEmpty else { return false }
+        guard !trimmedValue(modelName).isEmpty else { return false }
+        guard purchasePriceCents(from: purchasePriceText) != nil else { return false }
+        if selectedType == .other, typeDetail == nil {
+            return false
+        }
+        if selectedColor == .other, colorDetail == nil {
+            return false
+        }
+        return true
+    }
+
+    func addPart(
+        brand: String,
+        modelName: String,
+        type: PartType,
+        typeDetail: String?,
+        color: FirearmColor?,
+        colorDetail: String?,
+        purchaseDate: Date,
+        purchasePriceCents: Int,
+        notes: String?,
+        firearm: Firearm? = nil,
+        canAdd: Bool,
+        to context: ModelContext
+    ) -> Bool {
+        guard canAdd else {
+            return false
+        }
+
+        let part = Part(
+            brand: trimmedValue(brand),
+            modelName: trimmedValue(modelName),
+            type: type,
+            typeDetail: typeDetail,
+            color: color,
+            colorDetail: colorDetail,
+            purchaseDate: purchaseDate,
+            purchasePriceCents: purchasePriceCents,
+            notes: notes,
+            firearm: firearm,
+            sortOrder: nextSortOrder(in: context)
+        )
+        context.insert(part)
+
+        do {
+            try context.save()
+            UserDefaults.standard.set(Date(), forKey: "LastModelSaveDate")
+            return true
+        } catch {
+            print("Save error: \(error)")
+            return false
+        }
+    }
+
+    func updatePart(
+        _ part: Part,
+        brand: String,
+        modelName: String,
+        type: PartType,
+        typeDetail: String?,
+        color: FirearmColor?,
+        colorDetail: String?,
+        purchaseDate: Date,
+        purchasePriceCents: Int,
+        notes: String?,
+        firearm: Firearm?,
+        canSave: Bool,
+        in context: ModelContext
+    ) -> Bool {
+        guard canSave else {
+            return false
+        }
+
+        part.brand = trimmedValue(brand)
+        part.modelName = trimmedValue(modelName)
+        part.type = type.rawValue
+        part.typeDetail = typeDetail
+        part.color = color?.rawValue
+        part.colorDetail = colorDetail
+        part.purchaseDate = purchaseDate
+        part.purchasePriceCents = purchasePriceCents
+        part.notes = notes
+        part.firearm = firearm
+
+        do {
+            try context.save()
+            UserDefaults.standard.set(Date(), forKey: "LastModelSaveDate")
+            return true
+        } catch {
+            print("Save error: \(error)")
+            return false
+        }
+    }
+}

--- a/ArmoryInventory/Accessories/Parts/PartModels.swift
+++ b/ArmoryInventory/Accessories/Parts/PartModels.swift
@@ -1,0 +1,141 @@
+//
+//  PartModels.swift
+//  Armory Inventory
+//
+//  Created by Codex on 4/5/26.
+//
+
+import Foundation
+import SwiftData
+
+enum PartType: String, Codable, CaseIterable, Identifiable {
+    case barrel
+    case trigger
+    case slide
+    case boltCarrierGroup
+    case chargingHandle
+    case upperReceiver
+    case lowerReceiver
+    case recoilSystem
+    case internals
+    case other
+
+    var id: String { rawValue }
+
+    var displayName: String {
+        switch self {
+        case .barrel:
+            return "Barrel"
+        case .trigger:
+            return "Trigger"
+        case .slide:
+            return "Slide"
+        case .boltCarrierGroup:
+            return "Bolt Carrier Group"
+        case .chargingHandle:
+            return "Charging Handle"
+        case .upperReceiver:
+            return "Upper Receiver"
+        case .lowerReceiver:
+            return "Lower Receiver"
+        case .recoilSystem:
+            return "Recoil System"
+        case .internals:
+            return "Internals"
+        case .other:
+            return "Other"
+        }
+    }
+
+    static func displayOrder(for names: [String]) -> [String] {
+        let enumOrder = allCases.map(\.displayName)
+        let knownNames = enumOrder.filter(names.contains)
+        let customNames = names.filter { !enumOrder.contains($0) }.sorted()
+        return knownNames + customNames
+    }
+}
+
+@Model
+final class Part {
+    var id: UUID?
+    var brand: String
+    var modelName: String
+    var type: PartType.RawValue
+    var typeDetail: String?
+    var color: FirearmColor.RawValue?
+    var colorDetail: String?
+    var purchaseDate: Date
+    var purchasePriceCents: Int
+    var notes: String?
+    var sortOrder: Int
+    var createdAt: Date
+
+    @Relationship var firearm: Firearm?
+
+    init(
+        id: UUID? = UUID(),
+        brand: String,
+        modelName: String,
+        type: PartType,
+        typeDetail: String? = nil,
+        color: FirearmColor? = nil,
+        colorDetail: String? = nil,
+        purchaseDate: Date = .now,
+        purchasePriceCents: Int,
+        notes: String? = nil,
+        firearm: Firearm? = nil,
+        sortOrder: Int = 0,
+        createdAt: Date = .now
+    ) {
+        self.id = id
+        self.brand = brand
+        self.modelName = modelName
+        self.type = type.rawValue
+        self.typeDetail = typeDetail
+        self.color = color?.rawValue
+        self.colorDetail = colorDetail
+        self.purchaseDate = purchaseDate
+        self.purchasePriceCents = purchasePriceCents
+        self.notes = notes
+        self.firearm = firearm
+        self.sortOrder = sortOrder
+        self.createdAt = createdAt
+    }
+
+    var partType: PartType {
+        PartType(rawValue: type) ?? .other
+    }
+
+    var typeDisplayName: String {
+        if partType == .other, let typeDetail, !typeDetail.isEmpty {
+            return typeDetail
+        }
+        return partType.displayName
+    }
+
+    var displayName: String {
+        "\(brand) \(modelName)"
+    }
+
+    var partColor: FirearmColor? {
+        guard let color else {
+            return nil
+        }
+        return FirearmColor(rawValue: color) ?? .other
+    }
+
+    var colorDisplayName: String? {
+        guard let partColor else {
+            return nil
+        }
+        if partColor == .other, let colorDetail, !colorDetail.isEmpty {
+            return colorDetail
+        }
+        return partColor.displayName
+    }
+
+    var purchasePriceText: String {
+        let amount = Decimal(purchasePriceCents) / 100
+        return amount.formatted(.currency(code: Locale.current.currency?.identifier ?? "USD"))
+    }
+}

--- a/ArmoryInventory/Accessories/Parts/PartsView.swift
+++ b/ArmoryInventory/Accessories/Parts/PartsView.swift
@@ -1,0 +1,153 @@
+//
+//  PartsView.swift
+//  Armory Inventory
+//
+//  Created by Codex on 4/5/26.
+//
+
+import SwiftUI
+import SwiftData
+
+struct PartsView: View {
+    @Environment(\.modelContext) private var context
+    @AppStorage(InventorySettingsKeys.showValueInCard) private var showValueInCard = true
+    @AppStorage(InventorySettingsKeys.showTotalValue) private var showTotalValue = true
+    @State private var showingAddPart = false
+    @State private var selectedPart: Part?
+    @State private var parts: [Part] = []
+
+    private let inventoryListService: InventoryListServicing = AppServices.shared.resolve(InventoryListServicing.self)
+
+    var body: some View {
+        Group {
+            if parts.isEmpty {
+                ContentUnavailableView(
+                    "No Parts Yet",
+                    systemImage: "gearshape.2.fill",
+                    description: Text("Add your first part to track barrels, triggers, receivers, recoil systems, and other swap-ready components.")
+                )
+            } else {
+                List {
+                    ForEach(groupedPartTypes, id: \.self) { type in
+                        Section(type) {
+                            ForEach(groupedParts[type] ?? []) { part in
+                                Button {
+                                    selectedPart = part
+                                } label: {
+                                    VStack(alignment: .leading, spacing: 6) {
+                                        Text(part.displayName)
+                                            .font(.headline)
+
+                                        if showValueInCard, part.purchasePriceCents > 0 {
+                                            LabeledContent("Value", value: part.purchasePriceText)
+                                        }
+
+                                        if let firearm = part.firearm {
+                                            LabeledContent("Linked Firearm", value: firearm.displayName)
+                                        }
+                                    }
+                                    .padding(.vertical, 6)
+                                    .contentShape(Rectangle())
+                                }
+                                .buttonStyle(.plain)
+                            }
+                            .onDelete { offsets in
+                                deleteParts(at: offsets, in: type)
+                            }
+                        }
+                    }
+
+                    if showTotalValue {
+                        Section {
+                            LabeledContent("Total Value", value: totalValueText)
+                        }
+                    }
+                }
+            }
+        }
+        .navigationTitle("Parts")
+        .navigationBarTitleDisplayMode(.inline)
+        .task {
+            reloadParts()
+        }
+        .onAppear {
+            reloadParts()
+        }
+        .onChange(of: showingAddPart) {
+            if !showingAddPart {
+                reloadParts()
+            }
+        }
+        .onChange(of: selectedPart) {
+            if selectedPart == nil {
+                reloadParts()
+            }
+        }
+        .toolbar {
+            ToolbarItemGroup(placement: .topBarTrailing) {
+                EditButton()
+
+                Button {
+                    showingAddPart = true
+                } label: {
+                    Label("Add Part", systemImage: "plus")
+                }
+            }
+        }
+        .sheet(isPresented: $showingAddPart) {
+            AddPartView(viewModel: AddPartViewModel())
+                .presentationDetents([.large])
+        }
+        .sheet(item: $selectedPart) { part in
+            AddPartView(part: part, viewModel: AddPartViewModel())
+                .presentationDetents([.large])
+        }
+    }
+
+    private var groupedParts: [String: [Part]] {
+        Dictionary(grouping: parts, by: \.typeDisplayName)
+    }
+
+    private var groupedPartTypes: [String] {
+        PartType.displayOrder(for: Array(groupedParts.keys))
+    }
+
+    private func deleteParts(at offsets: IndexSet, in type: String) {
+        guard let sectionParts = groupedParts[type] else {
+            return
+        }
+
+        for index in offsets {
+            context.delete(sectionParts[index])
+        }
+        resequenceParts()
+
+        do {
+            try context.save()
+            UserDefaults.standard.set(Date(), forKey: "LastModelSaveDate")
+            reloadParts()
+        } catch {
+            print("Delete error: \(error)")
+        }
+    }
+
+    private func reloadParts() {
+        do {
+            parts = try inventoryListService.fetchParts(in: context)
+        } catch {
+            print("Parts fetch error: \(error)")
+        }
+    }
+
+    private func resequenceParts() {
+        for (index, part) in parts.enumerated() {
+            part.sortOrder = index
+        }
+    }
+
+    private var totalValueText: String {
+        let totalCents = parts.reduce(0) { $0 + max(0, $1.purchasePriceCents) }
+        let amount = Decimal(totalCents) / 100
+        return amount.formatted(.currency(code: Locale.current.currency?.identifier ?? "USD"))
+    }
+}

--- a/ArmoryInventory/ArmoryInventory.swift
+++ b/ArmoryInventory/ArmoryInventory.swift
@@ -57,6 +57,7 @@ struct ArmoryInventory: App {
             Optic.self,
             Magazine.self,
             Attachment.self,
+            Part.self,
         ])
         let storeURL = URL.applicationSupportDirectory
             .appending(path: "ArmoryInventory.store")
@@ -109,6 +110,13 @@ struct ArmoryInventory: App {
         if let attachments = try? context.fetch(FetchDescriptor<Attachment>()) {
             for attachment in attachments where attachment.id == nil {
                 attachment.id = UUID()
+                didChange = true
+            }
+        }
+
+        if let parts = try? context.fetch(FetchDescriptor<Part>()) {
+            for part in parts where part.id == nil {
+                part.id = UUID()
                 didChange = true
             }
         }

--- a/ArmoryInventory/Firearms/AddFirearmView.swift
+++ b/ArmoryInventory/Firearms/AddFirearmView.swift
@@ -31,9 +31,11 @@ struct AddFirearmView: View {
     @State private var selectedOpticIDs: Set<PersistentIdentifier> = []
     @State private var selectedMagazineIDs: Set<PersistentIdentifier> = []
     @State private var selectedAttachmentIDs: Set<PersistentIdentifier> = []
+    @State private var selectedPartIDs: Set<PersistentIdentifier> = []
     @State private var showingOpticsPicker = false
     @State private var showingMagazinesPicker = false
     @State private var showingAttachmentsPicker = false
+    @State private var showingPartsPicker = false
     @State private var isEditing = false
     @State private var lookupData = AddFirearmLookupData()
 
@@ -66,6 +68,7 @@ struct AddFirearmView: View {
         _selectedOpticIDs = State(initialValue: viewModel.selectedOpticIDs(for: firearm))
         _selectedMagazineIDs = State(initialValue: viewModel.selectedMagazineIDs(for: firearm))
         _selectedAttachmentIDs = State(initialValue: viewModel.selectedAttachmentIDs(for: firearm))
+        _selectedPartIDs = State(initialValue: viewModel.selectedPartIDs(for: firearm))
         _barrelLengthText = State(initialValue: viewModel.initialBarrelLengthText(for: firearm))
         _notes = State(initialValue: firearm?.notes ?? "")
         _isEditing = State(initialValue: firearm == nil)
@@ -275,10 +278,43 @@ struct AddFirearmView: View {
                     }
                 }
 
+                Section("Linked Parts") {
+                    if isEditing {
+                        Button {
+                            showingPartsPicker = true
+                        } label: {
+                            Label(selectedPartIDs.isEmpty ? "Add Parts" : "Manage Parts", systemImage: "plus.circle")
+                        }
+                    }
+
+                    if lookupData.parts.isEmpty {
+                        Text("Add parts first to link them to this firearm.")
+                            .font(.footnote)
+                            .foregroundStyle(.secondary)
+                    } else if availableParts.isEmpty {
+                        Text("No unlinked parts available.")
+                            .font(.footnote)
+                            .foregroundStyle(.secondary)
+                    } else if resolvedParts.isEmpty {
+                        Text("No parts linked.")
+                            .font(.footnote)
+                            .foregroundStyle(.secondary)
+                    } else {
+                        ForEach(resolvedParts) { part in
+                            VStack(alignment: .leading, spacing: 2) {
+                                Text(part.displayName)
+                                Text(part.typeDisplayName)
+                                    .font(.footnote)
+                                    .foregroundStyle(.secondary)
+                            }
+                        }
+                    }
+                }
+
                 if showsPostTaxTotalSection {
                     Section("Total Value") {
                         LabeledContent("Post-Tax Total", value: totalValueWithTaxText)
-                        Text("Includes the firearm plus linked optics, magazines, and attachments.")
+                        Text("Includes the firearm plus linked optics, magazines, attachments, and parts.")
                             .font(.footnote)
                             .foregroundStyle(.secondary)
                     }
@@ -468,6 +504,57 @@ struct AddFirearmView: View {
                 }
                 .presentationDetents([.medium, .large])
             }
+            .sheet(isPresented: $showingPartsPicker) {
+                NavigationStack {
+                    Group {
+                        if availableParts.isEmpty {
+                            ContentUnavailableView(
+                                "No Parts Available",
+                                systemImage: "gearshape.2.fill",
+                                description: Text("All saved parts are linked to other firearms or none have been added yet.")
+                            )
+                        } else {
+                            List {
+                                ForEach(availableParts) { part in
+                                    Button {
+                                        togglePartSelection(for: part)
+                                    } label: {
+                                        HStack {
+                                            VStack(alignment: .leading, spacing: 2) {
+                                                Text(part.displayName)
+                                                    .foregroundStyle(.primary)
+                                                Text(part.typeDisplayName)
+                                                    .font(.footnote)
+                                                    .foregroundStyle(.secondary)
+                                            }
+                                            Spacer()
+                                            if selectedPartIDs.contains(part.persistentModelID) {
+                                                Image(systemName: "checkmark.circle.fill")
+                                                    .foregroundStyle(.tint)
+                                            } else {
+                                                Image(systemName: "circle")
+                                                    .foregroundStyle(.tertiary)
+                                            }
+                                        }
+                                        .contentShape(Rectangle())
+                                    }
+                                    .buttonStyle(.plain)
+                                }
+                            }
+                        }
+                    }
+                    .navigationTitle("Link Parts")
+                    .navigationBarTitleDisplayMode(.inline)
+                    .toolbar {
+                        ToolbarItem(placement: .cancellationAction) {
+                            Button("Done") {
+                                showingPartsPicker = false
+                            }
+                        }
+                    }
+                }
+                .presentationDetents([.medium, .large])
+            }
         }
     }
 
@@ -507,6 +594,10 @@ struct AddFirearmView: View {
         viewModel.resolvedAttachments(from: lookupData.attachments, selectedIDs: selectedAttachmentIDs)
     }
 
+    private var resolvedParts: [Part] {
+        viewModel.resolvedParts(from: lookupData.parts, selectedIDs: selectedPartIDs)
+    }
+
     private var availableOptics: [Optic] {
         viewModel.availableOptics(from: lookupData.optics, selectedIDs: selectedOpticIDs, firearm: firearm)
     }
@@ -517,6 +608,10 @@ struct AddFirearmView: View {
 
     private var availableAttachments: [Attachment] {
         viewModel.availableAttachments(from: lookupData.attachments, selectedIDs: selectedAttachmentIDs, firearm: firearm)
+    }
+
+    private var availableParts: [Part] {
+        viewModel.availableParts(from: lookupData.parts, selectedIDs: selectedPartIDs, firearm: firearm)
     }
 
     private var duplicateExists: Bool {
@@ -552,7 +647,8 @@ struct AddFirearmView: View {
         let opticsTotal = resolvedOptics.reduce(0) { $0 + max(0, $1.purchasePriceCents) }
         let magazinesTotal = resolvedMagazines.reduce(0) { $0 + max(0, $1.purchasePriceCents) }
         let attachmentsTotal = resolvedAttachments.reduce(0) { $0 + max(0, $1.purchasePriceCents) }
-        return opticsTotal + magazinesTotal + attachmentsTotal
+        let partsTotal = resolvedParts.reduce(0) { $0 + max(0, $1.purchasePriceCents) }
+        return opticsTotal + magazinesTotal + attachmentsTotal + partsTotal
     }
 
     private var primaryButtonTitle: String {
@@ -608,6 +704,7 @@ struct AddFirearmView: View {
                 optics: resolvedOptics,
                 magazines: resolvedMagazines,
                 attachments: resolvedAttachments,
+                parts: resolvedParts,
                 canSave: canAdd,
                 in: context
             )
@@ -630,6 +727,7 @@ struct AddFirearmView: View {
                 optics: resolvedOptics,
                 magazines: resolvedMagazines,
                 attachments: resolvedAttachments,
+                parts: resolvedParts,
                 canAdd: canAdd,
                 to: context
             )
@@ -689,6 +787,14 @@ struct AddFirearmView: View {
         selectedAttachmentIDs = viewModel.toggledSelection(
             currentSelection: selectedAttachmentIDs,
             itemID: attachment.persistentModelID,
+            isEditing: isEditing
+        )
+    }
+
+    private func togglePartSelection(for part: Part) {
+        selectedPartIDs = viewModel.toggledSelection(
+            currentSelection: selectedPartIDs,
+            itemID: part.persistentModelID,
             isEditing: isEditing
         )
     }

--- a/ArmoryInventory/Firearms/AddFirearmView.swift
+++ b/ArmoryInventory/Firearms/AddFirearmView.swift
@@ -19,7 +19,7 @@ struct AddFirearmView: View {
     @State private var nickname = ""
     @State private var serialNumber = ""
     @State private var purchaseDate = Date.now
-    @State private var purchasePriceText = ""
+    @State private var purchasePriceText = "0.00"
     @State private var selectedType: FirearmType = .rifle
     @State private var selectedAction: FirearmAction = .semiAuto
     @State private var customAction = ""
@@ -155,8 +155,14 @@ struct AddFirearmView: View {
                 if showsPurchaseSection {
                     Section("Purchase") {
                         DatePicker("Purchase date", selection: $purchaseDate, displayedComponents: .date)
-                        TextField("Purchase price (USD)", text: $purchasePriceText)
-                            .keyboardType(.decimalPad)
+                        LabeledContent("Purchase Price") {
+                            SelectAllTextField(
+                                placeholder: "",
+                                text: $purchasePriceText,
+                                keyboardType: .decimalPad,
+                                textAlignment: .right
+                            )
+                        }
                         Text("Enter dollars and cents, for example 1299.99.")
                             .font(.footnote)
                             .foregroundStyle(.secondary)

--- a/ArmoryInventory/Firearms/AddFirearmViewModel.swift
+++ b/ArmoryInventory/Firearms/AddFirearmViewModel.swift
@@ -33,6 +33,10 @@ final class AddFirearmViewModel {
         Set(firearm?.attachments.map(\.persistentModelID) ?? [])
     }
 
+    func selectedPartIDs(for firearm: Firearm?) -> Set<PersistentIdentifier> {
+        Set(firearm?.parts.map(\.persistentModelID) ?? [])
+    }
+
     func trimmedValue(_ value: String) -> String {
         value.trimmingCharacters(in: .whitespacesAndNewlines)
     }
@@ -110,6 +114,10 @@ final class AddFirearmViewModel {
         attachments.filter { selectedIDs.contains($0.persistentModelID) }
     }
 
+    func resolvedParts(from parts: [Part], selectedIDs: Set<PersistentIdentifier>) -> [Part] {
+        parts.filter { selectedIDs.contains($0.persistentModelID) }
+    }
+
     func availableOptics(
         from optics: [Optic],
         selectedIDs: Set<PersistentIdentifier>,
@@ -165,6 +173,28 @@ final class AddFirearmViewModel {
             }
 
             guard let linkedFirearm = attachment.firearm else {
+                return true
+            }
+
+            guard let firearm else {
+                return false
+            }
+
+            return linkedFirearm.persistentModelID == firearm.persistentModelID
+        }
+    }
+
+    func availableParts(
+        from parts: [Part],
+        selectedIDs: Set<PersistentIdentifier>,
+        firearm: Firearm?
+    ) -> [Part] {
+        parts.filter { part in
+            if selectedIDs.contains(part.persistentModelID) {
+                return true
+            }
+
+            guard let linkedFirearm = part.firearm else {
                 return true
             }
 
@@ -290,6 +320,7 @@ final class AddFirearmViewModel {
         optics: [Optic],
         magazines: [Magazine],
         attachments: [Attachment],
+        parts: [Part],
         canAdd: Bool,
         to context: ModelContext
     ) -> Bool {
@@ -315,6 +346,7 @@ final class AddFirearmViewModel {
             optics: optics,
             magazines: magazines,
             attachments: attachments,
+            parts: parts,
             sortOrder: nextSortOrder(in: context)
         )
         context.insert(firearm)
@@ -348,6 +380,7 @@ final class AddFirearmViewModel {
         optics: [Optic],
         magazines: [Magazine],
         attachments: [Attachment],
+        parts: [Part],
         canSave: Bool,
         in context: ModelContext
     ) -> Bool {
@@ -372,6 +405,7 @@ final class AddFirearmViewModel {
         firearm.optics = optics
         firearm.magazines = magazines
         firearm.attachments = attachments
+        firearm.parts = parts
 
         do {
             try context.save()

--- a/ArmoryInventory/Firearms/FirearmModels.swift
+++ b/ArmoryInventory/Firearms/FirearmModels.swift
@@ -133,6 +133,7 @@ final class Firearm {
     @Relationship(inverse: \Optic.firearm) var optics: [Optic]
     @Relationship(inverse: \Magazine.firearm) var magazines: [Magazine]
     @Relationship(inverse: \Attachment.firearm) var attachments: [Attachment]
+    @Relationship(inverse: \Part.firearm) var parts: [Part]
 
     init(
         id: UUID? = UUID(),
@@ -153,6 +154,7 @@ final class Firearm {
         optics: [Optic] = [],
         magazines: [Magazine] = [],
         attachments: [Attachment] = [],
+        parts: [Part] = [],
         sortOrder: Int = 0,
         createdAt: Date = .now
     ) {
@@ -174,6 +176,7 @@ final class Firearm {
         self.optics = optics
         self.magazines = magazines
         self.attachments = attachments
+        self.parts = parts
         self.sortOrder = sortOrder
         self.createdAt = createdAt
     }
@@ -248,7 +251,8 @@ final class Firearm {
         let opticsValue = optics.reduce(0) { $0 + max(0, $1.purchasePriceCents) }
         let magazinesValue = magazines.reduce(0) { $0 + max(0, $1.purchasePriceCents) }
         let attachmentsValue = attachments.reduce(0) { $0 + max(0, $1.purchasePriceCents) }
-        return max(0, purchasePriceCents) + opticsValue + magazinesValue + attachmentsValue
+        let partsValue = parts.reduce(0) { $0 + max(0, $1.purchasePriceCents) }
+        return max(0, purchasePriceCents) + opticsValue + magazinesValue + attachmentsValue + partsValue
     }
 
     var totalCardValueText: String {

--- a/ArmoryInventory/Localizable.xcstrings
+++ b/ArmoryInventory/Localizable.xcstrings
@@ -241,6 +241,9 @@
     "Color details" : {
 
     },
+    "Color Details" : {
+
+    },
     "Common Calibers" : {
 
     },
@@ -325,7 +328,7 @@
     "Footprint" : {
 
     },
-    "Footprint details" : {
+    "Footprint Details" : {
 
     },
     "From" : {
@@ -409,10 +412,10 @@
     "Min" : {
 
     },
-    "Mode" : {
+    "mm" : {
 
     },
-    "Model name" : {
+    "Mode" : {
 
     },
     "Model Name" : {
@@ -544,7 +547,7 @@
     "Reset to Default Order" : {
 
     },
-    "Reticle (optional)" : {
+    "Reticle" : {
 
     },
     "Rounds" : {
@@ -560,9 +563,6 @@
 
     },
     "Serial Number" : {
-
-    },
-    "Serial number (optional)" : {
 
     },
     "Settings" : {
@@ -613,13 +613,13 @@
     "Tube" : {
 
     },
-    "Tube size in mm (optional)" : {
+    "Tube Size" : {
 
     },
     "Type" : {
 
     },
-    "Type details" : {
+    "Type Details" : {
 
     },
     "Typical: %lldgr-%lldgr" : {

--- a/ArmoryInventory/Localizable.xcstrings
+++ b/ArmoryInventory/Localizable.xcstrings
@@ -535,7 +535,7 @@
     "Purchase date" : {
 
     },
-    "Purchase price (USD)" : {
+    "Purchase Price" : {
 
     },
     "Purchased" : {

--- a/ArmoryInventory/Localizable.xcstrings
+++ b/ArmoryInventory/Localizable.xcstrings
@@ -118,6 +118,15 @@
     "Add optics first to link them to this firearm." : {
 
     },
+    "Add Part" : {
+
+    },
+    "Add Parts" : {
+
+    },
+    "Add parts first to link them to this firearm." : {
+
+    },
     "Add your first attachment to track stocks, grips, lasers, lights, and other hardware." : {
 
     },
@@ -131,6 +140,9 @@
 
     },
     "Add your first optic to start tracking mounts, magnification, and purchase cost." : {
+
+    },
+    "Add your first part to track barrels, triggers, receivers, recoil systems, and other swap-ready components." : {
 
     },
     "Adjust Quantity" : {
@@ -149,6 +161,9 @@
 
     },
     "All saved optics are linked to other firearms or none have been added yet." : {
+
+    },
+    "All saved parts are linked to other firearms or none have been added yet." : {
 
     },
     "All Types (%lld)" : {
@@ -364,7 +379,7 @@
     "in." : {
 
     },
-    "Includes the firearm plus linked optics, magazines, and attachments." : {
+    "Includes the firearm plus linked optics, magazines, attachments, and parts." : {
 
     },
     "Link Attachments" : {
@@ -374,6 +389,9 @@
 
     },
     "Link Optics" : {
+
+    },
+    "Link Parts" : {
 
     },
     "Linked Attachments" : {
@@ -386,6 +404,9 @@
 
     },
     "Linked Optics" : {
+
+    },
+    "Linked Parts" : {
 
     },
     "Magazine Details" : {
@@ -404,6 +425,9 @@
 
     },
     "Manage Optics" : {
+
+    },
+    "Manage Parts" : {
 
     },
     "Max" : {
@@ -437,6 +461,9 @@
 
     },
     "New Optic" : {
+
+    },
+    "New Part" : {
 
     },
     "Nickname" : {
@@ -478,6 +505,15 @@
     "No Optics Yet" : {
 
     },
+    "No Parts Available" : {
+
+    },
+    "No parts linked." : {
+
+    },
+    "No Parts Yet" : {
+
+    },
     "No unlinked attachments available." : {
 
     },
@@ -485,6 +521,9 @@
 
     },
     "No unlinked optics available." : {
+
+    },
+    "No unlinked parts available." : {
 
     },
     "None" : {
@@ -515,6 +554,15 @@
 
     },
     "Overview" : {
+
+    },
+    "Part Details" : {
+
+    },
+    "Part Type" : {
+
+    },
+    "Parts" : {
 
     },
     "Post-Tax Total" : {
@@ -604,7 +652,7 @@
     "Total Value" : {
 
     },
-    "Track firearms, ammo, optics, magazines, attachments, and related inventory." : {
+    "Track firearms, ammo, optics, magazines, attachments, parts, and related inventory." : {
 
     },
     "Track the major components you swap between firearms." : {

--- a/ArmoryInventory/SelectAllTextField.swift
+++ b/ArmoryInventory/SelectAllTextField.swift
@@ -1,0 +1,60 @@
+//
+//  SelectAllTextField.swift
+//  Armory Inventory
+//
+//  Created by Codex on 4/5/26.
+//
+
+import SwiftUI
+import UIKit
+
+struct SelectAllTextField: UIViewRepresentable {
+    let placeholder: String
+    @Binding var text: String
+    var keyboardType: UIKeyboardType = .default
+    var textAlignment: NSTextAlignment = .natural
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(text: $text)
+    }
+
+    func makeUIView(context: Context) -> UITextField {
+        let textField = UITextField(frame: .zero)
+        textField.delegate = context.coordinator
+        textField.addTarget(context.coordinator, action: #selector(Coordinator.textDidChange(_:)), for: .editingChanged)
+        textField.placeholder = placeholder
+        textField.keyboardType = keyboardType
+        textField.textAlignment = textAlignment
+        textField.borderStyle = .none
+        textField.backgroundColor = .clear
+        textField.clearButtonMode = .never
+        return textField
+    }
+
+    func updateUIView(_ uiView: UITextField, context: Context) {
+        if uiView.text != text {
+            uiView.text = text
+        }
+        uiView.placeholder = placeholder
+        uiView.keyboardType = keyboardType
+        uiView.textAlignment = textAlignment
+    }
+
+    final class Coordinator: NSObject, UITextFieldDelegate {
+        @Binding private var text: String
+
+        init(text: Binding<String>) {
+            _text = text
+        }
+
+        @objc func textDidChange(_ sender: UITextField) {
+            text = sender.text ?? ""
+        }
+
+        func textFieldDidBeginEditing(_ textField: UITextField) {
+            DispatchQueue.main.async {
+                textField.selectAll(nil)
+            }
+        }
+    }
+}

--- a/ArmoryInventory/Services/AddFirearmLookupService.swift
+++ b/ArmoryInventory/Services/AddFirearmLookupService.swift
@@ -14,6 +14,7 @@ struct AddFirearmLookupData {
     var optics: [Optic] = []
     var magazines: [Magazine] = []
     var attachments: [Attachment] = []
+    var parts: [Part] = []
 }
 
 protocol AddFirearmLookupServicing {
@@ -37,13 +38,17 @@ struct AddFirearmLookupService: AddFirearmLookupServicing {
         let attachmentsDescriptor = FetchDescriptor<Attachment>(
             sortBy: [SortDescriptor(\.brand), SortDescriptor(\.modelName)]
         )
+        let partsDescriptor = FetchDescriptor<Part>(
+            sortBy: [SortDescriptor(\.brand), SortDescriptor(\.modelName)]
+        )
 
         return AddFirearmLookupData(
             calibers: try context.fetch(calibersDescriptor),
             existingFirearms: try context.fetch(firearmsDescriptor),
             optics: try context.fetch(opticsDescriptor),
             magazines: try context.fetch(magazinesDescriptor),
-            attachments: try context.fetch(attachmentsDescriptor)
+            attachments: try context.fetch(attachmentsDescriptor),
+            parts: try context.fetch(partsDescriptor)
         )
     }
 }

--- a/ArmoryInventory/Services/InventoryListService.swift
+++ b/ArmoryInventory/Services/InventoryListService.swift
@@ -12,6 +12,7 @@ protocol InventoryListServicing {
     func fetchAttachments(in context: ModelContext) throws -> [Attachment]
     func fetchMagazines(in context: ModelContext) throws -> [Magazine]
     func fetchOptics(in context: ModelContext) throws -> [Optic]
+    func fetchParts(in context: ModelContext) throws -> [Part]
     func fetchFirearms(in context: ModelContext) throws -> [Firearm]
 }
 
@@ -36,6 +37,14 @@ struct InventoryListService: InventoryListServicing {
         try context.fetch(
             FetchDescriptor(
                 sortBy: [SortDescriptor(\Optic.sortOrder), SortDescriptor(\Optic.createdAt)]
+            )
+        )
+    }
+
+    func fetchParts(in context: ModelContext) throws -> [Part] {
+        try context.fetch(
+            FetchDescriptor(
+                sortBy: [SortDescriptor(\Part.sortOrder), SortDescriptor(\Part.createdAt)]
             )
         )
     }

--- a/ArmoryInventory/Services/UserDataTransferService.swift
+++ b/ArmoryInventory/Services/UserDataTransferService.swift
@@ -87,6 +87,7 @@ final class UserDataTransferService: UserDataTransferServicing {
         let optics = try context.fetch(FetchDescriptor<Optic>(sortBy: [SortDescriptor(\.sortOrder), SortDescriptor(\.createdAt)]))
         let magazines = try context.fetch(FetchDescriptor<Magazine>(sortBy: [SortDescriptor(\.sortOrder), SortDescriptor(\.createdAt)]))
         let attachments = try context.fetch(FetchDescriptor<Attachment>(sortBy: [SortDescriptor(\.sortOrder), SortDescriptor(\.createdAt)]))
+        let parts = try context.fetch(FetchDescriptor<Part>(sortBy: [SortDescriptor(\.sortOrder), SortDescriptor(\.createdAt)]))
 
         var ammoIdentifiers: [ObjectIdentifier: UUID] = [:]
         let ammoSnapshots = ammoTypes.map { ammo -> AmmoTypeSnapshot in
@@ -187,6 +188,23 @@ final class UserDataTransferService: UserDataTransferServicing {
             },
             attachments: attachments.map {
                 AttachmentSnapshot(
+                    id: $0.id ?? UUID(),
+                    brand: $0.brand,
+                    modelName: $0.modelName,
+                    type: $0.type,
+                    typeDetail: $0.typeDetail,
+                    color: $0.color,
+                    colorDetail: $0.colorDetail,
+                    purchaseDate: $0.purchaseDate,
+                    purchasePriceCents: $0.purchasePriceCents,
+                    notes: $0.notes,
+                    sortOrder: $0.sortOrder,
+                    createdAt: $0.createdAt,
+                    firearmID: $0.firearm?.id
+                )
+            },
+            parts: parts.map {
+                PartSnapshot(
                     id: $0.id ?? UUID(),
                     brand: $0.brand,
                     modelName: $0.modelName,
@@ -320,6 +338,25 @@ final class UserDataTransferService: UserDataTransferServicing {
             context.insert(attachment)
         }
 
+        for snapshot in snapshot.parts {
+            let part = Part(
+                id: snapshot.id,
+                brand: snapshot.brand,
+                modelName: snapshot.modelName,
+                type: PartType(rawValue: snapshot.type) ?? .other,
+                typeDetail: snapshot.typeDetail,
+                color: snapshot.color.flatMap(FirearmColor.init(rawValue:)),
+                colorDetail: snapshot.colorDetail,
+                purchaseDate: snapshot.purchaseDate,
+                purchasePriceCents: snapshot.purchasePriceCents,
+                notes: snapshot.notes,
+                firearm: snapshot.firearmID.flatMap { firearms[$0] },
+                sortOrder: snapshot.sortOrder,
+                createdAt: snapshot.createdAt
+            )
+            context.insert(part)
+        }
+
         for snapshot in snapshot.ammoAdjustmentRecords {
             let record = AmmoAdjustmentRecord(
                 quantity: snapshot.quantity,
@@ -339,6 +376,7 @@ final class UserDataTransferService: UserDataTransferServicing {
     private func deleteExistingData(in context: ModelContext) throws {
         try deleteAll(FetchDescriptor<AmmoAdjustmentRecord>(), in: context)
         try deleteAll(FetchDescriptor<Attachment>(), in: context)
+        try deleteAll(FetchDescriptor<Part>(), in: context)
         try deleteAll(FetchDescriptor<Magazine>(), in: context)
         try deleteAll(FetchDescriptor<Optic>(), in: context)
         try deleteAll(FetchDescriptor<Firearm>(), in: context)
@@ -410,6 +448,20 @@ final class UserDataTransferService: UserDataTransferServicing {
 private struct UserDataSnapshot: Codable {
     static let currentVersion = 1
 
+    private enum CodingKeys: String, CodingKey {
+        case version
+        case exportedAt
+        case settings
+        case calibers
+        case ammoTypes
+        case ammoAdjustmentRecords
+        case firearms
+        case optics
+        case magazines
+        case attachments
+        case parts
+    }
+
     let version: Int
     let exportedAt: Date
     let settings: [String: SettingValue]
@@ -420,6 +472,22 @@ private struct UserDataSnapshot: Codable {
     let optics: [OpticSnapshot]
     let magazines: [MagazineSnapshot]
     let attachments: [AttachmentSnapshot]
+    let parts: [PartSnapshot]
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        version = try container.decode(Int.self, forKey: .version)
+        exportedAt = try container.decode(Date.self, forKey: .exportedAt)
+        settings = try container.decode([String: SettingValue].self, forKey: .settings)
+        calibers = try container.decode([CaliberSnapshot].self, forKey: .calibers)
+        ammoTypes = try container.decode([AmmoTypeSnapshot].self, forKey: .ammoTypes)
+        ammoAdjustmentRecords = try container.decode([AmmoAdjustmentRecordSnapshot].self, forKey: .ammoAdjustmentRecords)
+        firearms = try container.decode([FirearmSnapshot].self, forKey: .firearms)
+        optics = try container.decode([OpticSnapshot].self, forKey: .optics)
+        magazines = try container.decode([MagazineSnapshot].self, forKey: .magazines)
+        attachments = try container.decode([AttachmentSnapshot].self, forKey: .attachments)
+        parts = try container.decodeIfPresent([PartSnapshot].self, forKey: .parts) ?? []
+    }
 
     init(
         version: Int = currentVersion,
@@ -431,7 +499,8 @@ private struct UserDataSnapshot: Codable {
         firearms: [FirearmSnapshot],
         optics: [OpticSnapshot],
         magazines: [MagazineSnapshot],
-        attachments: [AttachmentSnapshot]
+        attachments: [AttachmentSnapshot],
+        parts: [PartSnapshot]
     ) {
         self.version = version
         self.exportedAt = exportedAt
@@ -443,6 +512,7 @@ private struct UserDataSnapshot: Codable {
         self.optics = optics
         self.magazines = magazines
         self.attachments = attachments
+        self.parts = parts
     }
 }
 
@@ -532,6 +602,22 @@ private struct MagazineSnapshot: Codable {
 }
 
 private struct AttachmentSnapshot: Codable {
+    let id: UUID
+    let brand: String
+    let modelName: String
+    let type: String
+    let typeDetail: String?
+    let color: String?
+    let colorDetail: String?
+    let purchaseDate: Date
+    let purchasePriceCents: Int
+    let notes: String?
+    let sortOrder: Int
+    let createdAt: Date
+    let firearmID: UUID?
+}
+
+private struct PartSnapshot: Codable {
     let id: UUID
     let brand: String
     let modelName: String

--- a/ArmoryInventory/Settings/About/AboutView.swift
+++ b/ArmoryInventory/Settings/About/AboutView.swift
@@ -22,7 +22,7 @@ struct AboutView: View {
                             .font(.title2.weight(.semibold))
                             .multilineTextAlignment(.center)
 
-                        Text("Track firearms, ammo, optics, magazines, attachments, and related inventory.")
+                        Text("Track firearms, ammo, optics, magazines, attachments, parts, and related inventory.")
                             .font(.footnote)
                             .foregroundStyle(.secondary)
                             .multilineTextAlignment(.center)

--- a/ArmoryInventoryTests/AccessoriesTests/AddPartViewModelTests.swift
+++ b/ArmoryInventoryTests/AccessoriesTests/AddPartViewModelTests.swift
@@ -1,0 +1,189 @@
+//
+//  AddPartViewModelTests.swift
+//  Armory InventoryTests
+//
+//  Created by Codex on 4/5/26.
+//
+
+import XCTest
+import SwiftData
+@testable import ArmoryInventory
+
+final class AddPartViewModelTests: XCTestCase {
+    func testResolutionAndValidationHandleTrimmedAndInvalidValues() {
+        let viewModel = AddPartViewModel()
+
+        XCTAssertEqual(viewModel.initialPurchasePriceText(for: nil), "0.00")
+        XCTAssertEqual(viewModel.trimmedValue("  Geissele "), "Geissele")
+        XCTAssertEqual(viewModel.optionalValue("  SSA-E  "), "SSA-E")
+        XCTAssertNil(viewModel.optionalValue(" "))
+        XCTAssertEqual(viewModel.purchasePriceCents(from: " 240.00 "), 24000)
+        XCTAssertNil(viewModel.purchasePriceCents(from: "bad"))
+        XCTAssertNil(viewModel.resolvedTypeDetail(selectedType: .trigger, customType: "Ignored"))
+        XCTAssertEqual(viewModel.resolvedTypeDetail(selectedType: .other, customType: "  Fire Control Group  "), "Fire Control Group")
+        XCTAssertNil(viewModel.resolvedColorDetail(selectedColor: .black, customColor: "Ignored"))
+        XCTAssertEqual(viewModel.resolvedColorDetail(selectedColor: .other, customColor: "  Nitride  "), "Nitride")
+        XCTAssertNil(viewModel.linkedFirearm(for: nil, unlinkFirearm: false))
+        XCTAssertEqual(viewModel.purchasePriceWithTaxText(purchasePriceCents: nil, taxRate: 6), "--")
+        XCTAssertTrue(viewModel.isReadOnly(hasPart: true, isEditing: false))
+        XCTAssertFalse(viewModel.showsPurchaseSection(showValueInDetails: false, isReadOnly: true))
+        XCTAssertEqual(viewModel.primaryButtonTitle(hasPart: true, isEditing: false), "Edit")
+        XCTAssertFalse(
+            viewModel.canAdd(
+                brand: "Geissele",
+                modelName: "SSA-E",
+                selectedType: .other,
+                typeDetail: nil,
+                selectedColor: nil,
+                colorDetail: nil,
+                purchasePriceText: "100"
+            )
+        )
+        XCTAssertFalse(
+            viewModel.canAdd(
+                brand: "Geissele",
+                modelName: "SSA-E",
+                selectedType: .trigger,
+                typeDetail: nil,
+                selectedColor: .other,
+                colorDetail: nil,
+                purchasePriceText: "100"
+            )
+        )
+        XCTAssertTrue(
+            viewModel.canAdd(
+                brand: "Geissele",
+                modelName: "SSA-E",
+                selectedType: .trigger,
+                typeDetail: nil,
+                selectedColor: .black,
+                colorDetail: nil,
+                purchasePriceText: "100"
+            )
+        )
+    }
+
+    @MainActor
+    func testAddPartPersistsModel() throws {
+        let container = try makeInMemoryContainer()
+        let context = container.mainContext
+        let viewModel = AddPartViewModel()
+        let purchaseDate = Date(timeIntervalSince1970: 1_234_567)
+        let firearm = Firearm(
+            brand: "BCM",
+            modelName: "Recce",
+            purchasePriceCents: 160000,
+            type: .rifle,
+            action: .semiAuto
+        )
+        context.insert(firearm)
+
+        let didAdd = viewModel.addPart(
+            brand: "  Geissele ",
+            modelName: " SSA-E ",
+            type: .trigger,
+            typeDetail: nil,
+            color: .black,
+            colorDetail: nil,
+            purchaseDate: purchaseDate,
+            purchasePriceCents: 24000,
+            notes: "Match trigger",
+            firearm: firearm,
+            canAdd: true,
+            to: context
+        )
+
+        let parts = try context.fetch(FetchDescriptor<Part>())
+
+        XCTAssertTrue(didAdd)
+        XCTAssertEqual(parts.count, 1)
+        XCTAssertEqual(parts.first?.brand, "Geissele")
+        XCTAssertEqual(parts.first?.modelName, "SSA-E")
+        XCTAssertEqual(parts.first?.partType, .trigger)
+        XCTAssertEqual(parts.first?.firearm?.displayName, "BCM Recce")
+        XCTAssertEqual(parts.first?.purchaseDate, purchaseDate)
+        XCTAssertEqual(parts.first?.sortOrder, 0)
+    }
+
+    @MainActor
+    func testAddPartReturnsFalseWhenBlocked() throws {
+        let container = try makeInMemoryContainer()
+        let context = container.mainContext
+        let viewModel = AddPartViewModel()
+
+        let didAdd = viewModel.addPart(
+            brand: "BCM",
+            modelName: "MK2",
+            type: .chargingHandle,
+            typeDetail: nil,
+            color: nil,
+            colorDetail: nil,
+            purchaseDate: .now,
+            purchasePriceCents: 8000,
+            notes: nil,
+            firearm: nil,
+            canAdd: false,
+            to: context
+        )
+
+        XCTAssertFalse(didAdd)
+        XCTAssertTrue(try context.fetch(FetchDescriptor<Part>()).isEmpty)
+    }
+
+    @MainActor
+    func testUpdatePartPersistsEditedValues() throws {
+        let container = try makeInMemoryContainer()
+        let context = container.mainContext
+        let originalFirearm = Firearm(
+            brand: "Daniel Defense",
+            modelName: "MK18",
+            purchasePriceCents: 180000,
+            type: .rifle,
+            action: .semiAuto
+        )
+        let updatedFirearm = Firearm(
+            brand: "LMT",
+            modelName: "MARS-L",
+            purchasePriceCents: 250000,
+            type: .rifle,
+            action: .semiAuto
+        )
+        let part = Part(
+            brand: "BCM",
+            modelName: "MK2",
+            type: .chargingHandle,
+            purchasePriceCents: 8000,
+            firearm: originalFirearm
+        )
+        context.insert(originalFirearm)
+        context.insert(updatedFirearm)
+        context.insert(part)
+
+        let viewModel = AddPartViewModel()
+        let didSave = viewModel.updatePart(
+            part,
+            brand: "  Apex ",
+            modelName: " Trigger Kit ",
+            type: .other,
+            typeDetail: "Fire Control Group",
+            color: .other,
+            colorDetail: "Nitride",
+            purchaseDate: Date(timeIntervalSince1970: 9_999),
+            purchasePriceCents: 12999,
+            notes: "Updated",
+            firearm: updatedFirearm,
+            canSave: true,
+            in: context
+        )
+
+        XCTAssertTrue(didSave)
+        XCTAssertEqual(part.brand, "Apex")
+        XCTAssertEqual(part.modelName, "Trigger Kit")
+        XCTAssertEqual(part.partType, .other)
+        XCTAssertEqual(part.typeDetail, "Fire Control Group")
+        XCTAssertEqual(part.partColor, .other)
+        XCTAssertEqual(part.colorDetail, "Nitride")
+        XCTAssertEqual(part.firearm?.displayName, "LMT MARS-L")
+        XCTAssertEqual(part.notes, "Updated")
+    }
+}

--- a/ArmoryInventoryTests/AccessoriesTests/PartModelsTests.swift
+++ b/ArmoryInventoryTests/AccessoriesTests/PartModelsTests.swift
@@ -1,0 +1,68 @@
+//
+//  PartModelsTests.swift
+//  Armory InventoryTests
+//
+//  Created by Codex on 4/5/26.
+//
+
+import XCTest
+@testable import ArmoryInventory
+
+final class PartModelsTests: XCTestCase {
+    func testPartTypeDisplayNamesCoverKnownAndOtherCases() {
+        XCTAssertEqual(PartType.barrel.displayName, "Barrel")
+        XCTAssertEqual(PartType.trigger.displayName, "Trigger")
+        XCTAssertEqual(PartType.boltCarrierGroup.displayName, "Bolt Carrier Group")
+        XCTAssertEqual(PartType.other.displayName, "Other")
+    }
+
+    func testPartComputedPropertiesPreferCustomDetailsAndFallbacks() {
+        let firearm = Firearm(
+            brand: "BCM",
+            modelName: "Recce",
+            purchasePriceCents: 160000,
+            type: .rifle,
+            action: .semiAuto
+        )
+        let part = Part(
+            brand: "Apex",
+            modelName: "Enhancement Kit",
+            type: .other,
+            typeDetail: "Trigger Kit",
+            color: .other,
+            colorDetail: "Nitride",
+            purchasePriceCents: 12999,
+            firearm: firearm
+        )
+
+        XCTAssertEqual(part.partType, .other)
+        XCTAssertEqual(part.typeDisplayName, "Trigger Kit")
+        XCTAssertEqual(part.displayName, "Apex Enhancement Kit")
+        XCTAssertEqual(part.partColor, .other)
+        XCTAssertEqual(part.colorDisplayName, "Nitride")
+        XCTAssertTrue(part.purchasePriceText.contains("129"))
+        XCTAssertTrue(part.firearm === firearm)
+    }
+
+    func testPartComputedPropertiesFallbackWhenStoredValuesAreInvalidOrMissing() {
+        let part = Part(
+            brand: "BCM",
+            modelName: "MK2",
+            type: .chargingHandle,
+            purchasePriceCents: 8000
+        )
+        part.type = "not-a-real-type"
+        part.color = "not-a-real-color"
+        part.colorDetail = nil
+
+        XCTAssertEqual(part.partType, .other)
+        XCTAssertEqual(part.typeDisplayName, "Other")
+        XCTAssertEqual(part.partColor, .other)
+        XCTAssertEqual(part.colorDisplayName, "Other")
+
+        part.color = nil
+
+        XCTAssertNil(part.partColor)
+        XCTAssertNil(part.colorDisplayName)
+    }
+}

--- a/ArmoryInventoryTests/FirearmsTests/AddFirearmViewModelTests.swift
+++ b/ArmoryInventoryTests/FirearmsTests/AddFirearmViewModelTests.swift
@@ -183,6 +183,26 @@ final class AddFirearmViewModelTests: XCTestCase {
             purchasePriceCents: 5800,
             firearm: otherFirearm
         )
+        let freePart = Part(
+            brand: "Geissele",
+            modelName: "SSA-E",
+            type: .trigger,
+            purchasePriceCents: 24000
+        )
+        let currentPart = Part(
+            brand: "BCM",
+            modelName: "MK2",
+            type: .chargingHandle,
+            purchasePriceCents: 8000,
+            firearm: currentFirearm
+        )
+        let otherPart = Part(
+            brand: "Apex",
+            modelName: "Action Enhancement",
+            type: .trigger,
+            purchasePriceCents: 12500,
+            firearm: otherFirearm
+        )
 
         context.insert(currentFirearm)
         context.insert(otherFirearm)
@@ -195,19 +215,25 @@ final class AddFirearmViewModelTests: XCTestCase {
         context.insert(freeAttachment)
         context.insert(currentAttachment)
         context.insert(otherAttachment)
+        context.insert(freePart)
+        context.insert(currentPart)
+        context.insert(otherPart)
         try context.save()
 
         currentFirearm.optics = [currentOptic]
         currentFirearm.magazines = [currentMagazine]
         currentFirearm.attachments = [currentAttachment]
+        currentFirearm.parts = [currentPart]
 
         let selectedOpticIDs = viewModel.selectedOpticIDs(for: currentFirearm)
         let selectedMagazineIDs = viewModel.selectedMagazineIDs(for: currentFirearm)
         let selectedAttachmentIDs = viewModel.selectedAttachmentIDs(for: currentFirearm)
+        let selectedPartIDs = viewModel.selectedPartIDs(for: currentFirearm)
 
         XCTAssertEqual(selectedOpticIDs, [currentOptic.persistentModelID])
         XCTAssertEqual(selectedMagazineIDs, [currentMagazine.persistentModelID])
         XCTAssertEqual(selectedAttachmentIDs, [currentAttachment.persistentModelID])
+        XCTAssertEqual(selectedPartIDs, [currentPart.persistentModelID])
 
         XCTAssertEqual(
             Set(
@@ -242,6 +268,17 @@ final class AddFirearmViewModelTests: XCTestCase {
             ),
             [freeAttachment.persistentModelID, currentAttachment.persistentModelID]
         )
+        XCTAssertEqual(
+            Set(
+                viewModel.availableParts(
+                    from: [freePart, currentPart, otherPart],
+                    selectedIDs: [],
+                    firearm: currentFirearm
+                )
+                .map(\.persistentModelID)
+            ),
+            [freePart.persistentModelID, currentPart.persistentModelID]
+        )
 
         XCTAssertEqual(
             viewModel.resolvedOptics(
@@ -266,6 +303,14 @@ final class AddFirearmViewModelTests: XCTestCase {
             )
             .map(\.persistentModelID),
             [freeAttachment.persistentModelID, currentAttachment.persistentModelID]
+        )
+        XCTAssertEqual(
+            viewModel.resolvedParts(
+                from: [freePart, currentPart, otherPart],
+                selectedIDs: [freePart.persistentModelID, otherPart.persistentModelID]
+            )
+            .map(\.persistentModelID),
+            [freePart.persistentModelID, otherPart.persistentModelID]
         )
     }
 
@@ -375,10 +420,17 @@ final class AddFirearmViewModelTests: XCTestCase {
             type: .light,
             purchasePriceCents: 14000
         )
+        let part = Part(
+            brand: "Apex",
+            modelName: "Action Enhancement",
+            type: .trigger,
+            purchasePriceCents: 12500
+        )
         context.insert(caliber)
         context.insert(optic)
         context.insert(magazine)
         context.insert(attachment)
+        context.insert(part)
 
         let didAdd = viewModel.addFirearm(
             brand: "  cZ  ",
@@ -398,6 +450,7 @@ final class AddFirearmViewModelTests: XCTestCase {
             optics: [optic],
             magazines: [magazine],
             attachments: [attachment],
+            parts: [part],
             canAdd: true,
             to: context
         )
@@ -419,6 +472,7 @@ final class AddFirearmViewModelTests: XCTestCase {
         XCTAssertEqual(firearms.first?.optics.map(\.displayName), ["Holosun 507C"])
         XCTAssertEqual(firearms.first?.magazines.map(\.displayName), ["CZ P-10"])
         XCTAssertEqual(firearms.first?.attachments.map(\.displayName), ["Streamlight TLR-7A"])
+        XCTAssertEqual(firearms.first?.parts.map(\.displayName), ["Apex Action Enhancement"])
     }
 
     @MainActor
@@ -445,6 +499,7 @@ final class AddFirearmViewModelTests: XCTestCase {
             optics: [],
             magazines: [],
             attachments: [],
+            parts: [],
             canAdd: false,
             to: context
         )
@@ -495,6 +550,7 @@ final class AddFirearmViewModelTests: XCTestCase {
             optics: [],
             magazines: [],
             attachments: [],
+            parts: [],
             canSave: true,
             in: context
         )

--- a/ArmoryInventoryTests/FirearmsTests/FirearmModelsTests.swift
+++ b/ArmoryInventoryTests/FirearmsTests/FirearmModelsTests.swift
@@ -80,6 +80,12 @@ final class FirearmModelsTests: XCTestCase {
             type: .light,
             purchasePriceCents: 28000
         )
+        let part = Part(
+            brand: "Apex",
+            modelName: "Trigger Kit",
+            type: .trigger,
+            purchasePriceCents: 12500
+        )
         let firearm = Firearm(
             brand: "Staccato",
             modelName: "P",
@@ -95,7 +101,8 @@ final class FirearmModelsTests: XCTestCase {
             caliber: caliber,
             optics: [optic],
             magazines: [magazine],
-            attachments: [attachment]
+            attachments: [attachment],
+            parts: [part]
         )
 
         XCTAssertEqual(firearm.firearmType, .other)
@@ -108,8 +115,8 @@ final class FirearmModelsTests: XCTestCase {
         XCTAssertEqual(firearm.roundsText, "200 Rounds")
         XCTAssertEqual(firearm.barrelLengthText, "4.4 in")
         XCTAssertTrue(firearm.purchasePriceText.contains("2,500"))
-        XCTAssertEqual(firearm.totalCardValueCents, 365500)
-        XCTAssertTrue(firearm.totalCardValueText.contains("3,655"))
+        XCTAssertEqual(firearm.totalCardValueCents, 378000)
+        XCTAssertTrue(firearm.totalCardValueText.contains("3,780"))
     }
 
     func testFirearmComputedPropertiesFallbackForInvalidStoredValues() {
@@ -146,6 +153,12 @@ final class FirearmModelsTests: XCTestCase {
             type: .handStop,
             purchasePriceCents: -300
         )
+        let part = Part(
+            brand: "BCM",
+            modelName: "PNT",
+            type: .trigger,
+            purchasePriceCents: -500
+        )
         let firearm = Firearm(
             brand: "Colt",
             modelName: "6920",
@@ -155,7 +168,8 @@ final class FirearmModelsTests: XCTestCase {
             caliber: caliber,
             optics: [optic],
             magazines: [magazine],
-            attachments: [attachment]
+            attachments: [attachment],
+            parts: [part]
         )
         firearm.type = "invalid-type"
         firearm.action = "invalid-action"

--- a/ArmoryInventoryTests/Mocks/AmmoTestSupport.swift
+++ b/ArmoryInventoryTests/Mocks/AmmoTestSupport.swift
@@ -64,7 +64,8 @@ func makeInMemoryContainer() throws -> ModelContainer {
         Firearm.self,
         Optic.self,
         Magazine.self,
-        Attachment.self
+        Attachment.self,
+        Part.self
     ])
     let configuration = ModelConfiguration(schema: schema, isStoredInMemoryOnly: true)
     return try ModelContainer(for: schema, configurations: [configuration])

--- a/ArmoryInventoryTests/ServicesTests/AddFirearmLookupServiceTests.swift
+++ b/ArmoryInventoryTests/ServicesTests/AddFirearmLookupServiceTests.swift
@@ -23,6 +23,7 @@ final class AddFirearmLookupServiceTests: XCTestCase {
         XCTAssertTrue(lookupData.optics.isEmpty)
         XCTAssertTrue(lookupData.magazines.isEmpty)
         XCTAssertTrue(lookupData.attachments.isEmpty)
+        XCTAssertTrue(lookupData.parts.isEmpty)
     }
 
     @MainActor
@@ -149,6 +150,30 @@ final class AddFirearmLookupServiceTests: XCTestCase {
                 purchasePriceCents: 2500
             )
         )
+        context.insert(
+            Part(
+                brand: "Geissele",
+                modelName: "SSA-E",
+                type: .trigger,
+                purchasePriceCents: 24000
+            )
+        )
+        context.insert(
+            Part(
+                brand: "BCM",
+                modelName: "MK2",
+                type: .chargingHandle,
+                purchasePriceCents: 8000
+            )
+        )
+        context.insert(
+            Part(
+                brand: "Aero",
+                modelName: "M4E1",
+                type: .upperReceiver,
+                purchasePriceCents: 12500
+            )
+        )
 
         let lookupData = try service.fetchLookupData(in: context)
 
@@ -157,5 +182,6 @@ final class AddFirearmLookupServiceTests: XCTestCase {
         XCTAssertEqual(lookupData.optics.map(\.displayName), ["Aimpoint Acro", "Aimpoint T-2", "Vortex Razor"])
         XCTAssertEqual(lookupData.magazines.map(\.displayName), ["CZ Competition", "CZ OEM", "Magpul PMAG"])
         XCTAssertEqual(lookupData.attachments.map(\.displayName), ["BCM KAG", "BCM Vertical Grip", "SureFire X300"])
+        XCTAssertEqual(lookupData.parts.map(\.displayName), ["Aero M4E1", "BCM MK2", "Geissele SSA-E"])
     }
 }

--- a/ArmoryInventoryTests/ServicesTests/InventoryListServiceTests.swift
+++ b/ArmoryInventoryTests/ServicesTests/InventoryListServiceTests.swift
@@ -19,6 +19,7 @@ final class InventoryListServiceTests: XCTestCase {
         XCTAssertTrue(try service.fetchAttachments(in: context).isEmpty)
         XCTAssertTrue(try service.fetchMagazines(in: context).isEmpty)
         XCTAssertTrue(try service.fetchOptics(in: context).isEmpty)
+        XCTAssertTrue(try service.fetchParts(in: context).isEmpty)
         XCTAssertTrue(try service.fetchFirearms(in: context).isEmpty)
     }
 
@@ -146,6 +147,30 @@ final class InventoryListServiceTests: XCTestCase {
             sortOrder: 1,
             createdAt: earlyDate
         )
+        let firstPart = Part(
+            brand: "Geissele",
+            modelName: "SSA-E",
+            type: .trigger,
+            purchasePriceCents: 24000,
+            sortOrder: 1,
+            createdAt: middleDate
+        )
+        let secondPart = Part(
+            brand: "BCM",
+            modelName: "MK2",
+            type: .chargingHandle,
+            purchasePriceCents: 8000,
+            sortOrder: 0,
+            createdAt: laterDate
+        )
+        let thirdPart = Part(
+            brand: "Aero",
+            modelName: "M4E1",
+            type: .upperReceiver,
+            purchasePriceCents: 12500,
+            sortOrder: 1,
+            createdAt: earlyDate
+        )
 
         context.insert(firstAttachment)
         context.insert(secondAttachment)
@@ -156,6 +181,9 @@ final class InventoryListServiceTests: XCTestCase {
         context.insert(firstOptic)
         context.insert(secondOptic)
         context.insert(thirdOptic)
+        context.insert(firstPart)
+        context.insert(secondPart)
+        context.insert(thirdPart)
         context.insert(firstFirearm)
         context.insert(secondFirearm)
         context.insert(thirdFirearm)
@@ -163,11 +191,13 @@ final class InventoryListServiceTests: XCTestCase {
         let attachments = try service.fetchAttachments(in: context)
         let magazines = try service.fetchMagazines(in: context)
         let optics = try service.fetchOptics(in: context)
+        let parts = try service.fetchParts(in: context)
         let firearms = try service.fetchFirearms(in: context)
 
         XCTAssertEqual(attachments.map(\.displayName), ["BCM KAG", "SureFire M640DF", "Magpul CTR"])
         XCTAssertEqual(magazines.map(\.displayName), ["Magpul PMAG", "Mec-Gar Competition", "CZ OEM"])
         XCTAssertEqual(optics.map(\.displayName), ["Aimpoint T-2", "EOTech EXPS3", "Vortex Razor HD"])
+        XCTAssertEqual(parts.map(\.displayName), ["BCM MK2", "Aero M4E1", "Geissele SSA-E"])
         XCTAssertEqual(firearms.map(\.displayName), ["CZ P-10 C", "Benelli M4", "Daniel Defense DDM4"])
     }
 }

--- a/ArmoryInventoryTests/ServicesTests/UserDataTransferServiceTests.swift
+++ b/ArmoryInventoryTests/ServicesTests/UserDataTransferServiceTests.swift
@@ -88,6 +88,17 @@ final class UserDataTransferServiceTests: XCTestCase {
             sortOrder: 4,
             createdAt: Date(timeIntervalSince1970: 8_000)
         )
+        let part = Part(
+            id: UUID(),
+            brand: "Apex",
+            modelName: "Action Enhancement",
+            type: .trigger,
+            purchaseDate: Date(timeIntervalSince1970: 8_500),
+            purchasePriceCents: 12_500,
+            firearm: firearm,
+            sortOrder: 5,
+            createdAt: Date(timeIntervalSince1970: 8_600)
+        )
         let record = AmmoAdjustmentRecord(
             quantity: 50,
             occurredAt: Date(timeIntervalSince1970: 9_000),
@@ -102,6 +113,7 @@ final class UserDataTransferServiceTests: XCTestCase {
         sourceContext.insert(optic)
         sourceContext.insert(magazine)
         sourceContext.insert(attachment)
+        sourceContext.insert(part)
         sourceContext.insert(record)
         try sourceContext.save()
 
@@ -121,6 +133,7 @@ final class UserDataTransferServiceTests: XCTestCase {
         let importedOptics = try destinationContext.fetch(FetchDescriptor<Optic>())
         let importedMagazines = try destinationContext.fetch(FetchDescriptor<Magazine>())
         let importedAttachments = try destinationContext.fetch(FetchDescriptor<Attachment>())
+        let importedParts = try destinationContext.fetch(FetchDescriptor<Part>())
         let importedRecords = try destinationContext.fetch(FetchDescriptor<AmmoAdjustmentRecord>())
 
         XCTAssertEqual(importedFirearms.count, 1)
@@ -128,12 +141,14 @@ final class UserDataTransferServiceTests: XCTestCase {
         XCTAssertEqual(importedOptics.count, 1)
         XCTAssertEqual(importedMagazines.count, 1)
         XCTAssertEqual(importedAttachments.count, 1)
+        XCTAssertEqual(importedParts.count, 1)
         XCTAssertEqual(importedRecords.count, 1)
         XCTAssertEqual(importedFirearms.first?.id, firearmID)
         XCTAssertEqual(importedFirearms.first?.caliber?.name, "9mm")
         XCTAssertEqual(importedOptics.first?.firearm?.id, firearmID)
         XCTAssertEqual(importedMagazines.first?.caliber?.name, "9mm")
         XCTAssertEqual(importedAttachments.first?.firearm?.id, firearmID)
+        XCTAssertEqual(importedParts.first?.firearm?.id, firearmID)
         XCTAssertEqual(importedRecords.first?.ammoType?.brand, "Federal")
         XCTAssertEqual(importedRecords.first?.adjustmentKind, .purchase)
 


### PR DESCRIPTION
## Summary

Adds `Parts` as a first-class accessory category alongside optics, magazines, and attachments.

This PR introduces:
- a new `Part` model with add/edit/list flows
- firearm linking support for parts in the add/edit firearm flow
- parts support in accessory totals, firearm total value, lookup services, and backup import/export
- test coverage for part models, part view model behavior, firearm linking, lookup, inventory listing, and data transfer

## User-facing changes

- Users can now manage `Parts` from the Accessories tab.
- Parts can be linked to firearms the same way optics, magazines, and attachments are linked.
- Firearm total value now includes linked parts.
- Backup/export and import now preserve parts and their firearm associations.

## Implementation details

- Added new files:
  - `ArmoryInventory/Accessories/Parts/PartModels.swift`
  - `ArmoryInventory/Accessories/Parts/AddPartView.swift`
  - `ArmoryInventory/Accessories/Parts/AddPartViewModel.swift`
  - `ArmoryInventory/Accessories/Parts/PartsView.swift`
- Extended:
  - `Firearm` relationships and total-value calculation
  - firearm lookup and selection flow to include parts
  - inventory list service and app schema
  - user data transfer snapshots/import logic
  - localization strings and About copy