### PR TITLE
Add privacy policy

### DIFF
--- a/ArmoryInventory/Settings/About/AboutView.swift
+++ b/ArmoryInventory/Settings/About/AboutView.swift
@@ -39,6 +39,14 @@ struct AboutView: View {
                     LabeledContent("Build", value: appVersionText)
                 }
 
+                Section("Legal") {
+                    Button {
+                        openURL(privacyPolicyURL)
+                    } label: {
+                        Label("Privacy Policy", systemImage: "hand.raised")
+                    }
+                }
+
                 Section("Feedback") {
                     Button {
                         sendFeedback()
@@ -92,6 +100,10 @@ struct AboutView: View {
         case (.none, .none):
             return "Unavailable"
         }
+    }
+
+    private var privacyPolicyURL: URL {
+        URL(string: "https://github.com/LIYINXUE-PERSONAL/Armory-Inventory/blob/main/PRIVACY_POLICY.md")!
     }
 
     private func sendFeedback() {

--- a/PRIVACY_POLICY.md
+++ b/PRIVACY_POLICY.md
@@ -1,0 +1,57 @@
+# Privacy Policy for Armory Inventory
+
+Last updated: April 10, 2026
+
+Armory Inventory is designed to let you track firearms, ammunition, optics, magazines, attachments, parts, and related collection information on your own device.
+
+## Information the App Stores
+
+The information you enter into the app may include:
+
+- firearm details
+- ammunition and caliber details
+- accessory and part details
+- notes, purchase information, and values
+- app preferences and sort settings
+
+This information is stored locally on your device using Apple's SwiftData framework.
+
+## Information the Developer Collects
+
+The developer does not collect your inventory data through the app.
+
+Armory Inventory does not require account creation and does not provide a built-in cloud service for syncing your inventory to the developer's servers.
+
+## Backups and Data Transfers
+
+The app includes optional export and import features that let you create and restore backup files in JSON format.
+
+These backup files are created only when you choose to export your data. You are responsible for where you save, store, share, or back up those files.
+
+## Feedback Emails
+
+If you choose to use the in-app feedback option, the app opens your device's email client with a draft email addressed to the developer.
+
+When you send that email, your email provider may process your message, attachments, and related metadata according to its own privacy practices. The developer will receive the information you choose to include in the email.
+
+## Tracking and Analytics
+
+Armory Inventory does not use third-party analytics, advertising SDKs, or in-app tracking mechanisms based on the current version of the app.
+
+## Data Security
+
+Because your data is stored locally, the security of that data depends in part on the security protections enabled on your device and any locations where you store exported backups.
+
+## Children's Privacy
+
+Armory Inventory is not directed to children under 13.
+
+## Changes to This Privacy Policy
+
+This privacy policy may be updated from time to time. The latest version will be made available at the policy URL associated with the app.
+
+## Contact
+
+If you have questions about this privacy policy, you can contact:
+
+`armory.inventory@liyinxue.com`


### PR DESCRIPTION
## Summary
- add a repository-hosted privacy policy for Armory Inventory
- add a Privacy Policy entry in the About screen that opens the hosted document

## Testing
- DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild build -scheme 'Armory Inventory' -destination 'platform=iOS Simulator,name=iPhone 17,OS=26.4'