### PR TITLE
Add caliber creation from firearm form and prevent deleting linked calibers

### DIFF
--- a/ArmoryInventory/Ammo/CaliberList/CaliberDetailView.swift
+++ b/ArmoryInventory/Ammo/CaliberList/CaliberDetailView.swift
@@ -13,6 +13,7 @@ struct CaliberDetailView: View {
     @Environment(\.modelContext) private var context
     @State private var showingAddAmmoType = false
     @State private var selectedAmmoForAdjustment: AmmoType?
+    @State private var showingCannotDeleteCaliberAlert = false
     let caliber: Caliber
     let viewModel: CaliberListViewModel
 
@@ -71,8 +72,7 @@ struct CaliberDetailView: View {
 
                 Menu {
                     Button(role: .destructive) {
-                        viewModel.deleteCaliber(caliber, in: context)
-                        dismiss()
+                        deleteCaliber()
                     } label: {
                         Label("Delete Caliber", systemImage: "trash")
                     }
@@ -80,6 +80,11 @@ struct CaliberDetailView: View {
                     Image(systemName: "ellipsis")
                 }
             }
+        }
+        .alert("Cannot Delete Caliber", isPresented: $showingCannotDeleteCaliberAlert) {
+            Button("OK", role: .cancel) { }
+        } message: {
+            Text("A firearm is currently using this caliber, so it cannot be deleted.")
         }
         .sheet(isPresented: $showingAddAmmoType) {
             AddAmmoTypeView(caliber: caliber, viewModel: AddAmmoTypeViewModel())
@@ -109,5 +114,15 @@ struct CaliberDetailView: View {
         stride(from: 0, to: sortedAmmo.count, by: 2).map { index in
             Array(sortedAmmo[index..<min(index + 2, sortedAmmo.count)])
         }
+    }
+
+    private func deleteCaliber() {
+        if viewModel.hasLinkedFirearms(caliber) {
+            showingCannotDeleteCaliberAlert = true
+            return
+        }
+
+        viewModel.deleteCaliber(caliber, in: context)
+        dismiss()
     }
 }

--- a/ArmoryInventory/Ammo/CaliberList/CaliberListViewModel.swift
+++ b/ArmoryInventory/Ammo/CaliberList/CaliberListViewModel.swift
@@ -172,6 +172,10 @@ final class CaliberListViewModel {
         selectedID == caliber.persistentModelID
     }
 
+    func hasLinkedFirearms(_ caliber: Caliber) -> Bool {
+        !caliber.firearms.isEmpty
+    }
+
     func deleteCaliber(_ caliber: Caliber, in context: ModelContext) {
         context.delete(caliber)
         saveContext(context)

--- a/ArmoryInventory/Firearms/AddFirearmView.swift
+++ b/ArmoryInventory/Firearms/AddFirearmView.swift
@@ -39,6 +39,7 @@ struct AddFirearmView: View {
     @State private var showingMagazinesPicker = false
     @State private var showingAttachmentsPicker = false
     @State private var showingPartsPicker = false
+    @State private var showingAddCaliber = false
     @State private var isEditing = false
     @State private var lookupData = AddFirearmLookupData()
     @State private var snapshotErrorMessage: String?
@@ -124,6 +125,14 @@ struct AddFirearmView: View {
                         Text("None").tag(nil as Caliber?)
                         ForEach(lookupData.calibers) { caliber in
                             Text(caliber.name).tag(Optional(caliber))
+                        }
+                    }
+
+                    if isEditing {
+                        Button {
+                            showingAddCaliber = true
+                        } label: {
+                            Label("Add Caliber", systemImage: "plus.circle")
                         }
                     }
 
@@ -378,6 +387,10 @@ struct AddFirearmView: View {
                     Button(primaryButtonTitle) { handlePrimaryAction() }
                         .disabled(isEditing && !canAdd)
                 }
+            }
+            .sheet(isPresented: $showingAddCaliber, onDismiss: reloadLookupData) {
+                AddCaliberView(viewModel: AddCaliberViewModel())
+                    .presentationDetents([.medium])
             }
             .sheet(isPresented: $showingOpticsPicker) {
                 NavigationStack {

--- a/ArmoryInventory/Firearms/AddFirearmView.swift
+++ b/ArmoryInventory/Firearms/AddFirearmView.swift
@@ -121,19 +121,48 @@ struct AddFirearmView: View {
                         }
                     }
 
-                    Picker("Caliber", selection: $selectedCaliber) {
-                        Text("None").tag(nil as Caliber?)
-                        ForEach(lookupData.calibers) { caliber in
-                            Text(caliber.name).tag(Optional(caliber))
-                        }
-                    }
+                    LabeledContent("Caliber") {
+                        Menu {
+                            Button {
+                                selectedCaliber = nil
+                            } label: {
+                                if selectedCaliber == nil {
+                                    Label("None", systemImage: "checkmark")
+                                } else {
+                                    Text("None")
+                                }
+                            }
 
-                    if isEditing {
-                        Button {
-                            showingAddCaliber = true
+                            ForEach(lookupData.calibers) { caliber in
+                                Button {
+                                    selectedCaliber = caliber
+                                } label: {
+                                    if selectedCaliber?.persistentModelID == caliber.persistentModelID {
+                                        Label(caliber.name, systemImage: "checkmark")
+                                    } else {
+                                        Text(caliber.name)
+                                    }
+                                }
+                            }
+
+                            if isEditing {
+                                Divider()
+                                Button {
+                                    showingAddCaliber = true
+                                } label: {
+                                    Label("Add Caliber", systemImage: "plus.circle")
+                                }
+                            }
                         } label: {
-                            Label("Add Caliber", systemImage: "plus.circle")
+                            HStack(spacing: 6) {
+                                Text(selectedCaliber?.name ?? "None")
+                                    .foregroundStyle(selectedCaliber == nil ? .secondary : .primary)
+                                Image(systemName: "chevron.down")
+                                    .font(.caption.weight(.semibold))
+                                    .foregroundStyle(.secondary)
+                            }
                         }
+                        .buttonStyle(.plain)
                     }
 
                     Picker("Action", selection: $selectedAction) {

--- a/ArmoryInventoryTests/AmmoTests/CaliberListViewModelTests.swift
+++ b/ArmoryInventoryTests/AmmoTests/CaliberListViewModelTests.swift
@@ -167,6 +167,18 @@ final class CaliberListViewModelTests: XCTestCase {
         viewModel.updateQuantity(for: ammo, to: -10, in: context)
         XCTAssertEqual(ammo.quantity, 0)
         XCTAssertTrue(viewModel.shouldClearSelectedCaliber(caliber.persistentModelID, deleting: caliber))
+        XCTAssertFalse(viewModel.hasLinkedFirearms(caliber))
+
+        let linkedFirearm = Firearm(
+            brand: "Glock",
+            modelName: "17",
+            purchasePriceCents: 50000,
+            type: .pistol,
+            action: .semiAuto,
+            caliber: caliber
+        )
+        context.insert(linkedFirearm)
+        XCTAssertTrue(viewModel.hasLinkedFirearms(caliber))
 
         viewModel.deleteAmmo(ammo, in: context)
         XCTAssertTrue(try context.fetch(FetchDescriptor<AmmoType>()).isEmpty)


### PR DESCRIPTION
## Summary
- add an `Add Caliber` action to the Add/Edit Firearm configuration section so users can create calibers without leaving the firearm flow
- present `AddCaliberView` from `AddFirearmView` and refresh lookup data when the sheet is dismissed so newly added calibers are immediately selectable
- guard caliber deletion in `CaliberDetailView` by checking whether any firearms are linked and show a native alert if deletion is blocked
- add `hasLinkedFirearms(_:)` to `CaliberListViewModel` and cover it in existing view model tests

## Notes
- Tests were not run in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfc9301e68832fa3fbd256b3cca553)