### PR TITLE
Bugfix: Price over 999.99 cannot be parsed correctly

### DIFF
--- a/ArmoryInventory/Accessories/Attachments/AddAttachmentViewModel.swift
+++ b/ArmoryInventory/Accessories/Attachments/AddAttachmentViewModel.swift
@@ -9,6 +9,12 @@ import Foundation
 import SwiftData
 
 final class AddAttachmentViewModel {
+    private let priceInputParser: PriceInputParsing
+
+    init(priceInputParser: PriceInputParsing = PriceInputParserService()) {
+        self.priceInputParser = priceInputParser
+    }
+
     func initialPurchasePriceText(for attachment: Attachment?) -> String {
         attachment.map {
             (Decimal($0.purchasePriceCents) / 100).formatted(.number.precision(.fractionLength(2)))
@@ -25,18 +31,7 @@ final class AddAttachmentViewModel {
     }
 
     func purchasePriceCents(from text: String) -> Int? {
-        let trimmedText = trimmedValue(text)
-        guard !trimmedText.isEmpty else {
-            return nil
-        }
-
-        let normalizedText = trimmedText.replacingOccurrences(of: "$", with: "")
-        guard let amount = Decimal(string: normalizedText), amount >= 0 else {
-            return nil
-        }
-
-        let cents = (amount * 100 as NSDecimalNumber).rounding(accordingToBehavior: nil).intValue
-        return cents
+        priceInputParser.purchasePriceCents(from: text)
     }
 
     func resolvedTypeDetail(selectedType: AttachmentType, customType: String) -> String? {

--- a/ArmoryInventory/Accessories/Magazines/AddMagazineViewModel.swift
+++ b/ArmoryInventory/Accessories/Magazines/AddMagazineViewModel.swift
@@ -9,6 +9,12 @@ import Foundation
 import SwiftData
 
 final class AddMagazineViewModel {
+    private let priceInputParser: PriceInputParsing
+
+    init(priceInputParser: PriceInputParsing = PriceInputParserService()) {
+        self.priceInputParser = priceInputParser
+    }
+
     func initialPurchasePriceText(for magazine: Magazine?) -> String {
         magazine.map {
             (Decimal($0.purchasePriceCents) / 100).formatted(.number.precision(.fractionLength(2)))
@@ -25,18 +31,7 @@ final class AddMagazineViewModel {
     }
 
     func purchasePriceCents(from text: String) -> Int? {
-        let trimmedText = trimmedValue(text)
-        guard !trimmedText.isEmpty else {
-            return nil
-        }
-
-        let normalizedText = trimmedText.replacingOccurrences(of: "$", with: "")
-        guard let amount = Decimal(string: normalizedText), amount >= 0 else {
-            return nil
-        }
-
-        let cents = (amount * 100 as NSDecimalNumber).rounding(accordingToBehavior: nil).intValue
-        return cents
+        priceInputParser.purchasePriceCents(from: text)
     }
 
     func capacity(from text: String) -> Int? {

--- a/ArmoryInventory/Accessories/Optics/AddOpticViewModel.swift
+++ b/ArmoryInventory/Accessories/Optics/AddOpticViewModel.swift
@@ -9,6 +9,12 @@ import Foundation
 import SwiftData
 
 final class AddOpticViewModel {
+    private let priceInputParser: PriceInputParsing
+
+    init(priceInputParser: PriceInputParsing = PriceInputParserService()) {
+        self.priceInputParser = priceInputParser
+    }
+
     func initialPurchasePriceText(for optic: Optic?) -> String {
         optic.map {
             (Decimal($0.purchasePriceCents) / 100).formatted(.number.precision(.fractionLength(2)))
@@ -40,18 +46,7 @@ final class AddOpticViewModel {
     }
 
     func purchasePriceCents(from text: String) -> Int? {
-        let trimmedText = trimmedValue(text)
-        guard !trimmedText.isEmpty else {
-            return nil
-        }
-
-        let normalizedText = trimmedText.replacingOccurrences(of: "$", with: "")
-        guard let amount = Decimal(string: normalizedText), amount >= 0 else {
-            return nil
-        }
-
-        let cents = (amount * 100 as NSDecimalNumber).rounding(accordingToBehavior: nil).intValue
-        return cents
+        priceInputParser.purchasePriceCents(from: text)
     }
 
     func magnificationValue(from text: String) -> Double? {

--- a/ArmoryInventory/Accessories/Parts/AddPartViewModel.swift
+++ b/ArmoryInventory/Accessories/Parts/AddPartViewModel.swift
@@ -9,6 +9,12 @@ import Foundation
 import SwiftData
 
 final class AddPartViewModel {
+    private let priceInputParser: PriceInputParsing
+
+    init(priceInputParser: PriceInputParsing = PriceInputParserService()) {
+        self.priceInputParser = priceInputParser
+    }
+
     func initialPurchasePriceText(for part: Part?) -> String {
         part.map {
             (Decimal($0.purchasePriceCents) / 100).formatted(.number.precision(.fractionLength(2)))
@@ -25,18 +31,7 @@ final class AddPartViewModel {
     }
 
     func purchasePriceCents(from text: String) -> Int? {
-        let trimmedText = trimmedValue(text)
-        guard !trimmedText.isEmpty else {
-            return nil
-        }
-
-        let normalizedText = trimmedText.replacingOccurrences(of: "$", with: "")
-        guard let amount = Decimal(string: normalizedText), amount >= 0 else {
-            return nil
-        }
-
-        let cents = (amount * 100 as NSDecimalNumber).rounding(accordingToBehavior: nil).intValue
-        return cents
+        priceInputParser.purchasePriceCents(from: text)
     }
 
     func resolvedTypeDetail(selectedType: PartType, customType: String) -> String? {

--- a/ArmoryInventory/Firearms/AddFirearmViewModel.swift
+++ b/ArmoryInventory/Firearms/AddFirearmViewModel.swift
@@ -9,6 +9,12 @@ import Foundation
 import SwiftData
 
 final class AddFirearmViewModel {
+    private let priceInputParser: PriceInputParsing
+
+    init(priceInputParser: PriceInputParsing = PriceInputParserService()) {
+        self.priceInputParser = priceInputParser
+    }
+
     func initialPurchasePriceText(for firearm: Firearm?) -> String {
         firearm.map {
             (Decimal($0.purchasePriceCents) / 100).formatted(.number.precision(.fractionLength(2)))
@@ -88,18 +94,7 @@ final class AddFirearmViewModel {
     }
 
     func purchasePriceCents(from text: String) -> Int? {
-        let trimmedText = trimmedValue(text)
-        guard !trimmedText.isEmpty else {
-            return nil
-        }
-
-        let normalizedText = trimmedText.replacingOccurrences(of: "$", with: "")
-        guard let amount = Decimal(string: normalizedText), amount >= 0 else {
-            return nil
-        }
-
-        let cents = (amount * 100 as NSDecimalNumber).rounding(accordingToBehavior: nil).intValue
-        return cents
+        priceInputParser.purchasePriceCents(from: text)
     }
 
     func resolvedOptics(from optics: [Optic], selectedIDs: Set<PersistentIdentifier>) -> [Optic] {

--- a/ArmoryInventory/Services/PriceInputParserService.swift
+++ b/ArmoryInventory/Services/PriceInputParserService.swift
@@ -1,0 +1,55 @@
+//
+//  PriceInputParserService.swift
+//  Armory Inventory
+//
+//  Created by Codex on 4/5/26.
+//
+
+import Foundation
+
+protocol PriceInputParsing {
+    func purchasePriceCents(from text: String) -> Int?
+}
+
+struct PriceInputParserService: PriceInputParsing {
+    func purchasePriceCents(from text: String) -> Int? {
+        let trimmedText = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedText.isEmpty else {
+            return nil
+        }
+
+        let separators = CharacterSet(charactersIn: ".,")
+        let allowedScalars = trimmedText.unicodeScalars.filter { scalar in
+            CharacterSet.decimalDigits.contains(scalar) || separators.contains(scalar)
+        }
+        let sanitized = String(String.UnicodeScalarView(allowedScalars))
+        guard !sanitized.isEmpty else {
+            return nil
+        }
+
+        let lastPeriodIndex = sanitized.lastIndex(of: ".")
+        let lastCommaIndex = sanitized.lastIndex(of: ",")
+        let decimalSeparatorIndex = [lastPeriodIndex, lastCommaIndex].compactMap { $0 }.max()
+
+        let normalizedText: String
+        if let decimalSeparatorIndex {
+            let fractionalStart = sanitized.index(after: decimalSeparatorIndex)
+            let fractionalDigits = sanitized.distance(from: fractionalStart, to: sanitized.endIndex)
+            guard fractionalDigits > 0, fractionalDigits <= 2 else {
+                return nil
+            }
+
+            let integerPart = sanitized[..<decimalSeparatorIndex].filter(\.isNumber)
+            let fractionalPart = sanitized[fractionalStart...].filter(\.isNumber)
+            normalizedText = integerPart.isEmpty ? "0.\(fractionalPart)" : "\(integerPart).\(fractionalPart)"
+        } else {
+            normalizedText = String(sanitized.filter(\.isNumber))
+        }
+
+        guard let amount = Decimal(string: normalizedText), amount >= 0 else {
+            return nil
+        }
+
+        return NSDecimalNumber(decimal: amount * 100).intValue
+    }
+}

--- a/ArmoryInventoryTests/ServicesTests/PriceInputParserServiceTests.swift
+++ b/ArmoryInventoryTests/ServicesTests/PriceInputParserServiceTests.swift
@@ -1,0 +1,28 @@
+//
+//  PriceInputParserServiceTests.swift
+//  Armory InventoryTests
+//
+//  Created by Codex on 4/5/26.
+//
+
+import XCTest
+@testable import ArmoryInventory
+
+final class PriceInputParserServiceTests: XCTestCase {
+    private let service = PriceInputParserService()
+
+    func testParserAcceptsPlainAndFormattedCurrencyInput() {
+        XCTAssertEqual(service.purchasePriceCents(from: "999.99"), 99999)
+        XCTAssertEqual(service.purchasePriceCents(from: "1,000.00"), 100000)
+        XCTAssertEqual(service.purchasePriceCents(from: "$2,499.99"), 249999)
+        XCTAssertEqual(service.purchasePriceCents(from: "2499,99"), 249999)
+        XCTAssertEqual(service.purchasePriceCents(from: "2500"), 250000)
+    }
+
+    func testParserRejectsInvalidOrOverPreciseInput() {
+        XCTAssertNil(service.purchasePriceCents(from: ""))
+        XCTAssertNil(service.purchasePriceCents(from: "bad"))
+        XCTAssertNil(service.purchasePriceCents(from: "2499.999"))
+        XCTAssertNil(service.purchasePriceCents(from: "1,000."))
+    }
+}


### PR DESCRIPTION
## Summary

This PR extracts purchase price parsing into a dedicated service and fixes parsing for formatted values that include grouping separators, such as `1,000.00`. That resolves the reopen/detail-page bug where firearm values at `1000.00` or above were not counted because the stored display text could no longer be parsed back into cents.

## Changes

- Added `PriceInputParserService` under [PriceInputParserService.swift](/Users/liyinxue/Source/ArmoryInventory/ArmoryInventory/Services/PriceInputParserService.swift)
- Introduced the `PriceInputParsing` protocol for injection and reuse
- Updated firearm, optic, magazine, attachment, and part add/edit view models to use the parser service instead of duplicating parsing logic
- Added focused parser tests in [PriceInputParserServiceTests.swift](/Users/liyinxue/Source/ArmoryInventory/ArmoryInventoryTests/ServicesTests/PriceInputParserServiceTests.swift)
- Removed parser-specific edge case coverage from [AddFirearmViewModelTests.swift](/Users/liyinxue/Source/ArmoryInventory/ArmoryInventoryTests/FirearmsTests/AddFirearmViewModelTests.swift) so that file stays focused on firearm form behavior

## Behavior Fixed

- `999.99` continued to work before because it reopened without grouping separators
- `1000.00` and higher could reopen as `1,000.00`, which the old parser rejected
- The new parser accepts:
  - `999.99`
  - `1,000.00`
  - `$2,499.99`
  - `2499,99`
  - `2500`
- The parser still rejects malformed precision like `2499.999`

## Testing

- Added unit tests for valid and invalid price input parsing
- Full `xcodebuild test` was not run in this environment because the machine is configured to use Command Line Tools rather than a full Xcode developer directory