### PR TITLE
Add configurable accessory sorting controls

### DIFF
--- a/ArmoryInventory/Accessories/Attachments/AttachmentsView.swift
+++ b/ArmoryInventory/Accessories/Attachments/AttachmentsView.swift
@@ -11,6 +11,8 @@ import SwiftData
 struct AttachmentsView: View {
     @Environment(\.modelContext) private var context
     @AppStorage(AttachmentTypeSort.settingsVersionKey) private var typeSortVersion = 0
+    @AppStorage(InventorySettingsKeys.attachmentItemSortOrder) private var itemSortOrder = AccessoryItemSortOrder.manual.rawValue
+    @AppStorage(InventorySettingsKeys.attachmentItemSortDirection) private var itemSortDirectionRaw = ""
     @AppStorage(InventorySettingsKeys.showValueInCard) private var showValueInCard = true
     @AppStorage(InventorySettingsKeys.showTotalValue) private var showTotalValue = true
     @State private var showingAddAttachment = false
@@ -106,7 +108,9 @@ struct AttachmentsView: View {
     }
 
     private var groupedAttachments: [String: [Attachment]] {
-        Dictionary(grouping: attachments, by: \.typeDisplayName)
+        Dictionary(grouping: attachments, by: \.typeDisplayName).mapValues {
+            AccessoryItemSort.sorted($0, by: selectedItemSortOrder, direction: selectedItemSortDirection)
+        }
     }
 
     private var groupedAttachmentTypes: [String] {
@@ -150,5 +154,13 @@ struct AttachmentsView: View {
         let totalCents = attachments.reduce(0) { $0 + max(0, $1.purchasePriceCents) }
         let amount = Decimal(totalCents) / 100
         return amount.formatted(.currency(code: Locale.current.currency?.identifier ?? "USD"))
+    }
+
+    private var selectedItemSortOrder: AccessoryItemSortOrder {
+        AccessoryItemSortOrder(rawValue: itemSortOrder) ?? .manual
+    }
+
+    private var selectedItemSortDirection: AccessoryItemSortDirection {
+        AccessoryItemSortDirection(rawValue: itemSortDirectionRaw) ?? AccessoryItemSort.preferredDirection(for: selectedItemSortOrder)
     }
 }

--- a/ArmoryInventory/Accessories/Optics/OpticsModels.swift
+++ b/ArmoryInventory/Accessories/Optics/OpticsModels.swift
@@ -219,6 +219,10 @@ final class Optic {
         "\(brand) \(modelName)"
     }
 
+    var typeDisplayName: String {
+        opticType.displayName
+    }
+
     var magnificationText: String {
         let minText = minMagnification.formatted(.number.precision(.fractionLength(0...1)))
         let maxText = maxMagnification.formatted(.number.precision(.fractionLength(0...1)))

--- a/ArmoryInventory/Accessories/Optics/OpticsView.swift
+++ b/ArmoryInventory/Accessories/Optics/OpticsView.swift
@@ -10,6 +10,9 @@ import SwiftData
 
 struct OpticsView: View {
     @Environment(\.modelContext) private var context
+    @AppStorage(OpticTypeSort.settingsVersionKey) private var typeSortVersion = 0
+    @AppStorage(InventorySettingsKeys.opticItemSortOrder) private var itemSortOrder = AccessoryItemSortOrder.manual.rawValue
+    @AppStorage(InventorySettingsKeys.opticItemSortDirection) private var itemSortDirectionRaw = ""
     @AppStorage(InventorySettingsKeys.showValueInCard) private var showValueInCard = true
     @AppStorage(InventorySettingsKeys.showTotalValue) private var showTotalValue = true
     @State private var showingAddOptic = false
@@ -28,45 +31,51 @@ struct OpticsView: View {
                 )
             } else {
                 List {
-                    ForEach(optics) { optic in
-                        Button {
-                            selectedOptic = optic
-                        } label: {
-                            VStack(alignment: .leading, spacing: 6) {
-                                HStack(alignment: .firstTextBaseline) {
-                                    VStack(alignment: .leading, spacing: 2) {
-                                        Text(optic.displayName)
-                                            .font(.headline)
-                                        Text("\(optic.opticType.displayName) • \(optic.magnificationText)")
-                                            .font(.subheadline)
-                                            .foregroundStyle(.secondary)
+                    ForEach(groupedOpticTypes, id: \.self) { type in
+                        Section(type) {
+                            ForEach(groupedOptics[type] ?? []) { optic in
+                                Button {
+                                    selectedOptic = optic
+                                } label: {
+                                    VStack(alignment: .leading, spacing: 6) {
+                                        HStack(alignment: .firstTextBaseline) {
+                                            VStack(alignment: .leading, spacing: 2) {
+                                                Text(optic.displayName)
+                                                    .font(.headline)
+                                                Text(optic.magnificationText)
+                                                    .font(.subheadline)
+                                                    .foregroundStyle(.secondary)
+                                            }
+                                        }
+
+                                        LabeledContent("Footprint", value: optic.footprintDisplayName)
+
+                                        if let tubeSizeText = optic.tubeSizeText {
+                                            LabeledContent("Tube", value: tubeSizeText)
+                                        }
+
+                                        if let focalPlane = optic.opticFocalPlane {
+                                            LabeledContent("Focal Plane", value: focalPlane.displayName)
+                                        }
+
+                                        if showValueInCard, optic.purchasePriceCents > 0 {
+                                            LabeledContent("Value", value: optic.purchasePriceText)
+                                        }
+
+                                        if let firearm = optic.firearm {
+                                            LabeledContent("Linked Firearm", value: firearm.displayName)
+                                        }
                                     }
+                                    .padding(.vertical, 6)
+                                    .contentShape(Rectangle())
                                 }
-
-                                LabeledContent("Footprint", value: optic.footprintDisplayName)
-
-                                if let tubeSizeText = optic.tubeSizeText {
-                                    LabeledContent("Tube", value: tubeSizeText)
-                                }
-
-                                if let focalPlane = optic.opticFocalPlane {
-                                    LabeledContent("Focal Plane", value: focalPlane.displayName)
-                                }
-
-                                if showValueInCard, optic.purchasePriceCents > 0 {
-                                    LabeledContent("Value", value: optic.purchasePriceText)
-                                }
-
-                                if let firearm = optic.firearm {
-                                    LabeledContent("Linked Firearm", value: firearm.displayName)
-                                }
+                                .buttonStyle(.plain)
                             }
-                            .padding(.vertical, 6)
-                            .contentShape(Rectangle())
+                            .onDelete { offsets in
+                                deleteOptics(at: offsets, in: type)
+                            }
                         }
-                        .buttonStyle(.plain)
                     }
-                    .onDelete(perform: deleteOptics)
 
                     if showTotalValue {
                         Section {
@@ -94,6 +103,9 @@ struct OpticsView: View {
                 reloadOptics()
             }
         }
+        .onChange(of: typeSortVersion) { _, _ in
+            reloadOptics()
+        }
         .toolbar {
             ToolbarItemGroup(placement: .topBarTrailing) {
                 EditButton()
@@ -115,9 +127,23 @@ struct OpticsView: View {
         }
     }
 
-    private func deleteOptics(at offsets: IndexSet) {
+    private var groupedOptics: [String: [Optic]] {
+        Dictionary(grouping: optics, by: \.typeDisplayName).mapValues {
+            AccessoryItemSort.sorted($0, by: selectedItemSortOrder, direction: selectedItemSortDirection)
+        }
+    }
+
+    private var groupedOpticTypes: [String] {
+        OpticTypeSort.displayOrder(for: Array(groupedOptics.keys))
+    }
+
+    private func deleteOptics(at offsets: IndexSet, in type: String) {
+        guard let sectionOptics = groupedOptics[type] else {
+            return
+        }
+
         for index in offsets {
-            context.delete(optics[index])
+            context.delete(sectionOptics[index])
         }
         resequenceOptics()
 
@@ -148,5 +174,13 @@ struct OpticsView: View {
         let totalCents = optics.reduce(0) { $0 + max(0, $1.purchasePriceCents) }
         let amount = Decimal(totalCents) / 100
         return amount.formatted(.currency(code: Locale.current.currency?.identifier ?? "USD"))
+    }
+
+    private var selectedItemSortOrder: AccessoryItemSortOrder {
+        AccessoryItemSortOrder(rawValue: itemSortOrder) ?? .manual
+    }
+
+    private var selectedItemSortDirection: AccessoryItemSortDirection {
+        AccessoryItemSortDirection(rawValue: itemSortDirectionRaw) ?? AccessoryItemSort.preferredDirection(for: selectedItemSortOrder)
     }
 }

--- a/ArmoryInventory/Accessories/Parts/PartModels.swift
+++ b/ArmoryInventory/Accessories/Parts/PartModels.swift
@@ -47,12 +47,6 @@ enum PartType: String, Codable, CaseIterable, Identifiable {
         }
     }
 
-    static func displayOrder(for names: [String]) -> [String] {
-        let enumOrder = allCases.map(\.displayName)
-        let knownNames = enumOrder.filter(names.contains)
-        let customNames = names.filter { !enumOrder.contains($0) }.sorted()
-        return knownNames + customNames
-    }
 }
 
 @Model

--- a/ArmoryInventory/Accessories/Parts/PartsView.swift
+++ b/ArmoryInventory/Accessories/Parts/PartsView.swift
@@ -10,6 +10,9 @@ import SwiftData
 
 struct PartsView: View {
     @Environment(\.modelContext) private var context
+    @AppStorage(PartTypeSort.settingsVersionKey) private var typeSortVersion = 0
+    @AppStorage(InventorySettingsKeys.partItemSortOrder) private var itemSortOrder = AccessoryItemSortOrder.manual.rawValue
+    @AppStorage(InventorySettingsKeys.partItemSortDirection) private var itemSortDirectionRaw = ""
     @AppStorage(InventorySettingsKeys.showValueInCard) private var showValueInCard = true
     @AppStorage(InventorySettingsKeys.showTotalValue) private var showTotalValue = true
     @State private var showingAddPart = false
@@ -83,6 +86,9 @@ struct PartsView: View {
                 reloadParts()
             }
         }
+        .onChange(of: typeSortVersion) { _, _ in
+            reloadParts()
+        }
         .toolbar {
             ToolbarItemGroup(placement: .topBarTrailing) {
                 EditButton()
@@ -105,11 +111,13 @@ struct PartsView: View {
     }
 
     private var groupedParts: [String: [Part]] {
-        Dictionary(grouping: parts, by: \.typeDisplayName)
+        Dictionary(grouping: parts, by: \.typeDisplayName).mapValues {
+            AccessoryItemSort.sorted($0, by: selectedItemSortOrder, direction: selectedItemSortDirection)
+        }
     }
 
     private var groupedPartTypes: [String] {
-        PartType.displayOrder(for: Array(groupedParts.keys))
+        PartTypeSort.displayOrder(for: Array(groupedParts.keys))
     }
 
     private func deleteParts(at offsets: IndexSet, in type: String) {
@@ -149,5 +157,13 @@ struct PartsView: View {
         let totalCents = parts.reduce(0) { $0 + max(0, $1.purchasePriceCents) }
         let amount = Decimal(totalCents) / 100
         return amount.formatted(.currency(code: Locale.current.currency?.identifier ?? "USD"))
+    }
+
+    private var selectedItemSortOrder: AccessoryItemSortOrder {
+        AccessoryItemSortOrder(rawValue: itemSortOrder) ?? .manual
+    }
+
+    private var selectedItemSortDirection: AccessoryItemSortDirection {
+        AccessoryItemSortDirection(rawValue: itemSortDirectionRaw) ?? AccessoryItemSort.preferredDirection(for: selectedItemSortOrder)
     }
 }

--- a/ArmoryInventory/Localizable.xcstrings
+++ b/ArmoryInventory/Localizable.xcstrings
@@ -361,6 +361,12 @@
     "Hold and drag calibers to control the order used throughout the app." : {
 
     },
+    "Hold and drag optic types to control the section order used in optics." : {
+
+    },
+    "Hold and drag part types to control the section order used in parts." : {
+
+    },
     "Illuminated" : {
 
     },
@@ -550,6 +556,9 @@
     "Optics" : {
 
     },
+    "Optics Sorting" : {
+
+    },
     "Optional" : {
 
     },
@@ -569,6 +578,9 @@
 
     },
     "Parts" : {
+
+    },
+    "Parts Sorting" : {
 
     },
     "Post-Tax Total" : {
@@ -631,6 +643,9 @@
     "Show Value in Details" : {
 
     },
+    "Sort %@ In Each Type By" : {
+
+    },
     "Sort Firearms By" : {
 
     },
@@ -677,6 +692,9 @@
 
     },
     "Type Details" : {
+
+    },
+    "Type Order" : {
 
     },
     "Typical: %lldgr-%lldgr" : {

--- a/ArmoryInventory/Services/AccessoryItemSort.swift
+++ b/ArmoryInventory/Services/AccessoryItemSort.swift
@@ -1,0 +1,137 @@
+//
+//  AccessoryItemSort.swift
+//  Armory Inventory
+//
+//  Created by Codex on 4/6/26.
+//
+
+import Foundation
+
+enum AccessoryItemSortOrder: String, CaseIterable, Identifiable {
+    case manual
+    case purchaseDate
+    case value
+    case brand
+    case model
+
+    var id: String { rawValue }
+
+    var displayName: String {
+        switch self {
+        case .manual:
+            return "Manual"
+        case .purchaseDate:
+            return "Purchase Date"
+        case .value:
+            return "Value"
+        case .brand:
+            return "Brand"
+        case .model:
+            return "Model"
+        }
+    }
+}
+
+enum AccessoryItemSortDirection: String, CaseIterable, Identifiable {
+    case ascending
+    case descending
+
+    var id: String { rawValue }
+
+    var displayName: String {
+        switch self {
+        case .ascending:
+            return "Ascending"
+        case .descending:
+            return "Descending"
+        }
+    }
+}
+
+protocol AccessorySortableItem {
+    var brand: String { get }
+    var modelName: String { get }
+    var purchaseDate: Date { get }
+    var purchasePriceCents: Int { get }
+    var displayName: String { get }
+}
+
+enum AccessoryItemSort {
+    static func sorted<T: AccessorySortableItem>(
+        _ items: [T],
+        by sortOrder: AccessoryItemSortOrder,
+        direction: AccessoryItemSortDirection
+    ) -> [T] {
+        switch sortOrder {
+        case .manual:
+            return items
+        case .purchaseDate:
+            return items.sorted {
+                if $0.purchaseDate != $1.purchaseDate {
+                    return compare($0.purchaseDate, $1.purchaseDate, direction: direction)
+                }
+                return compareNames($0.displayName, $1.displayName, direction: direction)
+            }
+        case .value:
+            return items.sorted {
+                if $0.purchasePriceCents != $1.purchasePriceCents {
+                    return compare($0.purchasePriceCents, $1.purchasePriceCents, direction: direction)
+                }
+                return compareNames($0.displayName, $1.displayName, direction: direction)
+            }
+        case .brand:
+            return items.sorted {
+                let brandComparison = $0.brand.localizedStandardCompare($1.brand)
+                if brandComparison != .orderedSame {
+                    return compare(brandComparison, direction: direction)
+                }
+                return compareNames($0.modelName, $1.modelName, direction: direction)
+            }
+        case .model:
+            return items.sorted {
+                let modelComparison = $0.modelName.localizedStandardCompare($1.modelName)
+                if modelComparison != .orderedSame {
+                    return compare(modelComparison, direction: direction)
+                }
+                return compareNames($0.brand, $1.brand, direction: direction)
+            }
+        }
+    }
+
+    static func preferredDirection(for sortOrder: AccessoryItemSortOrder) -> AccessoryItemSortDirection {
+        switch sortOrder {
+        case .manual:
+            return .ascending
+        case .purchaseDate, .value:
+            return .descending
+        case .brand, .model:
+            return .ascending
+        }
+    }
+
+    private static func compare<T: Comparable>(_ lhs: T, _ rhs: T, direction: AccessoryItemSortDirection) -> Bool {
+        switch direction {
+        case .ascending:
+            return lhs < rhs
+        case .descending:
+            return lhs > rhs
+        }
+    }
+
+    private static func compare(_ comparison: ComparisonResult, direction: AccessoryItemSortDirection) -> Bool {
+        switch direction {
+        case .ascending:
+            return comparison == .orderedAscending
+        case .descending:
+            return comparison == .orderedDescending
+        }
+    }
+
+    private static func compareNames(_ lhs: String, _ rhs: String, direction: AccessoryItemSortDirection) -> Bool {
+        compare(lhs.localizedStandardCompare(rhs), direction: direction)
+    }
+}
+
+extension Attachment: AccessorySortableItem {}
+extension Optic: AccessorySortableItem {}
+extension Part: AccessorySortableItem {}

--- a/ArmoryInventory/Services/InventoryTaxRateProvider.swift
+++ b/ArmoryInventory/Services/InventoryTaxRateProvider.swift
@@ -39,6 +39,16 @@ enum InventorySettingsKeys {
     static let caliberSortOrderVersion = "CaliberSortOrderVersion"
     static let attachmentTypeSortOrder = "AttachmentTypeSortOrder"
     static let attachmentTypeSortOrderVersion = "AttachmentTypeSortOrderVersion"
+    static let attachmentItemSortOrder = "AttachmentItemSortOrder"
+    static let attachmentItemSortDirection = "AttachmentItemSortDirection"
+    static let opticTypeSortOrder = "OpticTypeSortOrder"
+    static let opticTypeSortOrderVersion = "OpticTypeSortOrderVersion"
+    static let opticItemSortOrder = "OpticItemSortOrder"
+    static let opticItemSortDirection = "OpticItemSortDirection"
+    static let partTypeSortOrder = "PartTypeSortOrder"
+    static let partTypeSortOrderVersion = "PartTypeSortOrderVersion"
+    static let partItemSortOrder = "PartItemSortOrder"
+    static let partItemSortDirection = "PartItemSortDirection"
     static let lastModelSaveDate = "LastModelSaveDate"
 
     static let managedUserDataKeys: [String] = [
@@ -54,6 +64,16 @@ enum InventorySettingsKeys {
         caliberSortOrderVersion,
         attachmentTypeSortOrder,
         attachmentTypeSortOrderVersion,
+        attachmentItemSortOrder,
+        attachmentItemSortDirection,
+        opticTypeSortOrder,
+        opticTypeSortOrderVersion,
+        opticItemSortOrder,
+        opticItemSortDirection,
+        partTypeSortOrder,
+        partTypeSortOrderVersion,
+        partItemSortOrder,
+        partItemSortDirection,
         lastModelSaveDate
     ]
 }

--- a/ArmoryInventory/Services/OpticTypeSort.swift
+++ b/ArmoryInventory/Services/OpticTypeSort.swift
@@ -1,0 +1,76 @@
+//
+//  OpticTypeSort.swift
+//  Armory Inventory
+//
+//  Created by Codex on 4/6/26.
+//
+
+import Foundation
+
+enum OpticTypeSort {
+    nonisolated static func areInAscendingOrder(_ lhs: String, _ rhs: String) -> Bool {
+        let lhsRank = rank(for: lhs)
+        let rhsRank = rank(for: rhs)
+
+        switch (lhsRank, rhsRank) {
+        case let (lhsRank?, rhsRank?):
+            if lhsRank != rhsRank {
+                return lhsRank < rhsRank
+            }
+        case (.some, .none):
+            return true
+        case (.none, .some):
+            return false
+        case (.none, .none):
+            break
+        }
+
+        return lhs.localizedStandardCompare(rhs) == .orderedAscending
+    }
+
+    nonisolated static func displayOrder(for typeNames: [String]) -> [String] {
+        typeNames.sorted(by: areInAscendingOrder)
+    }
+
+    nonisolated static func persistedOrder(including typeNames: [String] = []) -> [String] {
+        let names = typeNames.map(normalize(typeName:))
+        let savedOrder = UserDefaults.standard.stringArray(forKey: settingsKey)?.map(normalize(typeName:)) ?? []
+        let knownNames = defaultOrder.filter { !savedOrder.contains($0) }
+        let customNames = names.filter { !savedOrder.contains($0) && !knownNames.contains($0) }
+        return savedOrder + knownNames + customNames.sorted { $0.localizedStandardCompare($1) == .orderedAscending }
+    }
+
+    nonisolated static func saveOrder(_ typeNames: [String]) {
+        let normalized = typeNames.map(normalize(typeName:))
+        UserDefaults.standard.set(normalized, forKey: settingsKey)
+        let nextVersion = UserDefaults.standard.integer(forKey: settingsVersionKey) + 1
+        UserDefaults.standard.set(nextVersion, forKey: settingsVersionKey)
+    }
+
+    nonisolated static func resetOrder() {
+        UserDefaults.standard.removeObject(forKey: settingsKey)
+        let nextVersion = UserDefaults.standard.integer(forKey: settingsVersionKey) + 1
+        UserDefaults.standard.set(nextVersion, forKey: settingsVersionKey)
+    }
+
+    nonisolated static let settingsVersionKey = InventorySettingsKeys.opticTypeSortOrderVersion
+
+    nonisolated private static func rank(for typeName: String) -> Int? {
+        let normalizedName = normalize(typeName: typeName)
+        return currentOrder.firstIndex(of: normalizedName)
+    }
+
+    nonisolated private static func normalize(typeName: String) -> String {
+        typeName.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+    }
+
+    nonisolated private static var currentOrder: [String] {
+        persistedOrder()
+    }
+
+    nonisolated private static let settingsKey = InventorySettingsKeys.opticTypeSortOrder
+
+    nonisolated private static let defaultOrder: [String] = OpticType.allCases.map {
+        normalize(typeName: $0.displayName)
+    }
+}

--- a/ArmoryInventory/Services/PartTypeSort.swift
+++ b/ArmoryInventory/Services/PartTypeSort.swift
@@ -1,0 +1,76 @@
+//
+//  PartTypeSort.swift
+//  Armory Inventory
+//
+//  Created by Codex on 4/6/26.
+//
+
+import Foundation
+
+enum PartTypeSort {
+    nonisolated static func areInAscendingOrder(_ lhs: String, _ rhs: String) -> Bool {
+        let lhsRank = rank(for: lhs)
+        let rhsRank = rank(for: rhs)
+
+        switch (lhsRank, rhsRank) {
+        case let (lhsRank?, rhsRank?):
+            if lhsRank != rhsRank {
+                return lhsRank < rhsRank
+            }
+        case (.some, .none):
+            return true
+        case (.none, .some):
+            return false
+        case (.none, .none):
+            break
+        }
+
+        return lhs.localizedStandardCompare(rhs) == .orderedAscending
+    }
+
+    nonisolated static func displayOrder(for typeNames: [String]) -> [String] {
+        typeNames.sorted(by: areInAscendingOrder)
+    }
+
+    nonisolated static func persistedOrder(including typeNames: [String] = []) -> [String] {
+        let names = typeNames.map(normalize(typeName:))
+        let savedOrder = UserDefaults.standard.stringArray(forKey: settingsKey)?.map(normalize(typeName:)) ?? []
+        let knownNames = defaultOrder.filter { !savedOrder.contains($0) }
+        let customNames = names.filter { !savedOrder.contains($0) && !knownNames.contains($0) }
+        return savedOrder + knownNames + customNames.sorted { $0.localizedStandardCompare($1) == .orderedAscending }
+    }
+
+    nonisolated static func saveOrder(_ typeNames: [String]) {
+        let normalized = typeNames.map(normalize(typeName:))
+        UserDefaults.standard.set(normalized, forKey: settingsKey)
+        let nextVersion = UserDefaults.standard.integer(forKey: settingsVersionKey) + 1
+        UserDefaults.standard.set(nextVersion, forKey: settingsVersionKey)
+    }
+
+    nonisolated static func resetOrder() {
+        UserDefaults.standard.removeObject(forKey: settingsKey)
+        let nextVersion = UserDefaults.standard.integer(forKey: settingsVersionKey) + 1
+        UserDefaults.standard.set(nextVersion, forKey: settingsVersionKey)
+    }
+
+    nonisolated static let settingsVersionKey = InventorySettingsKeys.partTypeSortOrderVersion
+
+    nonisolated private static func rank(for typeName: String) -> Int? {
+        let normalizedName = normalize(typeName: typeName)
+        return currentOrder.firstIndex(of: normalizedName)
+    }
+
+    nonisolated private static func normalize(typeName: String) -> String {
+        typeName.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+    }
+
+    nonisolated private static var currentOrder: [String] {
+        persistedOrder()
+    }
+
+    nonisolated private static let settingsKey = InventorySettingsKeys.partTypeSortOrder
+
+    nonisolated private static let defaultOrder: [String] = PartType.allCases.map {
+        normalize(typeName: $0.displayName)
+    }
+}

--- a/ArmoryInventory/Settings/AccessoryItemSortingSection.swift
+++ b/ArmoryInventory/Settings/AccessoryItemSortingSection.swift
@@ -1,0 +1,48 @@
+//
+//  AccessoryItemSortingSection.swift
+//  Armory Inventory
+//
+//  Created by Codex on 4/6/26.
+//
+
+import SwiftUI
+
+struct AccessoryItemSortingSection: View {
+    @Binding var sortOrderRaw: String
+    @Binding var sortDirectionRaw: String
+    let itemLabelPlural: String
+
+    var body: some View {
+        Section("Ordering") {
+            Picker("Sort \(itemLabelPlural) In Each Type By", selection: $sortOrderRaw) {
+                ForEach(AccessoryItemSortOrder.allCases) { sortOrder in
+                    Text(sortOrder.displayName).tag(sortOrder.rawValue)
+                }
+            }
+
+            if selectedSortOrder != .manual {
+                Picker("Direction", selection: sortDirectionBinding) {
+                    ForEach(AccessoryItemSortDirection.allCases) { direction in
+                        Text(direction.displayName).tag(direction)
+                    }
+                }
+                .pickerStyle(.segmented)
+            }
+        }
+    }
+
+    private var selectedSortOrder: AccessoryItemSortOrder {
+        AccessoryItemSortOrder(rawValue: sortOrderRaw) ?? .manual
+    }
+
+    private var sortDirectionBinding: Binding<AccessoryItemSortDirection> {
+        Binding(
+            get: {
+                AccessoryItemSortDirection(rawValue: sortDirectionRaw) ?? AccessoryItemSort.preferredDirection(for: selectedSortOrder)
+            },
+            set: { direction in
+                sortDirectionRaw = direction.rawValue
+            }
+        )
+    }
+}

--- a/ArmoryInventory/Settings/OpticTypeOrdering/OpticTypeOrderingView.swift
+++ b/ArmoryInventory/Settings/OpticTypeOrdering/OpticTypeOrderingView.swift
@@ -1,23 +1,23 @@
 //
-//  AttachmentTypeOrderingView.swift
+//  OpticTypeOrderingView.swift
 //  Armory Inventory
 //
-//  Created by Codex on 4/2/26.
+//  Created by Codex on 4/6/26.
 //
 
 import SwiftUI
 
-struct AttachmentTypeOrderingView: View {
-    @AppStorage(AttachmentTypeSort.settingsVersionKey) private var sortVersion = 0
-    @AppStorage(InventorySettingsKeys.attachmentItemSortOrder) private var itemSortOrder = AccessoryItemSortOrder.manual.rawValue
-    @AppStorage(InventorySettingsKeys.attachmentItemSortDirection) private var itemSortDirectionRaw = ""
+struct OpticTypeOrderingView: View {
+    @AppStorage(OpticTypeSort.settingsVersionKey) private var sortVersion = 0
+    @AppStorage(InventorySettingsKeys.opticItemSortOrder) private var itemSortOrder = AccessoryItemSortOrder.manual.rawValue
+    @AppStorage(InventorySettingsKeys.opticItemSortDirection) private var itemSortDirectionRaw = ""
     @State private var rankingNames: [String] = []
-    let viewModel: AttachmentTypeOrderingViewModel
+    let viewModel: OpticTypeOrderingViewModel
 
     var body: some View {
         List {
             Section {
-                Text("Hold and drag attachment types to control the section order used in attachments.")
+                Text("Hold and drag optic types to control the section order used in optics.")
                     .font(.footnote)
                     .foregroundStyle(.secondary)
             }
@@ -38,10 +38,10 @@ struct AttachmentTypeOrderingView: View {
             AccessoryItemSortingSection(
                 sortOrderRaw: $itemSortOrder,
                 sortDirectionRaw: $itemSortDirectionRaw,
-                itemLabelPlural: "Attachments"
+                itemLabelPlural: "Optics"
             )
         }
-        .navigationTitle("Attachments Sorting")
+        .navigationTitle("Optics Sorting")
         .toolbar {
             ToolbarItem(placement: .topBarTrailing) {
                 EditButton()

--- a/ArmoryInventory/Settings/OpticTypeOrdering/OpticTypeOrderingViewModel.swift
+++ b/ArmoryInventory/Settings/OpticTypeOrdering/OpticTypeOrderingViewModel.swift
@@ -1,0 +1,53 @@
+//
+//  OpticTypeOrderingViewModel.swift
+//  Armory Inventory
+//
+//  Created by Codex on 4/6/26.
+//
+
+import Foundation
+
+final class OpticTypeOrderingViewModel {
+    func rankingSource() -> [String] {
+        OpticTypeSort.persistedOrder(including: OpticType.allCases.map(\.displayName))
+    }
+
+    func displayName(for normalizedName: String) -> String {
+        if let match = OpticType.allCases.first(where: {
+            $0.displayName.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() == normalizedName
+        }) {
+            return match.displayName
+        }
+
+        return normalizedName
+    }
+
+    func saveRanking(_ typeNames: [String]) {
+        OpticTypeSort.saveOrder(typeNames)
+    }
+
+    func refreshedRankingNames() -> [String] {
+        rankingSource()
+    }
+
+    func moveRanking(_ rankingNames: [String], from source: IndexSet, to destination: Int) -> [String] {
+        var updatedRankingNames = rankingNames
+        let movedItems = source.map { updatedRankingNames[$0] }
+        for offset in source.sorted(by: >) {
+            updatedRankingNames.remove(at: offset)
+        }
+
+        var insertionIndex = destination
+        for offset in source where offset < destination {
+            insertionIndex -= 1
+        }
+        updatedRankingNames.insert(contentsOf: movedItems, at: insertionIndex)
+        saveRanking(updatedRankingNames)
+        return updatedRankingNames
+    }
+
+    func resetOrder(rankingNames: inout [String]) {
+        OpticTypeSort.resetOrder()
+        rankingNames = rankingSource()
+    }
+}

--- a/ArmoryInventory/Settings/PartTypeOrdering/PartTypeOrderingView.swift
+++ b/ArmoryInventory/Settings/PartTypeOrdering/PartTypeOrderingView.swift
@@ -1,23 +1,23 @@
 //
-//  AttachmentTypeOrderingView.swift
+//  PartTypeOrderingView.swift
 //  Armory Inventory
 //
-//  Created by Codex on 4/2/26.
+//  Created by Codex on 4/6/26.
 //
 
 import SwiftUI
 
-struct AttachmentTypeOrderingView: View {
-    @AppStorage(AttachmentTypeSort.settingsVersionKey) private var sortVersion = 0
-    @AppStorage(InventorySettingsKeys.attachmentItemSortOrder) private var itemSortOrder = AccessoryItemSortOrder.manual.rawValue
-    @AppStorage(InventorySettingsKeys.attachmentItemSortDirection) private var itemSortDirectionRaw = ""
+struct PartTypeOrderingView: View {
+    @AppStorage(PartTypeSort.settingsVersionKey) private var sortVersion = 0
+    @AppStorage(InventorySettingsKeys.partItemSortOrder) private var itemSortOrder = AccessoryItemSortOrder.manual.rawValue
+    @AppStorage(InventorySettingsKeys.partItemSortDirection) private var itemSortDirectionRaw = ""
     @State private var rankingNames: [String] = []
-    let viewModel: AttachmentTypeOrderingViewModel
+    let viewModel: PartTypeOrderingViewModel
 
     var body: some View {
         List {
             Section {
-                Text("Hold and drag attachment types to control the section order used in attachments.")
+                Text("Hold and drag part types to control the section order used in parts.")
                     .font(.footnote)
                     .foregroundStyle(.secondary)
             }
@@ -38,10 +38,10 @@ struct AttachmentTypeOrderingView: View {
             AccessoryItemSortingSection(
                 sortOrderRaw: $itemSortOrder,
                 sortDirectionRaw: $itemSortDirectionRaw,
-                itemLabelPlural: "Attachments"
+                itemLabelPlural: "Parts"
             )
         }
-        .navigationTitle("Attachments Sorting")
+        .navigationTitle("Parts Sorting")
         .toolbar {
             ToolbarItem(placement: .topBarTrailing) {
                 EditButton()

--- a/ArmoryInventory/Settings/PartTypeOrdering/PartTypeOrderingViewModel.swift
+++ b/ArmoryInventory/Settings/PartTypeOrdering/PartTypeOrderingViewModel.swift
@@ -1,0 +1,53 @@
+//
+//  PartTypeOrderingViewModel.swift
+//  Armory Inventory
+//
+//  Created by Codex on 4/6/26.
+//
+
+import Foundation
+
+final class PartTypeOrderingViewModel {
+    func rankingSource() -> [String] {
+        PartTypeSort.persistedOrder(including: PartType.allCases.map(\.displayName))
+    }
+
+    func displayName(for normalizedName: String) -> String {
+        if let match = PartType.allCases.first(where: {
+            $0.displayName.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() == normalizedName
+        }) {
+            return match.displayName
+        }
+
+        return normalizedName
+    }
+
+    func saveRanking(_ typeNames: [String]) {
+        PartTypeSort.saveOrder(typeNames)
+    }
+
+    func refreshedRankingNames() -> [String] {
+        rankingSource()
+    }
+
+    func moveRanking(_ rankingNames: [String], from source: IndexSet, to destination: Int) -> [String] {
+        var updatedRankingNames = rankingNames
+        let movedItems = source.map { updatedRankingNames[$0] }
+        for offset in source.sorted(by: >) {
+            updatedRankingNames.remove(at: offset)
+        }
+
+        var insertionIndex = destination
+        for offset in source where offset < destination {
+            insertionIndex -= 1
+        }
+        updatedRankingNames.insert(contentsOf: movedItems, at: insertionIndex)
+        saveRanking(updatedRankingNames)
+        return updatedRankingNames
+    }
+
+    func resetOrder(rankingNames: inout [String]) {
+        PartTypeSort.resetOrder()
+        rankingNames = rankingSource()
+    }
+}

--- a/ArmoryInventory/Settings/SettingsView.swift
+++ b/ArmoryInventory/Settings/SettingsView.swift
@@ -56,9 +56,21 @@ struct SettingsView: View {
                 
                 Section("Accessories"){
                     NavigationLink {
+                        OpticTypeOrderingView(viewModel: OpticTypeOrderingViewModel())
+                    } label: {
+                        Label("Optics Sorting", systemImage: "arrow.up.arrow.down")
+                    }
+
+                    NavigationLink {
                         AttachmentTypeOrderingView(viewModel: AttachmentTypeOrderingViewModel())
                     } label: {
                         Label("Attachments Sorting", systemImage: "arrow.up.arrow.down")
+                    }
+                    
+                    NavigationLink {
+                        PartTypeOrderingView(viewModel: PartTypeOrderingViewModel())
+                    } label: {
+                        Label("Parts Sorting", systemImage: "arrow.up.arrow.down")
                     }
                 }
             }

--- a/ArmoryInventoryTests/AccessoriesTests/OpticsModelsTests.swift
+++ b/ArmoryInventoryTests/AccessoriesTests/OpticsModelsTests.swift
@@ -73,6 +73,7 @@ final class OpticsModelsTests: XCTestCase {
         XCTAssertEqual(optic.opticColor, .other)
         XCTAssertEqual(optic.colorDisplayName, "OD Green")
         XCTAssertEqual(optic.displayName, "Vortex Razor HD")
+        XCTAssertEqual(optic.typeDisplayName, "LPVO")
         XCTAssertEqual(optic.magnificationText, "1-6x")
         XCTAssertEqual(optic.tubeSizeText, "30 mm")
         XCTAssertTrue(optic.purchasePriceText.contains("1,299"))
@@ -103,6 +104,7 @@ final class OpticsModelsTests: XCTestCase {
         XCTAssertEqual(optic.footprintDisplayName, "Other")
         XCTAssertEqual(optic.opticColor, .other)
         XCTAssertEqual(optic.colorDisplayName, "Other")
+        XCTAssertEqual(optic.typeDisplayName, "Other")
         XCTAssertEqual(optic.magnificationText, "1x")
         XCTAssertNil(optic.tubeSizeText)
 

--- a/ArmoryInventoryTests/ServicesTests/AccessoryItemSortTests.swift
+++ b/ArmoryInventoryTests/ServicesTests/AccessoryItemSortTests.swift
@@ -1,0 +1,86 @@
+//
+//  AccessoryItemSortTests.swift
+//  Armory InventoryTests
+//
+//  Created by Codex on 4/6/26.
+//
+
+import XCTest
+@testable import ArmoryInventory
+
+final class AccessoryItemSortTests: XCTestCase {
+    func testPreferredDirectionMatchesSortOrder() {
+        XCTAssertEqual(AccessoryItemSort.preferredDirection(for: .manual), .ascending)
+        XCTAssertEqual(AccessoryItemSort.preferredDirection(for: .purchaseDate), .descending)
+        XCTAssertEqual(AccessoryItemSort.preferredDirection(for: .value), .descending)
+        XCTAssertEqual(AccessoryItemSort.preferredDirection(for: .brand), .ascending)
+        XCTAssertEqual(AccessoryItemSort.preferredDirection(for: .model), .ascending)
+    }
+
+    func testManualSortPreservesInputOrder() {
+        let items = [
+            makeOptic(brand: "Vortex", model: "Razor", purchaseDate: 300, price: 100_000),
+            makeOptic(brand: "Aimpoint", model: "T-2", purchaseDate: 100, price: 80_000),
+            makeOptic(brand: "EOTech", model: "EXPS3", purchaseDate: 200, price: 70_000)
+        ]
+
+        let sorted = AccessoryItemSort.sorted(items, by: .manual, direction: .ascending)
+
+        XCTAssertEqual(sorted.map(\.displayName), ["Vortex Razor", "Aimpoint T-2", "EOTech EXPS3"])
+    }
+
+    func testPurchaseDateSortUsesDirectionAndNameFallback() {
+        let items = [
+            makeOptic(brand: "Vortex", model: "Razor", purchaseDate: 200, price: 100_000),
+            makeOptic(brand: "Aimpoint", model: "T-2", purchaseDate: 300, price: 80_000),
+            makeOptic(brand: "EOTech", model: "EXPS3", purchaseDate: 300, price: 70_000)
+        ]
+
+        let descending = AccessoryItemSort.sorted(items, by: .purchaseDate, direction: .descending)
+        let ascending = AccessoryItemSort.sorted(items, by: .purchaseDate, direction: .ascending)
+
+        XCTAssertEqual(descending.map(\.displayName), ["EOTech EXPS3", "Aimpoint T-2", "Vortex Razor"])
+        XCTAssertEqual(ascending.map(\.displayName), ["Vortex Razor", "Aimpoint T-2", "EOTech EXPS3"])
+    }
+
+    func testValueSortUsesDirectionAndNameFallback() {
+        let items = [
+            makeOptic(brand: "Vortex", model: "Razor", purchaseDate: 300, price: 100_000),
+            makeOptic(brand: "Aimpoint", model: "T-2", purchaseDate: 100, price: 80_000),
+            makeOptic(brand: "EOTech", model: "EXPS3", purchaseDate: 200, price: 80_000)
+        ]
+
+        let descending = AccessoryItemSort.sorted(items, by: .value, direction: .descending)
+        let ascending = AccessoryItemSort.sorted(items, by: .value, direction: .ascending)
+
+        XCTAssertEqual(descending.map(\.displayName), ["Vortex Razor", "EOTech EXPS3", "Aimpoint T-2"])
+        XCTAssertEqual(ascending.map(\.displayName), ["Aimpoint T-2", "EOTech EXPS3", "Vortex Razor"])
+    }
+
+    func testBrandAndModelSortUseConfiguredDirection() {
+        let items = [
+            makeOptic(brand: "Vortex", model: "Razor", purchaseDate: 300, price: 100_000),
+            makeOptic(brand: "Aimpoint", model: "CompM5", purchaseDate: 100, price: 90_000),
+            makeOptic(brand: "Aimpoint", model: "T-2", purchaseDate: 200, price: 80_000)
+        ]
+
+        let brandSorted = AccessoryItemSort.sorted(items, by: .brand, direction: .ascending)
+        let modelSorted = AccessoryItemSort.sorted(items, by: .model, direction: .descending)
+
+        XCTAssertEqual(brandSorted.map(\.displayName), ["Aimpoint CompM5", "Aimpoint T-2", "Vortex Razor"])
+        XCTAssertEqual(modelSorted.map(\.displayName), ["Aimpoint T-2", "Vortex Razor", "Aimpoint CompM5"])
+    }
+
+    private func makeOptic(brand: String, model: String, purchaseDate: TimeInterval, price: Int) -> Optic {
+        Optic(
+            brand: brand,
+            modelName: model,
+            type: .redDot,
+            minMagnification: 1,
+            maxMagnification: 1,
+            footprint: .picatinny,
+            purchaseDate: Date(timeIntervalSince1970: purchaseDate),
+            purchasePriceCents: price
+        )
+    }
+}

--- a/ArmoryInventoryTests/ServicesTests/OpticTypeSortTests.swift
+++ b/ArmoryInventoryTests/ServicesTests/OpticTypeSortTests.swift
@@ -1,0 +1,75 @@
+//
+//  OpticTypeSortTests.swift
+//  Armory InventoryTests
+//
+//  Created by Codex on 4/6/26.
+//
+
+import XCTest
+@testable import ArmoryInventory
+
+final class OpticTypeSortTests: XCTestCase {
+    override func setUp() {
+        super.setUp()
+        OpticTypeSort.resetOrder()
+    }
+
+    override func tearDown() {
+        OpticTypeSort.resetOrder()
+        super.tearDown()
+    }
+
+    func testAscendingOrderPrefersConfiguredRankingOverUnknownNames() {
+        OpticTypeSort.saveOrder(["LPVO", "Red Dot", "Scope"])
+
+        XCTAssertTrue(OpticTypeSort.areInAscendingOrder("LPVO", "Red Dot"))
+        XCTAssertTrue(OpticTypeSort.areInAscendingOrder("Red Dot", "Custom Thermal"))
+        XCTAssertFalse(OpticTypeSort.areInAscendingOrder("Custom Thermal", "Scope"))
+    }
+
+    func testDisplayOrderSortsBySavedRankingThenLocalizedFallback() {
+        OpticTypeSort.saveOrder(["Holographic", "Scope"])
+
+        XCTAssertEqual(
+            OpticTypeSort.displayOrder(for: ["Red Dot", "Custom Z", "Scope", "Holographic", "Custom A"]),
+            ["Holographic", "Scope", "Red Dot", "Custom A", "Custom Z"]
+        )
+    }
+
+    func testPersistedOrderIncludesSavedKnownAndCustomNames() {
+        OpticTypeSort.saveOrder([" scope ", "custom thermal"])
+
+        let persisted = OpticTypeSort.persistedOrder(including: ["LPVO", "Custom Magnified", "Red Dot"])
+
+        XCTAssertEqual(
+            persisted,
+            [
+                "scope",
+                "custom thermal",
+                "red dot",
+                "holographic",
+                "prism",
+                "lpvo",
+                "magnifier",
+                "other",
+                "custom magnified"
+            ]
+        )
+    }
+
+    func testResetOrderClearsSavedOrderAndBumpsVersion() {
+        OpticTypeSort.saveOrder(["Scope"])
+        let versionAfterSave = UserDefaults.standard.integer(forKey: OpticTypeSort.settingsVersionKey)
+
+        OpticTypeSort.resetOrder()
+
+        XCTAssertEqual(
+            OpticTypeSort.persistedOrder(),
+            OpticType.allCases.map(\.displayName).map { $0.lowercased() }
+        )
+        XCTAssertEqual(
+            UserDefaults.standard.integer(forKey: OpticTypeSort.settingsVersionKey),
+            versionAfterSave + 1
+        )
+    }
+}

--- a/ArmoryInventoryTests/ServicesTests/PartTypeSortTests.swift
+++ b/ArmoryInventoryTests/ServicesTests/PartTypeSortTests.swift
@@ -1,0 +1,78 @@
+//
+//  PartTypeSortTests.swift
+//  Armory InventoryTests
+//
+//  Created by Codex on 4/6/26.
+//
+
+import XCTest
+@testable import ArmoryInventory
+
+final class PartTypeSortTests: XCTestCase {
+    override func setUp() {
+        super.setUp()
+        PartTypeSort.resetOrder()
+    }
+
+    override func tearDown() {
+        PartTypeSort.resetOrder()
+        super.tearDown()
+    }
+
+    func testAscendingOrderPrefersConfiguredRankingOverUnknownNames() {
+        PartTypeSort.saveOrder(["Trigger", "Barrel", "Slide"])
+
+        XCTAssertTrue(PartTypeSort.areInAscendingOrder("Trigger", "Barrel"))
+        XCTAssertTrue(PartTypeSort.areInAscendingOrder("Barrel", "Custom Tuning Kit"))
+        XCTAssertFalse(PartTypeSort.areInAscendingOrder("Custom Tuning Kit", "Slide"))
+    }
+
+    func testDisplayOrderSortsBySavedRankingThenLocalizedFallback() {
+        PartTypeSort.saveOrder(["Charging Handle", "Lower Receiver"])
+
+        XCTAssertEqual(
+            PartTypeSort.displayOrder(for: ["Trigger", "Custom Z", "Lower Receiver", "Charging Handle", "Custom A"]),
+            ["Charging Handle", "Lower Receiver", "Trigger", "Custom A", "Custom Z"]
+        )
+    }
+
+    func testPersistedOrderIncludesSavedKnownAndCustomNames() {
+        PartTypeSort.saveOrder([" barrel ", "custom internals"])
+
+        let persisted = PartTypeSort.persistedOrder(including: ["Trigger", "Custom Buffer", "Slide"])
+
+        XCTAssertEqual(
+            persisted,
+            [
+                "barrel",
+                "custom internals",
+                "trigger",
+                "slide",
+                "bolt carrier group",
+                "charging handle",
+                "upper receiver",
+                "lower receiver",
+                "recoil system",
+                "internals",
+                "other",
+                "custom buffer"
+            ]
+        )
+    }
+
+    func testResetOrderClearsSavedOrderAndBumpsVersion() {
+        PartTypeSort.saveOrder(["Trigger"])
+        let versionAfterSave = UserDefaults.standard.integer(forKey: PartTypeSort.settingsVersionKey)
+
+        PartTypeSort.resetOrder()
+
+        XCTAssertEqual(
+            PartTypeSort.persistedOrder(),
+            PartType.allCases.map(\.displayName).map { $0.lowercased() }
+        )
+        XCTAssertEqual(
+            UserDefaults.standard.integer(forKey: PartTypeSort.settingsVersionKey),
+            versionAfterSave + 1
+        )
+    }
+}

--- a/ArmoryInventoryTests/ServicesTests/UserDataTransferServiceTests.swift
+++ b/ArmoryInventoryTests/ServicesTests/UserDataTransferServiceTests.swift
@@ -156,6 +156,14 @@ final class UserDataTransferServiceTests: XCTestCase {
         XCTAssertEqual(destinationDefaults.stringArray(forKey: InventorySettingsKeys.caliberSortOrder), ["9mm", ".45 acp"])
         XCTAssertEqual(destinationDefaults.bool(forKey: InventorySettingsKeys.showValueInCard), true)
         XCTAssertEqual(destinationDefaults.integer(forKey: InventorySettingsKeys.attachmentTypeSortOrderVersion), 2)
+        XCTAssertEqual(destinationDefaults.string(forKey: InventorySettingsKeys.attachmentItemSortOrder), AccessoryItemSortOrder.value.rawValue)
+        XCTAssertEqual(destinationDefaults.string(forKey: InventorySettingsKeys.attachmentItemSortDirection), AccessoryItemSortDirection.descending.rawValue)
+        XCTAssertEqual(destinationDefaults.stringArray(forKey: InventorySettingsKeys.opticTypeSortOrder), ["lpvo", "red dot"])
+        XCTAssertEqual(destinationDefaults.string(forKey: InventorySettingsKeys.opticItemSortOrder), AccessoryItemSortOrder.purchaseDate.rawValue)
+        XCTAssertEqual(destinationDefaults.string(forKey: InventorySettingsKeys.opticItemSortDirection), AccessoryItemSortDirection.descending.rawValue)
+        XCTAssertEqual(destinationDefaults.stringArray(forKey: InventorySettingsKeys.partTypeSortOrder), ["trigger", "barrel"])
+        XCTAssertEqual(destinationDefaults.string(forKey: InventorySettingsKeys.partItemSortOrder), AccessoryItemSortOrder.brand.rawValue)
+        XCTAssertEqual(destinationDefaults.string(forKey: InventorySettingsKeys.partItemSortDirection), AccessoryItemSortDirection.ascending.rawValue)
         XCTAssertNotNil(destinationDefaults.object(forKey: InventorySettingsKeys.lastModelSaveDate) as? Date)
     }
 
@@ -235,6 +243,11 @@ final class UserDataTransferServiceTests: XCTestCase {
         XCTAssertNil(defaults.object(forKey: InventorySettingsKeys.firearmsSalesTaxRate))
         XCTAssertNil(defaults.object(forKey: InventorySettingsKeys.showValueInCard))
         XCTAssertNil(defaults.object(forKey: InventorySettingsKeys.caliberSortOrder))
+        XCTAssertNil(defaults.object(forKey: InventorySettingsKeys.attachmentItemSortOrder))
+        XCTAssertNil(defaults.object(forKey: InventorySettingsKeys.opticTypeSortOrder))
+        XCTAssertNil(defaults.object(forKey: InventorySettingsKeys.opticItemSortOrder))
+        XCTAssertNil(defaults.object(forKey: InventorySettingsKeys.partTypeSortOrder))
+        XCTAssertNil(defaults.object(forKey: InventorySettingsKeys.partItemSortOrder))
         XCTAssertNil(defaults.object(forKey: InventorySettingsKeys.lastModelSaveDate))
     }
 
@@ -252,6 +265,14 @@ final class UserDataTransferServiceTests: XCTestCase {
         defaults.set(true, forKey: InventorySettingsKeys.showValueInCard)
         defaults.set(["9mm", ".45 acp"], forKey: InventorySettingsKeys.caliberSortOrder)
         defaults.set(2, forKey: InventorySettingsKeys.attachmentTypeSortOrderVersion)
+        defaults.set(AccessoryItemSortOrder.value.rawValue, forKey: InventorySettingsKeys.attachmentItemSortOrder)
+        defaults.set(AccessoryItemSortDirection.descending.rawValue, forKey: InventorySettingsKeys.attachmentItemSortDirection)
+        defaults.set(["lpvo", "red dot"], forKey: InventorySettingsKeys.opticTypeSortOrder)
+        defaults.set(AccessoryItemSortOrder.purchaseDate.rawValue, forKey: InventorySettingsKeys.opticItemSortOrder)
+        defaults.set(AccessoryItemSortDirection.descending.rawValue, forKey: InventorySettingsKeys.opticItemSortDirection)
+        defaults.set(["trigger", "barrel"], forKey: InventorySettingsKeys.partTypeSortOrder)
+        defaults.set(AccessoryItemSortOrder.brand.rawValue, forKey: InventorySettingsKeys.partItemSortOrder)
+        defaults.set(AccessoryItemSortDirection.ascending.rawValue, forKey: InventorySettingsKeys.partItemSortDirection)
         defaults.set(Date(timeIntervalSince1970: 10_000), forKey: InventorySettingsKeys.lastModelSaveDate)
     }
 }

--- a/ArmoryInventoryTests/SettingsTests/OpticTypeOrderingViewModelTests.swift
+++ b/ArmoryInventoryTests/SettingsTests/OpticTypeOrderingViewModelTests.swift
@@ -1,0 +1,70 @@
+//
+//  OpticTypeOrderingViewModelTests.swift
+//  Armory InventoryTests
+//
+//  Created by Codex on 4/6/26.
+//
+
+import XCTest
+@testable import ArmoryInventory
+
+final class OpticTypeOrderingViewModelTests: XCTestCase {
+    override func setUp() {
+        super.setUp()
+        OpticTypeSort.resetOrder()
+    }
+
+    override func tearDown() {
+        OpticTypeSort.resetOrder()
+        super.tearDown()
+    }
+
+    func testRankingSourceReturnsDefaultOpticOrder() {
+        let viewModel = OpticTypeOrderingViewModel()
+
+        XCTAssertEqual(
+            viewModel.rankingSource(),
+            OpticType.allCases.map(\.displayName).map { $0.lowercased() }
+        )
+    }
+
+    func testDisplayNameMatchesKnownTypesAndFallsBackForUnknownNames() {
+        let viewModel = OpticTypeOrderingViewModel()
+
+        XCTAssertEqual(viewModel.displayName(for: "red dot"), "Red Dot")
+        XCTAssertEqual(viewModel.displayName(for: "lpvo"), "LPVO")
+        XCTAssertEqual(viewModel.displayName(for: "custom thermal"), "custom thermal")
+    }
+
+    func testSaveRankingAndRefreshedRankingNamesPersistCustomOrder() {
+        let viewModel = OpticTypeOrderingViewModel()
+        let savedRanking = ["other", "scope", "red dot"]
+
+        viewModel.saveRanking(savedRanking)
+
+        XCTAssertEqual(viewModel.refreshedRankingNames().prefix(3).map { $0 }, savedRanking)
+    }
+
+    func testMoveRankingReordersValuesAndPersistsResult() {
+        let viewModel = OpticTypeOrderingViewModel()
+        let rankingNames = ["scope", "red dot", "holographic", "lpvo"]
+
+        let updated = viewModel.moveRanking(rankingNames, from: IndexSet(integer: 1), to: 4)
+
+        XCTAssertEqual(updated, ["scope", "holographic", "lpvo", "red dot"])
+        XCTAssertEqual(Array(viewModel.refreshedRankingNames().prefix(4)), updated)
+    }
+
+    func testResetOrderRestoresDefaultOrdering() {
+        let viewModel = OpticTypeOrderingViewModel()
+        var rankingNames = ["other", "scope", "red dot"]
+        viewModel.saveRanking(rankingNames)
+
+        viewModel.resetOrder(rankingNames: &rankingNames)
+
+        XCTAssertEqual(
+            rankingNames,
+            OpticType.allCases.map(\.displayName).map { $0.lowercased() }
+        )
+    }
+}

--- a/ArmoryInventoryTests/SettingsTests/PartTypeOrderingViewModelTests.swift
+++ b/ArmoryInventoryTests/SettingsTests/PartTypeOrderingViewModelTests.swift
@@ -1,0 +1,70 @@
+//
+//  PartTypeOrderingViewModelTests.swift
+//  Armory InventoryTests
+//
+//  Created by Codex on 4/6/26.
+//
+
+import XCTest
+@testable import ArmoryInventory
+
+final class PartTypeOrderingViewModelTests: XCTestCase {
+    override func setUp() {
+        super.setUp()
+        PartTypeSort.resetOrder()
+    }
+
+    override func tearDown() {
+        PartTypeSort.resetOrder()
+        super.tearDown()
+    }
+
+    func testRankingSourceReturnsDefaultPartOrder() {
+        let viewModel = PartTypeOrderingViewModel()
+
+        XCTAssertEqual(
+            viewModel.rankingSource(),
+            PartType.allCases.map(\.displayName).map { $0.lowercased() }
+        )
+    }
+
+    func testDisplayNameMatchesKnownTypesAndFallsBackForUnknownNames() {
+        let viewModel = PartTypeOrderingViewModel()
+
+        XCTAssertEqual(viewModel.displayName(for: "trigger"), "Trigger")
+        XCTAssertEqual(viewModel.displayName(for: "bolt carrier group"), "Bolt Carrier Group")
+        XCTAssertEqual(viewModel.displayName(for: "custom internals"), "custom internals")
+    }
+
+    func testSaveRankingAndRefreshedRankingNamesPersistCustomOrder() {
+        let viewModel = PartTypeOrderingViewModel()
+        let savedRanking = ["other", "trigger", "barrel"]
+
+        viewModel.saveRanking(savedRanking)
+
+        XCTAssertEqual(viewModel.refreshedRankingNames().prefix(3).map { $0 }, savedRanking)
+    }
+
+    func testMoveRankingReordersValuesAndPersistsResult() {
+        let viewModel = PartTypeOrderingViewModel()
+        let rankingNames = ["trigger", "barrel", "slide", "charging handle"]
+
+        let updated = viewModel.moveRanking(rankingNames, from: IndexSet(integer: 1), to: 4)
+
+        XCTAssertEqual(updated, ["trigger", "slide", "charging handle", "barrel"])
+        XCTAssertEqual(Array(viewModel.refreshedRankingNames().prefix(4)), updated)
+    }
+
+    func testResetOrderRestoresDefaultOrdering() {
+        let viewModel = PartTypeOrderingViewModel()
+        var rankingNames = ["other", "trigger", "barrel"]
+        viewModel.saveRanking(rankingNames)
+
+        viewModel.resetOrder(rankingNames: &rankingNames)
+
+        XCTAssertEqual(
+            rankingNames,
+            PartType.allCases.map(\.displayName).map { $0.lowercased() }
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- group optics by configurable type order and add persisted optics sorting settings
- add configurable part type ordering and shared in-section sorting controls for optics, attachments, and parts
- cover new sorting persistence and ordering behavior with targeted tests

## Testing
- DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test -scheme 'Armory Inventory' -destination 'platform=iOS Simulator,name=iPhone 17,OS=26.4' -only-testing:ArmoryInventoryTests/AccessoryItemSortTests -only-testing:ArmoryInventoryTests/OpticTypeSortTests -only-testing:ArmoryInventoryTests/PartTypeSortTests -only-testing:ArmoryInventoryTests/OpticTypeOrderingViewModelTests -only-testing:ArmoryInventoryTests/PartTypeOrderingViewModelTests -only-testing:ArmoryInventoryTests/AttachmentTypeOrderingViewModelTests -only-testing:ArmoryInventoryTests/UserDataTransferServiceTests