### PR TITLE
Split out-of-stock ammo into its own section

### DIFF
--- a/ArmoryInventory.xcodeproj/project.pbxproj
+++ b/ArmoryInventory.xcodeproj/project.pbxproj
@@ -372,7 +372,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 15.0;
-				MARKETING_VERSION = 1.2;
+				MARKETING_VERSION = 1.3;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.liyinxue.Armory-Inventory";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -426,7 +426,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 15.0;
-				MARKETING_VERSION = 1.2;
+				MARKETING_VERSION = 1.3;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.liyinxue.Armory-Inventory";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/ArmoryInventory/Ammo/AmmoCardView.swift
+++ b/ArmoryInventory/Ammo/AmmoCardView.swift
@@ -26,9 +26,11 @@ struct AmmoCardView: View {
 
             Spacer(minLength: 0)
 
-            Text(AmmoType.roundsText(for: ammo.quantity))
-                .font(.system(size: 28, weight: .bold, design: .rounded))
-                .foregroundStyle(.white)
+            if ammo.quantity > 0 {
+                Text(AmmoType.roundsText(for: ammo.quantity))
+                    .font(.system(size: 28, weight: .bold, design: .rounded))
+                    .foregroundStyle(.white)
+            }
 
             if showValueInCard, ammo.centsPerRound > 0, ammo.quantity > 0 {
                 Text(ammo.totalValueText)

--- a/ArmoryInventory/Ammo/CaliberList/CaliberDetailView.swift
+++ b/ArmoryInventory/Ammo/CaliberList/CaliberDetailView.swift
@@ -28,7 +28,7 @@ struct CaliberDetailView: View {
                         .foregroundStyle(.secondary)
                 }
 
-                if sortedAmmo.isEmpty {
+                if viewModel.sortedAmmo(for: caliber).isEmpty {
                     ContentUnavailableView(
                         "No Ammo Yet",
                         systemImage: "shippingbox",
@@ -37,23 +37,13 @@ struct CaliberDetailView: View {
                     .frame(maxWidth: .infinity)
                     .padding(.vertical, 32)
                 } else {
-                    Grid(horizontalSpacing: 12, verticalSpacing: 12) {
-                        ForEach(ammoRows, id: \.self) { row in
-                            GridRow {
-                                ForEach(row) { ammo in
-                                    AmmoCardView(
-                                        ammo: ammo,
-                                        backgroundStyle: AmmoCardView.backgroundStyle(for: ammo)
-                                    )
-                                    .onTapGesture {
-                                        selectedAmmoForAdjustment = ammo
-                                    }
-                                }
+                    VStack(alignment: .leading, spacing: 20) {
+                        if !viewModel.inStockSortedAmmo(for: caliber).isEmpty {
+                            ammoSection(title: "In Stock", ammo: viewModel.inStockSortedAmmo(for: caliber))
+                        }
 
-                                if row.count == 1 {
-                                    Color.clear
-                                }
-                            }
+                        if !viewModel.outOfStockSortedAmmo(for: caliber).isEmpty {
+                            ammoSection(title: "Out of Stock", ammo: viewModel.outOfStockSortedAmmo(for: caliber))
                         }
                     }
                 }
@@ -106,13 +96,31 @@ struct CaliberDetailView: View {
         }
     }
 
-    private var sortedAmmo: [AmmoType] {
-        viewModel.sortedAmmo(for: caliber)
-    }
+    @ViewBuilder
+    private func ammoSection(title: String, ammo: [AmmoType]) -> some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text(title)
+                .font(.headline)
 
-    private var ammoRows: [[AmmoType]] {
-        stride(from: 0, to: sortedAmmo.count, by: 2).map { index in
-            Array(sortedAmmo[index..<min(index + 2, sortedAmmo.count)])
+            Grid(horizontalSpacing: 12, verticalSpacing: 12) {
+                ForEach(viewModel.ammoRows(for: ammo), id: \.self) { row in
+                    GridRow {
+                        ForEach(row) { ammo in
+                            AmmoCardView(
+                                ammo: ammo,
+                                backgroundStyle: AmmoCardView.backgroundStyle(for: ammo)
+                            )
+                            .onTapGesture {
+                                selectedAmmoForAdjustment = ammo
+                            }
+                        }
+
+                        if row.count == 1 {
+                            Color.clear
+                        }
+                    }
+                }
+            }
         }
     }
 

--- a/ArmoryInventory/Ammo/CaliberList/CaliberListView.swift
+++ b/ArmoryInventory/Ammo/CaliberList/CaliberListView.swift
@@ -57,8 +57,10 @@ struct CaliberListView: View {
                                                 toggleCollapsedState(for: caliber)
                                             }
                                         } label: {
-                                            Image(systemName: isCollapsed(caliber) ? "chevron.down" : "chevron.up")
+                                            Image(systemName: "chevron.down")
                                                 .font(.headline)
+                                                .rotationEffect(.degrees(isCollapsed(caliber) ? 0 : 180))
+                                                .animation(.easeInOut(duration: 0.2), value: isCollapsed(caliber))
                                         }
                                         .buttonStyle(.borderless)
                                     }
@@ -73,9 +75,17 @@ struct CaliberListView: View {
                                                 )
                                                 .frame(maxWidth: .infinity)
                                                 .padding(.vertical, 12)
+                                            } else if viewModel.inStockSortedAmmo(for: caliber).isEmpty {
+                                                ContentUnavailableView(
+                                                    "No Ammo In Stock",
+                                                    systemImage: "exclamationmark.circle",
+                                                    description: Text("Open \(caliber.name) to view out-of-stock loads.")
+                                                )
+                                                .frame(maxWidth: .infinity)
+                                                .padding(.vertical, 12)
                                             } else {
                                                 Grid(horizontalSpacing: 12, verticalSpacing: 12) {
-                                                    ForEach(ammoRows(for: caliber), id: \.self) { row in
+                                                    ForEach(viewModel.ammoRows(for: caliber, includeOutOfStock: false), id: \.self) { row in
                                                         GridRow {
                                                             ForEach(row) { ammo in
                                                                 AmmoCardView(
@@ -95,7 +105,10 @@ struct CaliberListView: View {
                                                 }
                                             }
                                         }
-                                        .transition(.opacity)
+                                        .transition(.modifier(
+                                            active: TopAnchoredStretchModifier(progress: 0.01),
+                                            identity: TopAnchoredStretchModifier(progress: 1)
+                                        ))
                                     }
                                 }
                                 .padding(16)
@@ -164,17 +177,6 @@ struct CaliberListView: View {
         return viewModel.sortedCalibers(from: calibers)
     }
 
-    private func sortedAmmo(for caliber: Caliber) -> [AmmoType] {
-        viewModel.sortedAmmo(for: caliber)
-    }
-
-    private func ammoRows(for caliber: Caliber) -> [[AmmoType]] {
-        let ammo = sortedAmmo(for: caliber)
-        return stride(from: 0, to: ammo.count, by: 2).map { index in
-            Array(ammo[index..<min(index + 2, ammo.count)])
-        }
-    }
-
     private func deleteAmmo(_ ammo: AmmoType) {
         viewModel.deleteAmmo(ammo, in: context)
     }
@@ -224,6 +226,17 @@ struct CaliberListView: View {
             for: sortedCalibers,
             currencyCode: Locale.current.currency?.identifier ?? "USD"
         )
+    }
+}
+
+private struct TopAnchoredStretchModifier: ViewModifier {
+    let progress: CGFloat
+
+    func body(content: Content) -> some View {
+        content
+            .scaleEffect(x: 1, y: progress, anchor: .top)
+            .opacity(progress)
+            .clipped()
     }
 }
 

--- a/ArmoryInventory/Ammo/CaliberList/CaliberListViewModel.swift
+++ b/ArmoryInventory/Ammo/CaliberList/CaliberListViewModel.swift
@@ -86,7 +86,7 @@ final class CaliberListViewModel {
     }
 
     func outOfStockSortedAmmo(for caliber: Caliber) -> [AmmoType] {
-        sortedAmmo(for: caliber).filter { $0.quantity == 0 }
+        sortedAmmo(for: caliber).filter { $0.quantity <= 0 }
     }
 
     func ammoRows(for caliber: Caliber, includeOutOfStock: Bool) -> [[AmmoType]] {

--- a/ArmoryInventory/Ammo/CaliberList/CaliberListViewModel.swift
+++ b/ArmoryInventory/Ammo/CaliberList/CaliberListViewModel.swift
@@ -81,6 +81,25 @@ final class CaliberListViewModel {
         }
     }
 
+    func inStockSortedAmmo(for caliber: Caliber) -> [AmmoType] {
+        sortedAmmo(for: caliber).filter { $0.quantity > 0 }
+    }
+
+    func outOfStockSortedAmmo(for caliber: Caliber) -> [AmmoType] {
+        sortedAmmo(for: caliber).filter { $0.quantity == 0 }
+    }
+
+    func ammoRows(for caliber: Caliber, includeOutOfStock: Bool) -> [[AmmoType]] {
+        let ammo = includeOutOfStock ? sortedAmmo(for: caliber) : inStockSortedAmmo(for: caliber)
+        return ammoRows(for: ammo)
+    }
+
+    func ammoRows(for ammo: [AmmoType]) -> [[AmmoType]] {
+        return stride(from: 0, to: ammo.count, by: 2).map { index in
+            Array(ammo[index..<min(index + 2, ammo.count)])
+        }
+    }
+
     func totalValueText(for calibers: [Caliber], currencyCode: String) -> String {
         let totalCents = calibers
             .flatMap(\.ammoTypes)

--- a/ArmoryInventory/Firearms/FirearmsView.swift
+++ b/ArmoryInventory/Firearms/FirearmsView.swift
@@ -227,6 +227,10 @@ struct FirearmsView: View {
                         }
                     }
                 }
+                .transition(.modifier(
+                    active: TopAnchoredStretchModifier(progress: 0.01),
+                    identity: TopAnchoredStretchModifier(progress: 1)
+                ))
             }
         }
         .padding(16)
@@ -434,6 +438,17 @@ struct FirearmsView: View {
 
     private func compareNames(_ lhs: String, _ rhs: String) -> Bool {
         compare(lhs.localizedStandardCompare(rhs))
+    }
+}
+
+private struct TopAnchoredStretchModifier: ViewModifier {
+    let progress: CGFloat
+
+    func body(content: Content) -> some View {
+        content
+            .scaleEffect(x: 1, y: progress, anchor: .top)
+            .opacity(progress)
+            .clipped()
     }
 }
 

--- a/ArmoryInventory/Firearms/FirearmsView.swift
+++ b/ArmoryInventory/Firearms/FirearmsView.swift
@@ -158,7 +158,9 @@ struct FirearmsView: View {
                 HStack {
                     Text("Filters")
                     Spacer()
-                    Image(systemName: showingFilters ? "chevron.up" : "chevron.down")
+                    Image(systemName: "chevron.down")
+                        .rotationEffect(.degrees(showingFilters ? 180 : 0))
+                        .animation(.easeInOut(duration: 0.2), value: showingFilters)
                         .foregroundStyle(.secondary)
                 }
             }

--- a/ArmoryInventory/Localizable.xcstrings
+++ b/ArmoryInventory/Localizable.xcstrings
@@ -496,6 +496,9 @@
     "Nickname" : {
 
     },
+    "No Ammo In Stock" : {
+
+    },
     "No Ammo Yet" : {
 
     },
@@ -566,6 +569,9 @@
 
     },
     "OK" : {
+
+    },
+    "Open %@ to view out-of-stock loads." : {
 
     },
     "Optic Details" : {

--- a/ArmoryInventoryTests/AmmoTests/CaliberListViewModelTests.swift
+++ b/ArmoryInventoryTests/AmmoTests/CaliberListViewModelTests.swift
@@ -139,7 +139,10 @@ final class CaliberListViewModelTests: XCTestCase {
             viewModel.inStockSortedAmmo(for: caliber).map(\.brand),
             ["Blazer", "Federal", "Federal"]
         )
-        XCTAssertTrue(viewModel.outOfStockSortedAmmo(for: caliber).isEmpty)
+        XCTAssertEqual(
+            viewModel.outOfStockSortedAmmo(for: secondCaliber).map(\.brand),
+            ["PMC"]
+        )
 
         let expectedValue = (Decimal(1500) / 100).formatted(.currency(code: "USD"))
         XCTAssertEqual(
@@ -172,7 +175,14 @@ final class CaliberListViewModelTests: XCTestCase {
             quantity: 0,
             caliber: caliber
         )
-        caliber.ammoTypes = [third, first, second]
+        let fourth = AmmoType(
+            brand: "PMC",
+            bulletType: "FMJ",
+            grain: 147,
+            quantity: -10,
+            caliber: caliber
+        )
+        caliber.ammoTypes = [third, first, second, fourth]
 
         let viewModel = CaliberListViewModel(
             ammoChangeService: AmmoChangeServiceMock(),
@@ -187,9 +197,9 @@ final class CaliberListViewModelTests: XCTestCase {
         XCTAssertEqual(inStockRows[0].map(\.brand), ["Federal", "Blazer"])
         XCTAssertEqual(allRows.count, 2)
         XCTAssertEqual(allRows[0].map(\.brand), ["Federal", "Blazer"])
-        XCTAssertEqual(allRows[1].map(\.brand), ["AAC"])
+        XCTAssertEqual(allRows[1].map(\.brand), ["AAC", "PMC"])
         XCTAssertEqual(outOfStockRows.count, 1)
-        XCTAssertEqual(outOfStockRows[0].map(\.brand), ["AAC"])
+        XCTAssertEqual(outOfStockRows[0].map(\.brand), ["AAC", "PMC"])
     }
 
     @MainActor

--- a/ArmoryInventoryTests/AmmoTests/CaliberListViewModelTests.swift
+++ b/ArmoryInventoryTests/AmmoTests/CaliberListViewModelTests.swift
@@ -135,12 +135,61 @@ final class CaliberListViewModelTests: XCTestCase {
             viewModel.sortedAmmo(for: caliber).map(\.grain),
             [124, 115, 124]
         )
+        XCTAssertEqual(
+            viewModel.inStockSortedAmmo(for: caliber).map(\.brand),
+            ["Blazer", "Federal", "Federal"]
+        )
+        XCTAssertTrue(viewModel.outOfStockSortedAmmo(for: caliber).isEmpty)
 
         let expectedValue = (Decimal(1500) / 100).formatted(.currency(code: "USD"))
         XCTAssertEqual(
             viewModel.totalValueText(for: [firstCaliber, secondCaliber], currencyCode: "USD"),
             expectedValue
         )
+    }
+
+    @MainActor
+    func testAmmoRowsCanIncludeOrExcludeOutOfStockLoads() {
+        let caliber = Caliber(name: "9mm")
+        let first = AmmoType(
+            brand: "Federal",
+            bulletType: "FMJ",
+            grain: 115,
+            quantity: 40,
+            caliber: caliber
+        )
+        let second = AmmoType(
+            brand: "Blazer",
+            bulletType: "JHP",
+            grain: 124,
+            quantity: 20,
+            caliber: caliber
+        )
+        let third = AmmoType(
+            brand: "AAC",
+            bulletType: "OTM",
+            grain: 77,
+            quantity: 0,
+            caliber: caliber
+        )
+        caliber.ammoTypes = [third, first, second]
+
+        let viewModel = CaliberListViewModel(
+            ammoChangeService: AmmoChangeServiceMock(),
+            taxRateProvider: FixedInventoryTaxRateProvider()
+        )
+
+        let inStockRows = viewModel.ammoRows(for: caliber, includeOutOfStock: false)
+        let allRows = viewModel.ammoRows(for: caliber, includeOutOfStock: true)
+        let outOfStockRows = viewModel.ammoRows(for: viewModel.outOfStockSortedAmmo(for: caliber))
+
+        XCTAssertEqual(inStockRows.count, 1)
+        XCTAssertEqual(inStockRows[0].map(\.brand), ["Federal", "Blazer"])
+        XCTAssertEqual(allRows.count, 2)
+        XCTAssertEqual(allRows[0].map(\.brand), ["Federal", "Blazer"])
+        XCTAssertEqual(allRows[1].map(\.brand), ["AAC"])
+        XCTAssertEqual(outOfStockRows.count, 1)
+        XCTAssertEqual(outOfStockRows[0].map(\.brand), ["AAC"])
     }
 
     @MainActor


### PR DESCRIPTION
## Summary
- move out-of-stock ammo out of the main ammo card flow and show it in a dedicated section
- remove zero-round labels from out-of-stock cards and refine the caliber expand/collapse animation
- include the project version bump and add view model test coverage for the new ammo grouping behavior

## Testing
- `xcodebuild test -scheme 'Armory Inventory' -destination 'platform=iOS Simulator,name=iPhone 17,OS=26.4' -only-testing:ArmoryInventoryTests/CaliberListViewModelTests` *(failed in this environment because CoreSimulatorService was unavailable)*