### PR TITLE
[Magazine Patterns Refactor] Introduce generic magazine pattern model

### DIFF
--- a/ArmoryInventory/Accessories/Magazines/MagazinePatternModels.swift
+++ b/ArmoryInventory/Accessories/Magazines/MagazinePatternModels.swift
@@ -67,6 +67,7 @@ struct MagazinePattern: Identifiable, Codable, Hashable {
     private static let catalogPrefix = "catalog:"
     private static let customPrefix = "custom:"
     private static let legacyPrefix = "legacy:"
+    private static let unknownPrefix = "unknown:"
 
     let id: String
     let kind: MagazinePatternKind
@@ -105,7 +106,7 @@ struct MagazinePattern: Identifiable, Codable, Hashable {
     }
 
     static let unknown = MagazinePattern(
-        id: "\(legacyPrefix)unknown",
+        id: "\(unknownPrefix)pattern",
         kind: .unknown,
         displayName: "Unknown Pattern",
         familyLabel: "Unknown",

--- a/ArmoryInventory/Accessories/Magazines/MagazinePatternModels.swift
+++ b/ArmoryInventory/Accessories/Magazines/MagazinePatternModels.swift
@@ -23,6 +23,36 @@ struct MagazinePatternCompatibility: Codable, Hashable {
     let platformTags: [String]
     let fitDescriptors: [String]
 
+    init(
+        supportedCaliberNames: [String],
+        compatibleFirearmTypes: [FirearmType],
+        compatibleFirearmActions: [FirearmAction],
+        platformTags: [String],
+        fitDescriptors: [String]
+    ) {
+        self.supportedCaliberNames = supportedCaliberNames
+        self.compatibleFirearmTypes = compatibleFirearmTypes
+        self.compatibleFirearmActions = compatibleFirearmActions
+        self.platformTags = platformTags
+        self.fitDescriptors = fitDescriptors
+    }
+
+    init(
+        supportedCalibers: [KnownCaliber],
+        compatibleFirearmTypes: [FirearmType],
+        compatibleFirearmActions: [FirearmAction],
+        platformTags: [String],
+        fitDescriptors: [String]
+    ) {
+        self.init(
+            supportedCaliberNames: supportedCalibers.map(\.displayName),
+            compatibleFirearmTypes: compatibleFirearmTypes,
+            compatibleFirearmActions: compatibleFirearmActions,
+            platformTags: platformTags,
+            fitDescriptors: fitDescriptors
+        )
+    }
+
     static let empty = MagazinePatternCompatibility(
         supportedCaliberNames: [],
         compatibleFirearmTypes: [],
@@ -176,7 +206,7 @@ enum MagazinePatternCatalog {
             displayName: "AR-15 STANAG",
             familyLabel: "AR-15 STANAG",
             compatibility: MagazinePatternCompatibility(
-                supportedCaliberNames: [".223 Rem", "5.56 NATO", ".300 Blackout"],
+                supportedCalibers: [.rem223, .nato556, .blackout300],
                 compatibleFirearmTypes: [.rifle],
                 compatibleFirearmActions: [.semiAuto, .selectFire],
                 platformTags: ["AR-15", "STANAG", "AR-15 pattern lower"],
@@ -191,7 +221,7 @@ enum MagazinePatternCatalog {
             displayName: "Glock Double-Stack 9mm Full-Size",
             familyLabel: "Glock Double-Stack 9mm",
             compatibility: MagazinePatternCompatibility(
-                supportedCaliberNames: ["9mm"],
+                supportedCalibers: [.mm9],
                 compatibleFirearmTypes: [.pistol],
                 compatibleFirearmActions: [.semiAuto],
                 platformTags: ["Glock 17", "Glock 19", "Glock 34", "Glock 45"],
@@ -206,7 +236,7 @@ enum MagazinePatternCatalog {
             displayName: "Glock Double-Stack 9mm Compact",
             familyLabel: "Glock Double-Stack 9mm",
             compatibility: MagazinePatternCompatibility(
-                supportedCaliberNames: ["9mm"],
+                supportedCalibers: [.mm9],
                 compatibleFirearmTypes: [.pistol],
                 compatibleFirearmActions: [.semiAuto],
                 platformTags: ["Glock 19", "Glock 26", "Glock 49"],
@@ -221,7 +251,7 @@ enum MagazinePatternCatalog {
             displayName: "SIG P320 9mm",
             familyLabel: "SIG P320 9mm",
             compatibility: MagazinePatternCompatibility(
-                supportedCaliberNames: ["9mm"],
+                supportedCalibers: [.mm9],
                 compatibleFirearmTypes: [.pistol],
                 compatibleFirearmActions: [.semiAuto],
                 platformTags: ["SIG P320", "SIG M17", "SIG M18", "AXG Pro"],
@@ -236,7 +266,7 @@ enum MagazinePatternCatalog {
             displayName: "2011 / Double-Stack 1911 9mm",
             familyLabel: "2011 / Double-Stack 1911 9mm",
             compatibility: MagazinePatternCompatibility(
-                supportedCaliberNames: ["9mm"],
+                supportedCalibers: [.mm9],
                 compatibleFirearmTypes: [.pistol],
                 compatibleFirearmActions: [.semiAuto],
                 platformTags: ["2011", "Staccato", "Atlas", "double-stack 1911"],

--- a/ArmoryInventory/Accessories/Magazines/MagazinePatternModels.swift
+++ b/ArmoryInventory/Accessories/Magazines/MagazinePatternModels.swift
@@ -15,39 +15,28 @@ enum MagazinePatternKind: String, Codable, CaseIterable, Identifiable {
     var id: String { rawValue }
 }
 
-enum MagazinePatternFamily: String, Codable, CaseIterable, Identifiable {
-    case ar15Stanag
-    case glockDoubleStack9mm
-    case sigP320DoubleStack9mm
-    case doubleStack1911_2011_9mm
-    case legacy
-    case unknown
+struct MagazinePatternCompatibility: Codable, Hashable {
+    let supportedCaliberNames: [String]
+    let compatibleFirearmTypes: [FirearmType]
+    let compatibleFirearmActions: [FirearmAction]
+    let platformTags: [String]
+    let fitDescriptors: [String]
 
-    var id: String { rawValue }
-}
-
-enum MagazinePatternFitProfile: String, Codable, CaseIterable, Identifiable {
-    case rifleStandard
-    case fullSizeAndCompact
-    case compactOnly
-    case servicePistol
-    case doubleStack1911
-    case legacy
-    case unknown
-
-    var id: String { rawValue }
+    static let empty = MagazinePatternCompatibility(
+        supportedCaliberNames: [],
+        compatibleFirearmTypes: [],
+        compatibleFirearmActions: [],
+        platformTags: [],
+        fitDescriptors: []
+    )
 }
 
 struct MagazinePattern: Identifiable, Codable, Hashable {
     let id: String
     let kind: MagazinePatternKind
-    let family: MagazinePatternFamily
     let displayName: String
-    let supportedCaliberNames: [String]
-    let compatibleFirearmTypes: [FirearmType]
-    let compatibleFirearmActions: [FirearmAction]
-    let compatiblePlatformNames: [String]
-    let fitProfile: MagazinePatternFitProfile
+    let familyLabel: String
+    let compatibility: MagazinePatternCompatibility
     let aliases: [String]
     let notes: String?
 
@@ -65,7 +54,7 @@ struct MagazinePattern: Identifiable, Codable, Hashable {
             return false
         }
 
-        return supportedCaliberNames.contains { Self.normalize($0) == normalizedQuery }
+        return compatibility.supportedCaliberNames.contains { Self.normalize($0) == normalizedQuery }
     }
 
     func isCompatible(
@@ -73,8 +62,8 @@ struct MagazinePattern: Identifiable, Codable, Hashable {
         action: FirearmAction,
         caliberName: String?
     ) -> Bool {
-        let typeMatches = compatibleFirearmTypes.isEmpty || compatibleFirearmTypes.contains(firearmType)
-        let actionMatches = compatibleFirearmActions.isEmpty || compatibleFirearmActions.contains(action)
+        let typeMatches = compatibility.compatibleFirearmTypes.isEmpty || compatibility.compatibleFirearmTypes.contains(firearmType)
+        let actionMatches = compatibility.compatibleFirearmActions.isEmpty || compatibility.compatibleFirearmActions.contains(action)
         let caliberMatches = caliberName == nil || supports(caliberName: caliberName)
         return typeMatches && actionMatches && caliberMatches
     }
@@ -82,23 +71,21 @@ struct MagazinePattern: Identifiable, Codable, Hashable {
     static let unknown = MagazinePattern(
         id: "unknown",
         kind: .unknown,
-        family: .unknown,
         displayName: "Unknown Pattern",
-        supportedCaliberNames: [],
-        compatibleFirearmTypes: [],
-        compatibleFirearmActions: [],
-        compatiblePlatformNames: [],
-        fitProfile: .unknown,
+        familyLabel: "Unknown",
+        compatibility: .empty,
         aliases: [],
         notes: "Fallback used when no catalog pattern can be resolved."
     )
 
     static func legacy(
         displayName: String,
+        familyLabel: String? = nil,
         supportedCaliberNames: [String] = [],
         compatibleFirearmTypes: [FirearmType] = [],
         compatibleFirearmActions: [FirearmAction] = [],
-        compatiblePlatformNames: [String] = [],
+        platformTags: [String] = [],
+        fitDescriptors: [String] = [],
         notes: String? = nil
     ) -> MagazinePattern {
         let trimmedDisplayName = displayName.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -109,13 +96,15 @@ struct MagazinePattern: Identifiable, Codable, Hashable {
         return MagazinePattern(
             id: "legacy:\(legacyID)",
             kind: .legacy,
-            family: .legacy,
             displayName: resolvedName,
-            supportedCaliberNames: supportedCaliberNames,
-            compatibleFirearmTypes: compatibleFirearmTypes,
-            compatibleFirearmActions: compatibleFirearmActions,
-            compatiblePlatformNames: compatiblePlatformNames,
-            fitProfile: .legacy,
+            familyLabel: familyLabel ?? resolvedName,
+            compatibility: MagazinePatternCompatibility(
+                supportedCaliberNames: supportedCaliberNames,
+                compatibleFirearmTypes: compatibleFirearmTypes,
+                compatibleFirearmActions: compatibleFirearmActions,
+                platformTags: platformTags,
+                fitDescriptors: fitDescriptors
+            ),
             aliases: [],
             notes: notes
         )
@@ -134,65 +123,75 @@ enum MagazinePatternCatalog {
         MagazinePattern(
             id: "ar15-stanag-223-556-300blk",
             kind: .catalog,
-            family: .ar15Stanag,
             displayName: "AR-15 STANAG",
-            supportedCaliberNames: [".223 Rem", "5.56 NATO", ".300 Blackout"],
-            compatibleFirearmTypes: [.rifle],
-            compatibleFirearmActions: [.semiAuto, .selectFire],
-            compatiblePlatformNames: ["AR-15", "STANAG", "AR-15 pattern lower"],
-            fitProfile: .rifleStandard,
+            familyLabel: "AR-15 STANAG",
+            compatibility: MagazinePatternCompatibility(
+                supportedCaliberNames: [".223 Rem", "5.56 NATO", ".300 Blackout"],
+                compatibleFirearmTypes: [.rifle],
+                compatibleFirearmActions: [.semiAuto, .selectFire],
+                platformTags: ["AR-15", "STANAG", "AR-15 pattern lower"],
+                fitDescriptors: ["standard rifle magazine", "straight-in STANAG magwell"]
+            ),
             aliases: ["STANAG AR-15", "AR-15 PMAG", "GI AR-15"],
             notes: "Standard AR-15 magazine family shared across .223 Rem, 5.56 NATO, and .300 Blackout platforms."
         ),
         MagazinePattern(
             id: "glock-double-stack-9mm-full-size-compact",
             kind: .catalog,
-            family: .glockDoubleStack9mm,
             displayName: "Glock Double-Stack 9mm Full-Size",
-            supportedCaliberNames: ["9mm"],
-            compatibleFirearmTypes: [.pistol],
-            compatibleFirearmActions: [.semiAuto],
-            compatiblePlatformNames: ["Glock 17", "Glock 19", "Glock 34", "Glock 45"],
-            fitProfile: .fullSizeAndCompact,
+            familyLabel: "Glock Double-Stack 9mm",
+            compatibility: MagazinePatternCompatibility(
+                supportedCaliberNames: ["9mm"],
+                compatibleFirearmTypes: [.pistol],
+                compatibleFirearmActions: [.semiAuto],
+                platformTags: ["Glock 17", "Glock 19", "Glock 34", "Glock 45"],
+                fitDescriptors: ["full-size body", "fits full-size and compact Glock-pattern frames"]
+            ),
             aliases: ["G17/G19 9mm", "Glock OEM 17-round", "Glock full-size 9mm"],
             notes: "Longer Glock-pattern 9mm magazines that work in both full-size and compact frames."
         ),
         MagazinePattern(
             id: "glock-double-stack-9mm-compact",
             kind: .catalog,
-            family: .glockDoubleStack9mm,
             displayName: "Glock Double-Stack 9mm Compact",
-            supportedCaliberNames: ["9mm"],
-            compatibleFirearmTypes: [.pistol],
-            compatibleFirearmActions: [.semiAuto],
-            compatiblePlatformNames: ["Glock 19", "Glock 26", "Glock 49"],
-            fitProfile: .compactOnly,
+            familyLabel: "Glock Double-Stack 9mm",
+            compatibility: MagazinePatternCompatibility(
+                supportedCaliberNames: ["9mm"],
+                compatibleFirearmTypes: [.pistol],
+                compatibleFirearmActions: [.semiAuto],
+                platformTags: ["Glock 19", "Glock 26", "Glock 49"],
+                fitDescriptors: ["compact body", "compact-only Glock-pattern frames"]
+            ),
             aliases: ["G19-only 9mm", "Glock OEM 15-round", "Glock compact 9mm"],
             notes: "Shorter Glock-pattern 9mm magazines that do not fit the same set of firearms as full-size bodies."
         ),
         MagazinePattern(
             id: "sig-p320-double-stack-9mm",
             kind: .catalog,
-            family: .sigP320DoubleStack9mm,
             displayName: "SIG P320 9mm",
-            supportedCaliberNames: ["9mm"],
-            compatibleFirearmTypes: [.pistol],
-            compatibleFirearmActions: [.semiAuto],
-            compatiblePlatformNames: ["SIG P320", "SIG M17", "SIG M18", "AXG Pro"],
-            fitProfile: .servicePistol,
+            familyLabel: "SIG P320 9mm",
+            compatibility: MagazinePatternCompatibility(
+                supportedCaliberNames: ["9mm"],
+                compatibleFirearmTypes: [.pistol],
+                compatibleFirearmActions: [.semiAuto],
+                platformTags: ["SIG P320", "SIG M17", "SIG M18", "AXG Pro"],
+                fitDescriptors: ["double-stack service pistol body"]
+            ),
             aliases: ["P320 9mm", "M17/M18 9mm", "SIG 320 full-size 9mm"],
             notes: "Double-stack SIG P320 family magazines."
         ),
         MagazinePattern(
             id: "2011-double-stack-9mm",
             kind: .catalog,
-            family: .doubleStack1911_2011_9mm,
             displayName: "2011 / Double-Stack 1911 9mm",
-            supportedCaliberNames: ["9mm"],
-            compatibleFirearmTypes: [.pistol],
-            compatibleFirearmActions: [.semiAuto],
-            compatiblePlatformNames: ["2011", "Staccato", "Atlas", "double-stack 1911"],
-            fitProfile: .doubleStack1911,
+            familyLabel: "2011 / Double-Stack 1911 9mm",
+            compatibility: MagazinePatternCompatibility(
+                supportedCaliberNames: ["9mm"],
+                compatibleFirearmTypes: [.pistol],
+                compatibleFirearmActions: [.semiAuto],
+                platformTags: ["2011", "Staccato", "Atlas", "double-stack 1911"],
+                fitDescriptors: ["double-stack 1911 grip module", "2011 pattern"]
+            ),
             aliases: ["2011 9mm", "DS 1911 9mm", "Staccato 9mm"],
             notes: "Double-stack 1911 / 2011 magazine family."
         )

--- a/ArmoryInventory/Accessories/Magazines/MagazinePatternModels.swift
+++ b/ArmoryInventory/Accessories/Magazines/MagazinePatternModels.swift
@@ -1,0 +1,214 @@
+//
+//  MagazinePatternModels.swift
+//  Armory Inventory
+//
+//  Created by Codex on 4/21/26.
+//
+
+import Foundation
+
+enum MagazinePatternKind: String, Codable, CaseIterable, Identifiable {
+    case catalog
+    case legacy
+    case unknown
+
+    var id: String { rawValue }
+}
+
+enum MagazinePatternFamily: String, Codable, CaseIterable, Identifiable {
+    case ar15Stanag
+    case glockDoubleStack9mm
+    case sigP320DoubleStack9mm
+    case doubleStack1911_2011_9mm
+    case legacy
+    case unknown
+
+    var id: String { rawValue }
+}
+
+enum MagazinePatternFitProfile: String, Codable, CaseIterable, Identifiable {
+    case rifleStandard
+    case fullSizeAndCompact
+    case compactOnly
+    case servicePistol
+    case doubleStack1911
+    case legacy
+    case unknown
+
+    var id: String { rawValue }
+}
+
+struct MagazinePattern: Identifiable, Codable, Hashable {
+    let id: String
+    let kind: MagazinePatternKind
+    let family: MagazinePatternFamily
+    let displayName: String
+    let supportedCaliberNames: [String]
+    let compatibleFirearmTypes: [FirearmType]
+    let compatibleFirearmActions: [FirearmAction]
+    let compatiblePlatformNames: [String]
+    let fitProfile: MagazinePatternFitProfile
+    let aliases: [String]
+    let notes: String?
+
+    var isFallback: Bool {
+        kind != .catalog
+    }
+
+    func supports(caliberName: String?) -> Bool {
+        guard let caliberName else {
+            return false
+        }
+
+        let normalizedQuery = Self.normalize(caliberName)
+        guard !normalizedQuery.isEmpty else {
+            return false
+        }
+
+        return supportedCaliberNames.contains { Self.normalize($0) == normalizedQuery }
+    }
+
+    func isCompatible(
+        with firearmType: FirearmType,
+        action: FirearmAction,
+        caliberName: String?
+    ) -> Bool {
+        let typeMatches = compatibleFirearmTypes.isEmpty || compatibleFirearmTypes.contains(firearmType)
+        let actionMatches = compatibleFirearmActions.isEmpty || compatibleFirearmActions.contains(action)
+        let caliberMatches = caliberName == nil || supports(caliberName: caliberName)
+        return typeMatches && actionMatches && caliberMatches
+    }
+
+    static let unknown = MagazinePattern(
+        id: "unknown",
+        kind: .unknown,
+        family: .unknown,
+        displayName: "Unknown Pattern",
+        supportedCaliberNames: [],
+        compatibleFirearmTypes: [],
+        compatibleFirearmActions: [],
+        compatiblePlatformNames: [],
+        fitProfile: .unknown,
+        aliases: [],
+        notes: "Fallback used when no catalog pattern can be resolved."
+    )
+
+    static func legacy(
+        displayName: String,
+        supportedCaliberNames: [String] = [],
+        compatibleFirearmTypes: [FirearmType] = [],
+        compatibleFirearmActions: [FirearmAction] = [],
+        compatiblePlatformNames: [String] = [],
+        notes: String? = nil
+    ) -> MagazinePattern {
+        let trimmedDisplayName = displayName.trimmingCharacters(in: .whitespacesAndNewlines)
+        let resolvedName = trimmedDisplayName.isEmpty ? "Legacy Pattern" : trimmedDisplayName
+        let normalizedID = normalize(resolvedName)
+        let legacyID = normalizedID.isEmpty ? "legacy-pattern" : normalizedID
+
+        return MagazinePattern(
+            id: "legacy:\(legacyID)",
+            kind: .legacy,
+            family: .legacy,
+            displayName: resolvedName,
+            supportedCaliberNames: supportedCaliberNames,
+            compatibleFirearmTypes: compatibleFirearmTypes,
+            compatibleFirearmActions: compatibleFirearmActions,
+            compatiblePlatformNames: compatiblePlatformNames,
+            fitProfile: .legacy,
+            aliases: [],
+            notes: notes
+        )
+    }
+
+    private static func normalize(_ value: String) -> String {
+        value
+            .folding(options: [.caseInsensitive, .diacriticInsensitive], locale: .current)
+            .replacingOccurrences(of: "[^a-z0-9]+", with: "-", options: .regularExpression)
+            .trimmingCharacters(in: CharacterSet(charactersIn: "-"))
+    }
+}
+
+enum MagazinePatternCatalog {
+    static let canonicalPatterns: [MagazinePattern] = [
+        MagazinePattern(
+            id: "ar15-stanag-223-556-300blk",
+            kind: .catalog,
+            family: .ar15Stanag,
+            displayName: "AR-15 STANAG",
+            supportedCaliberNames: [".223 Rem", "5.56 NATO", ".300 Blackout"],
+            compatibleFirearmTypes: [.rifle],
+            compatibleFirearmActions: [.semiAuto, .selectFire],
+            compatiblePlatformNames: ["AR-15", "STANAG", "AR-15 pattern lower"],
+            fitProfile: .rifleStandard,
+            aliases: ["STANAG AR-15", "AR-15 PMAG", "GI AR-15"],
+            notes: "Standard AR-15 magazine family shared across .223 Rem, 5.56 NATO, and .300 Blackout platforms."
+        ),
+        MagazinePattern(
+            id: "glock-double-stack-9mm-full-size-compact",
+            kind: .catalog,
+            family: .glockDoubleStack9mm,
+            displayName: "Glock Double-Stack 9mm Full-Size",
+            supportedCaliberNames: ["9mm"],
+            compatibleFirearmTypes: [.pistol],
+            compatibleFirearmActions: [.semiAuto],
+            compatiblePlatformNames: ["Glock 17", "Glock 19", "Glock 34", "Glock 45"],
+            fitProfile: .fullSizeAndCompact,
+            aliases: ["G17/G19 9mm", "Glock OEM 17-round", "Glock full-size 9mm"],
+            notes: "Longer Glock-pattern 9mm magazines that work in both full-size and compact frames."
+        ),
+        MagazinePattern(
+            id: "glock-double-stack-9mm-compact",
+            kind: .catalog,
+            family: .glockDoubleStack9mm,
+            displayName: "Glock Double-Stack 9mm Compact",
+            supportedCaliberNames: ["9mm"],
+            compatibleFirearmTypes: [.pistol],
+            compatibleFirearmActions: [.semiAuto],
+            compatiblePlatformNames: ["Glock 19", "Glock 26", "Glock 49"],
+            fitProfile: .compactOnly,
+            aliases: ["G19-only 9mm", "Glock OEM 15-round", "Glock compact 9mm"],
+            notes: "Shorter Glock-pattern 9mm magazines that do not fit the same set of firearms as full-size bodies."
+        ),
+        MagazinePattern(
+            id: "sig-p320-double-stack-9mm",
+            kind: .catalog,
+            family: .sigP320DoubleStack9mm,
+            displayName: "SIG P320 9mm",
+            supportedCaliberNames: ["9mm"],
+            compatibleFirearmTypes: [.pistol],
+            compatibleFirearmActions: [.semiAuto],
+            compatiblePlatformNames: ["SIG P320", "SIG M17", "SIG M18", "AXG Pro"],
+            fitProfile: .servicePistol,
+            aliases: ["P320 9mm", "M17/M18 9mm", "SIG 320 full-size 9mm"],
+            notes: "Double-stack SIG P320 family magazines."
+        ),
+        MagazinePattern(
+            id: "2011-double-stack-9mm",
+            kind: .catalog,
+            family: .doubleStack1911_2011_9mm,
+            displayName: "2011 / Double-Stack 1911 9mm",
+            supportedCaliberNames: ["9mm"],
+            compatibleFirearmTypes: [.pistol],
+            compatibleFirearmActions: [.semiAuto],
+            compatiblePlatformNames: ["2011", "Staccato", "Atlas", "double-stack 1911"],
+            fitProfile: .doubleStack1911,
+            aliases: ["2011 9mm", "DS 1911 9mm", "Staccato 9mm"],
+            notes: "Double-stack 1911 / 2011 magazine family."
+        )
+    ]
+
+    static func pattern(id: String) -> MagazinePattern? {
+        canonicalPatterns.first { $0.id == id }
+    }
+
+    static func suggestedPatterns(
+        firearmType: FirearmType,
+        action: FirearmAction,
+        caliberName: String?
+    ) -> [MagazinePattern] {
+        canonicalPatterns.filter {
+            $0.isCompatible(with: firearmType, action: action, caliberName: caliberName)
+        }
+    }
+}

--- a/ArmoryInventory/Accessories/Magazines/MagazinePatternModels.swift
+++ b/ArmoryInventory/Accessories/Magazines/MagazinePatternModels.swift
@@ -32,6 +32,8 @@ struct MagazinePatternCompatibility: Codable, Hashable {
 }
 
 struct MagazinePattern: Identifiable, Codable, Hashable {
+    private static let normalizationLocale = Locale(identifier: "en_US_POSIX")
+
     let id: String
     let kind: MagazinePatternKind
     let displayName: String
@@ -64,7 +66,7 @@ struct MagazinePattern: Identifiable, Codable, Hashable {
     ) -> Bool {
         let typeMatches = compatibility.compatibleFirearmTypes.isEmpty || compatibility.compatibleFirearmTypes.contains(firearmType)
         let actionMatches = compatibility.compatibleFirearmActions.isEmpty || compatibility.compatibleFirearmActions.contains(action)
-        let caliberMatches = caliberName == nil || supports(caliberName: caliberName)
+        let caliberMatches = compatibility.supportedCaliberNames.isEmpty || caliberName == nil || supports(caliberName: caliberName)
         return typeMatches && actionMatches && caliberMatches
     }
 
@@ -91,7 +93,7 @@ struct MagazinePattern: Identifiable, Codable, Hashable {
         let trimmedDisplayName = displayName.trimmingCharacters(in: .whitespacesAndNewlines)
         let resolvedName = trimmedDisplayName.isEmpty ? "Legacy Pattern" : trimmedDisplayName
         let normalizedID = normalize(resolvedName)
-        let legacyID = normalizedID.isEmpty ? "legacy-pattern" : normalizedID
+        let legacyID = normalizedID.isEmpty ? fallbackLegacyID(for: resolvedName) : normalizedID
 
         return MagazinePattern(
             id: "legacy:\(legacyID)",
@@ -112,9 +114,21 @@ struct MagazinePattern: Identifiable, Codable, Hashable {
 
     private static func normalize(_ value: String) -> String {
         value
-            .folding(options: [.caseInsensitive, .diacriticInsensitive], locale: .current)
+            .folding(options: [.caseInsensitive, .diacriticInsensitive], locale: normalizationLocale)
             .replacingOccurrences(of: "[^a-z0-9]+", with: "-", options: .regularExpression)
             .trimmingCharacters(in: CharacterSet(charactersIn: "-"))
+    }
+
+    private static func fallbackLegacyID(for value: String) -> String {
+        let scalarFingerprint = value.unicodeScalars
+            .map { String(format: "%04x", $0.value) }
+            .joined(separator: "")
+
+        if scalarFingerprint.isEmpty {
+            return "legacy-empty"
+        }
+
+        return "legacy-\(scalarFingerprint)"
     }
 }
 

--- a/ArmoryInventory/Accessories/Magazines/MagazinePatternModels.swift
+++ b/ArmoryInventory/Accessories/Magazines/MagazinePatternModels.swift
@@ -9,6 +9,7 @@ import Foundation
 
 enum MagazinePatternKind: String, Codable, CaseIterable, Identifiable {
     case catalog
+    case custom
     case legacy
     case unknown
 
@@ -33,6 +34,9 @@ struct MagazinePatternCompatibility: Codable, Hashable {
 
 struct MagazinePattern: Identifiable, Codable, Hashable {
     private static let normalizationLocale = Locale(identifier: "en_US_POSIX")
+    private static let catalogPrefix = "catalog:"
+    private static let customPrefix = "custom:"
+    private static let legacyPrefix = "legacy:"
 
     let id: String
     let kind: MagazinePatternKind
@@ -71,7 +75,7 @@ struct MagazinePattern: Identifiable, Codable, Hashable {
     }
 
     static let unknown = MagazinePattern(
-        id: "unknown",
+        id: "\(legacyPrefix)unknown",
         kind: .unknown,
         displayName: "Unknown Pattern",
         familyLabel: "Unknown",
@@ -79,6 +83,38 @@ struct MagazinePattern: Identifiable, Codable, Hashable {
         aliases: [],
         notes: "Fallback used when no catalog pattern can be resolved."
     )
+
+    static func custom(
+        id: UUID = UUID(),
+        displayName: String,
+        familyLabel: String,
+        supportedCaliberNames: [String] = [],
+        compatibleFirearmTypes: [FirearmType] = [],
+        compatibleFirearmActions: [FirearmAction] = [],
+        platformTags: [String] = [],
+        fitDescriptors: [String] = [],
+        aliases: [String] = [],
+        notes: String? = nil
+    ) -> MagazinePattern {
+        let resolvedDisplayName = displayName.trimmingCharacters(in: .whitespacesAndNewlines)
+        let resolvedFamilyLabel = familyLabel.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        return MagazinePattern(
+            id: "\(customPrefix)\(id.uuidString.lowercased())",
+            kind: .custom,
+            displayName: resolvedDisplayName.isEmpty ? "Custom Pattern" : resolvedDisplayName,
+            familyLabel: resolvedFamilyLabel.isEmpty ? (resolvedDisplayName.isEmpty ? "Custom Pattern" : resolvedDisplayName) : resolvedFamilyLabel,
+            compatibility: MagazinePatternCompatibility(
+                supportedCaliberNames: supportedCaliberNames,
+                compatibleFirearmTypes: compatibleFirearmTypes,
+                compatibleFirearmActions: compatibleFirearmActions,
+                platformTags: platformTags,
+                fitDescriptors: fitDescriptors
+            ),
+            aliases: aliases,
+            notes: notes
+        )
+    }
 
     static func legacy(
         displayName: String,
@@ -96,7 +132,7 @@ struct MagazinePattern: Identifiable, Codable, Hashable {
         let legacyID = normalizedID.isEmpty ? fallbackLegacyID(for: resolvedName) : normalizedID
 
         return MagazinePattern(
-            id: "legacy:\(legacyID)",
+            id: "\(legacyPrefix)\(legacyID)",
             kind: .legacy,
             displayName: resolvedName,
             familyLabel: familyLabel ?? resolvedName,
@@ -135,7 +171,7 @@ struct MagazinePattern: Identifiable, Codable, Hashable {
 enum MagazinePatternCatalog {
     static let canonicalPatterns: [MagazinePattern] = [
         MagazinePattern(
-            id: "ar15-stanag-223-556-300blk",
+            id: "catalog:ar15-stanag-223-556-300blk",
             kind: .catalog,
             displayName: "AR-15 STANAG",
             familyLabel: "AR-15 STANAG",
@@ -150,7 +186,7 @@ enum MagazinePatternCatalog {
             notes: "Standard AR-15 magazine family shared across .223 Rem, 5.56 NATO, and .300 Blackout platforms."
         ),
         MagazinePattern(
-            id: "glock-double-stack-9mm-full-size-compact",
+            id: "catalog:glock-double-stack-9mm-full-size-compact",
             kind: .catalog,
             displayName: "Glock Double-Stack 9mm Full-Size",
             familyLabel: "Glock Double-Stack 9mm",
@@ -165,7 +201,7 @@ enum MagazinePatternCatalog {
             notes: "Longer Glock-pattern 9mm magazines that work in both full-size and compact frames."
         ),
         MagazinePattern(
-            id: "glock-double-stack-9mm-compact",
+            id: "catalog:glock-double-stack-9mm-compact",
             kind: .catalog,
             displayName: "Glock Double-Stack 9mm Compact",
             familyLabel: "Glock Double-Stack 9mm",
@@ -180,7 +216,7 @@ enum MagazinePatternCatalog {
             notes: "Shorter Glock-pattern 9mm magazines that do not fit the same set of firearms as full-size bodies."
         ),
         MagazinePattern(
-            id: "sig-p320-double-stack-9mm",
+            id: "catalog:sig-p320-double-stack-9mm",
             kind: .catalog,
             displayName: "SIG P320 9mm",
             familyLabel: "SIG P320 9mm",
@@ -195,7 +231,7 @@ enum MagazinePatternCatalog {
             notes: "Double-stack SIG P320 family magazines."
         ),
         MagazinePattern(
-            id: "2011-double-stack-9mm",
+            id: "catalog:2011-double-stack-9mm",
             kind: .catalog,
             displayName: "2011 / Double-Stack 1911 9mm",
             familyLabel: "2011 / Double-Stack 1911 9mm",

--- a/ArmoryInventory/Ammo/AmmoModels.swift
+++ b/ArmoryInventory/Ammo/AmmoModels.swift
@@ -8,6 +8,27 @@
 import Foundation
 import SwiftData
 
+enum KnownCaliber: String, CaseIterable, Codable, Hashable {
+    case lr22 = ".22 LR"
+    case rem223 = ".223 Rem"
+    case nato556 = "5.56 NATO"
+    case blackout300 = ".300 Blackout"
+    case creedmoor65 = "6.5 Creedmoor"
+    case x39_762 = "7.62x39"
+    case win308 = ".308 Win"
+    case acp380 = ".380 ACP"
+    case mm9 = "9mm"
+    case sw40 = ".40 S&W"
+    case acp45 = ".45 ACP"
+    case gauge12 = "12 Gauge"
+
+    var displayName: String { rawValue }
+
+    var normalizedName: String {
+        displayName.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+    }
+}
+
 @Model
 final class Caliber {
     @Attribute(.unique) var name: String
@@ -107,20 +128,9 @@ final class AmmoAdjustmentRecord {
 }
 
 enum CommonAmmoCatalog {
-    static let defaultCaliberNames: [String] = [
-        ".22 LR",
-        ".223 Rem",
-        "5.56 NATO",
-        ".300 Blackout",
-        "6.5 Creedmoor",
-        "7.62x39",
-        ".308 Win",
-        ".380 ACP",
-        "9mm",
-        ".40 S&W",
-        ".45 ACP",
-        "12 Gauge"
-    ]
+    static let defaultCalibers: [KnownCaliber] = KnownCaliber.allCases
+
+    static let defaultCaliberNames: [String] = defaultCalibers.map(\.displayName)
 
     static let commonBrands: [String] = [
         "AAC",
@@ -194,18 +204,22 @@ enum CommonAmmoCatalog {
         referenceGrainRangesByCaliber[caliberName]
     }
 
+    static func referenceGrainRange(for caliber: KnownCaliber) -> ClosedRange<Int>? {
+        referenceGrainRangesByCaliber[caliber.displayName]
+    }
+
     private static let referenceGrainRangesByCaliber: [String: ClosedRange<Int>] = [
-        "9mm": 115...150,
-        ".223 Rem": 55...77,
-        "5.56 NATO": 55...77,
-        ".300 Blackout": 110...220,
-        ".45 ACP": 185...230,
-        ".40 S&W": 155...205,
-        ".380 ACP": 85...99,
-        ".22 LR": 32...45,
-        "7.62x39": 123...124,
-        ".308 Win": 150...180,
-        "6.5 Creedmoor": 120...147
+        KnownCaliber.mm9.displayName: 115...150,
+        KnownCaliber.rem223.displayName: 55...77,
+        KnownCaliber.nato556.displayName: 55...77,
+        KnownCaliber.blackout300.displayName: 110...220,
+        KnownCaliber.acp45.displayName: 185...230,
+        KnownCaliber.sw40.displayName: 155...205,
+        KnownCaliber.acp380.displayName: 85...99,
+        KnownCaliber.lr22.displayName: 32...45,
+        KnownCaliber.x39_762.displayName: 123...124,
+        KnownCaliber.win308.displayName: 150...180,
+        KnownCaliber.creedmoor65.displayName: 120...147
     ]
 
 }

--- a/ArmoryInventory/Services/CaliberSort.swift
+++ b/ArmoryInventory/Services/CaliberSort.swift
@@ -70,18 +70,5 @@ enum CaliberSort {
 
     nonisolated private static let settingsKey = InventorySettingsKeys.caliberSortOrder
 
-    nonisolated private static let defaultOrder: [String] = [
-        ".22 lr",
-        ".223 rem",
-        "5.56 nato",
-        ".300 blackout",
-        "7.62x39",
-        "6.5 creedmoor",
-        ".308 win",
-        ".380 acp",
-        "9mm",
-        ".40 s&w",
-        ".45 acp",
-        "12 gauge"
-    ]
+    nonisolated private static let defaultOrder: [String] = KnownCaliber.allCases.map(\.normalizedName)
 }

--- a/ArmoryInventoryTests/AccessoriesTests/MagazinePatternModelsTests.swift
+++ b/ArmoryInventoryTests/AccessoriesTests/MagazinePatternModelsTests.swift
@@ -10,7 +10,7 @@ import XCTest
 
 final class MagazinePatternModelsTests: XCTestCase {
     func testAr15PatternSupportsMultipleCalibers() throws {
-        let pattern = try XCTUnwrap(MagazinePatternCatalog.pattern(id: "ar15-stanag-223-556-300blk"))
+        let pattern = try XCTUnwrap(MagazinePatternCatalog.pattern(id: "catalog:ar15-stanag-223-556-300blk"))
 
         XCTAssertEqual(pattern.familyLabel, "AR-15 STANAG")
         XCTAssertTrue(pattern.supports(caliberName: ".223 Rem"))
@@ -23,8 +23,8 @@ final class MagazinePatternModelsTests: XCTestCase {
     }
 
     func testCatalogCanRepresentDistinctPatternsForSameCaliber() throws {
-        let fullSize = try XCTUnwrap(MagazinePatternCatalog.pattern(id: "glock-double-stack-9mm-full-size-compact"))
-        let compact = try XCTUnwrap(MagazinePatternCatalog.pattern(id: "glock-double-stack-9mm-compact"))
+        let fullSize = try XCTUnwrap(MagazinePatternCatalog.pattern(id: "catalog:glock-double-stack-9mm-full-size-compact"))
+        let compact = try XCTUnwrap(MagazinePatternCatalog.pattern(id: "catalog:glock-double-stack-9mm-compact"))
 
         XCTAssertEqual(fullSize.compatibility.supportedCaliberNames, ["9mm"])
         XCTAssertEqual(compact.compatibility.supportedCaliberNames, ["9mm"])
@@ -52,13 +52,13 @@ final class MagazinePatternModelsTests: XCTestCase {
         XCTAssertEqual(
             Set(pistolPatterns.map(\.id)),
             [
-                "glock-double-stack-9mm-full-size-compact",
-                "glock-double-stack-9mm-compact",
-                "sig-p320-double-stack-9mm",
-                "2011-double-stack-9mm"
+                "catalog:glock-double-stack-9mm-full-size-compact",
+                "catalog:glock-double-stack-9mm-compact",
+                "catalog:sig-p320-double-stack-9mm",
+                "catalog:2011-double-stack-9mm"
             ]
         )
-        XCTAssertEqual(riflePatterns.map(\.id), ["ar15-stanag-223-556-300blk"])
+        XCTAssertEqual(riflePatterns.map(\.id), ["catalog:ar15-stanag-223-556-300blk"])
     }
 
     func testLegacyFallbackPreservesUserFacingDetails() {
@@ -83,6 +83,26 @@ final class MagazinePatternModelsTests: XCTestCase {
         XCTAssertTrue(legacyPattern.isFallback)
     }
 
+    func testCustomPatternsUseStableOpaqueIDNamespace() {
+        let pattern = MagazinePattern.custom(
+            id: UUID(uuidString: "12345678-1234-1234-1234-1234567890AB")!,
+            displayName: "My PCC Pattern",
+            familyLabel: "AR9 Lower",
+            supportedCaliberNames: ["9mm"],
+            compatibleFirearmTypes: [.rifle],
+            compatibleFirearmActions: [.semiAuto],
+            platformTags: ["AR9", "Colt-style"],
+            fitDescriptors: ["straight magazine"],
+            aliases: ["Competition PCC"]
+        )
+
+        XCTAssertEqual(pattern.id, "custom:12345678-1234-1234-1234-1234567890ab")
+        XCTAssertEqual(pattern.displayName, "My PCC Pattern")
+        XCTAssertEqual(pattern.familyLabel, "AR9 Lower")
+        XCTAssertEqual(pattern.compatibility.platformTags, ["AR9", "Colt-style"])
+        XCTAssertEqual(pattern.aliases, ["Competition PCC"])
+    }
+
     func testLegacyFallbackGeneratesDistinctIDsWhenSlugWouldBeEmpty() {
         let punctuationPattern = MagazinePattern.legacy(displayName: "!!!")
         let cjkPattern = MagazinePattern.legacy(displayName: "弹匣")
@@ -95,6 +115,7 @@ final class MagazinePatternModelsTests: XCTestCase {
     func testUnknownFallbackIsAvailableForUnmappedRecords() {
         XCTAssertEqual(MagazinePattern.unknown.kind, .unknown)
         XCTAssertEqual(MagazinePattern.unknown.familyLabel, "Unknown")
+        XCTAssertEqual(MagazinePattern.unknown.id, "legacy:unknown")
         XCTAssertTrue(MagazinePattern.unknown.compatibility.supportedCaliberNames.isEmpty)
         XCTAssertTrue(MagazinePattern.unknown.compatibility.platformTags.isEmpty)
         XCTAssertTrue(MagazinePattern.unknown.isFallback)

--- a/ArmoryInventoryTests/AccessoriesTests/MagazinePatternModelsTests.swift
+++ b/ArmoryInventoryTests/AccessoriesTests/MagazinePatternModelsTests.swift
@@ -13,21 +13,25 @@ final class MagazinePatternModelsTests: XCTestCase {
         let pattern = try XCTUnwrap(MagazinePatternCatalog.pattern(id: "catalog:ar15-stanag-223-556-300blk"))
 
         XCTAssertEqual(pattern.familyLabel, "AR-15 STANAG")
-        XCTAssertTrue(pattern.supports(caliberName: ".223 Rem"))
-        XCTAssertTrue(pattern.supports(caliberName: "5.56 NATO"))
-        XCTAssertTrue(pattern.supports(caliberName: ".300 Blackout"))
-        XCTAssertFalse(pattern.supports(caliberName: "9mm"))
+        XCTAssertEqual(
+            pattern.compatibility.supportedCaliberNames,
+            [KnownCaliber.rem223.displayName, KnownCaliber.nato556.displayName, KnownCaliber.blackout300.displayName]
+        )
+        XCTAssertTrue(pattern.supports(caliberName: KnownCaliber.rem223.displayName))
+        XCTAssertTrue(pattern.supports(caliberName: KnownCaliber.nato556.displayName))
+        XCTAssertTrue(pattern.supports(caliberName: KnownCaliber.blackout300.displayName))
+        XCTAssertFalse(pattern.supports(caliberName: KnownCaliber.mm9.displayName))
         XCTAssertTrue(pattern.compatibility.platformTags.contains("AR-15"))
-        XCTAssertTrue(pattern.isCompatible(with: .rifle, action: .semiAuto, caliberName: "5.56 NATO"))
-        XCTAssertFalse(pattern.isCompatible(with: .pistol, action: .semiAuto, caliberName: "5.56 NATO"))
+        XCTAssertTrue(pattern.isCompatible(with: .rifle, action: .semiAuto, caliberName: KnownCaliber.nato556.displayName))
+        XCTAssertFalse(pattern.isCompatible(with: .pistol, action: .semiAuto, caliberName: KnownCaliber.nato556.displayName))
     }
 
     func testCatalogCanRepresentDistinctPatternsForSameCaliber() throws {
         let fullSize = try XCTUnwrap(MagazinePatternCatalog.pattern(id: "catalog:glock-double-stack-9mm-full-size-compact"))
         let compact = try XCTUnwrap(MagazinePatternCatalog.pattern(id: "catalog:glock-double-stack-9mm-compact"))
 
-        XCTAssertEqual(fullSize.compatibility.supportedCaliberNames, ["9mm"])
-        XCTAssertEqual(compact.compatibility.supportedCaliberNames, ["9mm"])
+        XCTAssertEqual(fullSize.compatibility.supportedCaliberNames, [KnownCaliber.mm9.displayName])
+        XCTAssertEqual(compact.compatibility.supportedCaliberNames, [KnownCaliber.mm9.displayName])
         XCTAssertEqual(fullSize.familyLabel, "Glock Double-Stack 9mm")
         XCTAssertEqual(compact.familyLabel, "Glock Double-Stack 9mm")
         XCTAssertNotEqual(fullSize.id, compact.id)
@@ -41,12 +45,12 @@ final class MagazinePatternModelsTests: XCTestCase {
         let pistolPatterns = MagazinePatternCatalog.suggestedPatterns(
             firearmType: .pistol,
             action: .semiAuto,
-            caliberName: "9mm"
+            caliberName: KnownCaliber.mm9.displayName
         )
         let riflePatterns = MagazinePatternCatalog.suggestedPatterns(
             firearmType: .rifle,
             action: .semiAuto,
-            caliberName: ".300 Blackout"
+            caliberName: KnownCaliber.blackout300.displayName
         )
 
         XCTAssertEqual(
@@ -65,7 +69,7 @@ final class MagazinePatternModelsTests: XCTestCase {
         let legacyPattern = MagazinePattern.legacy(
             displayName: "CZ 75 Pattern",
             familyLabel: "CZ 75",
-            supportedCaliberNames: ["9mm"],
+            supportedCaliberNames: [KnownCaliber.mm9.displayName],
             compatibleFirearmTypes: [.pistol],
             compatibleFirearmActions: [.semiAuto],
             platformTags: ["CZ 75", "Shadow 2"],
@@ -76,7 +80,7 @@ final class MagazinePatternModelsTests: XCTestCase {
         XCTAssertEqual(legacyPattern.kind, .legacy)
         XCTAssertEqual(legacyPattern.familyLabel, "CZ 75")
         XCTAssertEqual(legacyPattern.displayName, "CZ 75 Pattern")
-        XCTAssertEqual(legacyPattern.compatibility.supportedCaliberNames, ["9mm"])
+        XCTAssertEqual(legacyPattern.compatibility.supportedCaliberNames, [KnownCaliber.mm9.displayName])
         XCTAssertEqual(legacyPattern.compatibility.platformTags, ["CZ 75", "Shadow 2"])
         XCTAssertEqual(legacyPattern.compatibility.fitDescriptors, ["double-stack steel-frame pistol"])
         XCTAssertTrue(legacyPattern.id.hasPrefix("legacy:"))
@@ -88,7 +92,7 @@ final class MagazinePatternModelsTests: XCTestCase {
             id: UUID(uuidString: "12345678-1234-1234-1234-1234567890AB")!,
             displayName: "My PCC Pattern",
             familyLabel: "AR9 Lower",
-            supportedCaliberNames: ["9mm"],
+            supportedCaliberNames: [KnownCaliber.mm9.displayName],
             compatibleFirearmTypes: [.rifle],
             compatibleFirearmActions: [.semiAuto],
             platformTags: ["AR9", "Colt-style"],
@@ -129,8 +133,8 @@ final class MagazinePatternModelsTests: XCTestCase {
             compatibleFirearmActions: [.semiAuto]
         )
 
-        XCTAssertTrue(unknownPattern.isCompatible(with: .pistol, action: .semiAuto, caliberName: "9mm"))
-        XCTAssertTrue(legacyPattern.isCompatible(with: .pistol, action: .semiAuto, caliberName: ".45 ACP"))
-        XCTAssertFalse(legacyPattern.isCompatible(with: .rifle, action: .semiAuto, caliberName: ".45 ACP"))
+        XCTAssertTrue(unknownPattern.isCompatible(with: .pistol, action: .semiAuto, caliberName: KnownCaliber.mm9.displayName))
+        XCTAssertTrue(legacyPattern.isCompatible(with: .pistol, action: .semiAuto, caliberName: KnownCaliber.acp45.displayName))
+        XCTAssertFalse(legacyPattern.isCompatible(with: .rifle, action: .semiAuto, caliberName: KnownCaliber.acp45.displayName))
     }
 }

--- a/ArmoryInventoryTests/AccessoriesTests/MagazinePatternModelsTests.swift
+++ b/ArmoryInventoryTests/AccessoriesTests/MagazinePatternModelsTests.swift
@@ -119,10 +119,17 @@ final class MagazinePatternModelsTests: XCTestCase {
     func testUnknownFallbackIsAvailableForUnmappedRecords() {
         XCTAssertEqual(MagazinePattern.unknown.kind, .unknown)
         XCTAssertEqual(MagazinePattern.unknown.familyLabel, "Unknown")
-        XCTAssertEqual(MagazinePattern.unknown.id, "legacy:unknown")
+        XCTAssertEqual(MagazinePattern.unknown.id, "unknown:pattern")
         XCTAssertTrue(MagazinePattern.unknown.compatibility.supportedCaliberNames.isEmpty)
         XCTAssertTrue(MagazinePattern.unknown.compatibility.platformTags.isEmpty)
         XCTAssertTrue(MagazinePattern.unknown.isFallback)
+    }
+
+    func testUnknownFallbackUsesDistinctNamespaceFromLegacyPatterns() {
+        let legacyUnknown = MagazinePattern.legacy(displayName: "unknown")
+
+        XCTAssertEqual(legacyUnknown.id, "legacy:unknown")
+        XCTAssertNotEqual(MagazinePattern.unknown.id, legacyUnknown.id)
     }
 
     func testEmptyCaliberConstraintsActAsWildcard() {

--- a/ArmoryInventoryTests/AccessoriesTests/MagazinePatternModelsTests.swift
+++ b/ArmoryInventoryTests/AccessoriesTests/MagazinePatternModelsTests.swift
@@ -83,11 +83,33 @@ final class MagazinePatternModelsTests: XCTestCase {
         XCTAssertTrue(legacyPattern.isFallback)
     }
 
+    func testLegacyFallbackGeneratesDistinctIDsWhenSlugWouldBeEmpty() {
+        let punctuationPattern = MagazinePattern.legacy(displayName: "!!!")
+        let cjkPattern = MagazinePattern.legacy(displayName: "弹匣")
+
+        XCTAssertNotEqual(punctuationPattern.id, cjkPattern.id)
+        XCTAssertEqual(punctuationPattern.id, "legacy:legacy-002100210021")
+        XCTAssertEqual(cjkPattern.id, "legacy:legacy-5f395323")
+    }
+
     func testUnknownFallbackIsAvailableForUnmappedRecords() {
         XCTAssertEqual(MagazinePattern.unknown.kind, .unknown)
         XCTAssertEqual(MagazinePattern.unknown.familyLabel, "Unknown")
         XCTAssertTrue(MagazinePattern.unknown.compatibility.supportedCaliberNames.isEmpty)
         XCTAssertTrue(MagazinePattern.unknown.compatibility.platformTags.isEmpty)
         XCTAssertTrue(MagazinePattern.unknown.isFallback)
+    }
+
+    func testEmptyCaliberConstraintsActAsWildcard() {
+        let unknownPattern = MagazinePattern.unknown
+        let legacyPattern = MagazinePattern.legacy(
+            displayName: "Imported Pattern",
+            compatibleFirearmTypes: [.pistol],
+            compatibleFirearmActions: [.semiAuto]
+        )
+
+        XCTAssertTrue(unknownPattern.isCompatible(with: .pistol, action: .semiAuto, caliberName: "9mm"))
+        XCTAssertTrue(legacyPattern.isCompatible(with: .pistol, action: .semiAuto, caliberName: ".45 ACP"))
+        XCTAssertFalse(legacyPattern.isCompatible(with: .rifle, action: .semiAuto, caliberName: ".45 ACP"))
     }
 }

--- a/ArmoryInventoryTests/AccessoriesTests/MagazinePatternModelsTests.swift
+++ b/ArmoryInventoryTests/AccessoriesTests/MagazinePatternModelsTests.swift
@@ -1,0 +1,90 @@
+//
+//  MagazinePatternModelsTests.swift
+//  Armory InventoryTests
+//
+//  Created by Codex on 4/21/26.
+//
+
+import XCTest
+@testable import ArmoryInventory
+
+final class MagazinePatternModelsTests: XCTestCase {
+    func testAr15PatternSupportsMultipleCalibers() throws {
+        let pattern = try XCTUnwrap(MagazinePatternCatalog.pattern(id: "ar15-stanag-223-556-300blk"))
+
+        XCTAssertEqual(pattern.family, .ar15Stanag)
+        XCTAssertTrue(pattern.supports(caliberName: ".223 Rem"))
+        XCTAssertTrue(pattern.supports(caliberName: "5.56 NATO"))
+        XCTAssertTrue(pattern.supports(caliberName: ".300 Blackout"))
+        XCTAssertFalse(pattern.supports(caliberName: "9mm"))
+        XCTAssertTrue(pattern.isCompatible(with: .rifle, action: .semiAuto, caliberName: "5.56 NATO"))
+        XCTAssertFalse(pattern.isCompatible(with: .pistol, action: .semiAuto, caliberName: "5.56 NATO"))
+    }
+
+    func testCatalogCanRepresentDistinctPatternsForSameCaliber() throws {
+        let fullSize = try XCTUnwrap(MagazinePatternCatalog.pattern(id: "glock-double-stack-9mm-full-size-compact"))
+        let compact = try XCTUnwrap(MagazinePatternCatalog.pattern(id: "glock-double-stack-9mm-compact"))
+
+        XCTAssertEqual(fullSize.supportedCaliberNames, ["9mm"])
+        XCTAssertEqual(compact.supportedCaliberNames, ["9mm"])
+        XCTAssertEqual(fullSize.family, .glockDoubleStack9mm)
+        XCTAssertEqual(compact.family, .glockDoubleStack9mm)
+        XCTAssertNotEqual(fullSize.id, compact.id)
+        XCTAssertNotEqual(fullSize.fitProfile, compact.fitProfile)
+        XCTAssertTrue(fullSize.compatiblePlatformNames.contains("Glock 17"))
+        XCTAssertFalse(compact.compatiblePlatformNames.contains("Glock 17"))
+        XCTAssertTrue(compact.compatiblePlatformNames.contains("Glock 19"))
+    }
+
+    func testSuggestedPatternsFilterByTypeActionAndCaliber() {
+        let pistolPatterns = MagazinePatternCatalog.suggestedPatterns(
+            firearmType: .pistol,
+            action: .semiAuto,
+            caliberName: "9mm"
+        )
+        let riflePatterns = MagazinePatternCatalog.suggestedPatterns(
+            firearmType: .rifle,
+            action: .semiAuto,
+            caliberName: ".300 Blackout"
+        )
+
+        XCTAssertEqual(
+            Set(pistolPatterns.map(\.id)),
+            [
+                "glock-double-stack-9mm-full-size-compact",
+                "glock-double-stack-9mm-compact",
+                "sig-p320-double-stack-9mm",
+                "2011-double-stack-9mm"
+            ]
+        )
+        XCTAssertEqual(riflePatterns.map(\.id), ["ar15-stanag-223-556-300blk"])
+    }
+
+    func testLegacyFallbackPreservesUserFacingDetails() {
+        let legacyPattern = MagazinePattern.legacy(
+            displayName: "CZ 75 Pattern",
+            supportedCaliberNames: ["9mm"],
+            compatibleFirearmTypes: [.pistol],
+            compatibleFirearmActions: [.semiAuto],
+            compatiblePlatformNames: ["CZ 75", "Shadow 2"],
+            notes: "Imported before catalog support existed."
+        )
+
+        XCTAssertEqual(legacyPattern.kind, .legacy)
+        XCTAssertEqual(legacyPattern.family, .legacy)
+        XCTAssertEqual(legacyPattern.displayName, "CZ 75 Pattern")
+        XCTAssertEqual(legacyPattern.fitProfile, .legacy)
+        XCTAssertEqual(legacyPattern.supportedCaliberNames, ["9mm"])
+        XCTAssertEqual(legacyPattern.compatiblePlatformNames, ["CZ 75", "Shadow 2"])
+        XCTAssertTrue(legacyPattern.id.hasPrefix("legacy:"))
+        XCTAssertTrue(legacyPattern.isFallback)
+    }
+
+    func testUnknownFallbackIsAvailableForUnmappedRecords() {
+        XCTAssertEqual(MagazinePattern.unknown.kind, .unknown)
+        XCTAssertEqual(MagazinePattern.unknown.family, .unknown)
+        XCTAssertTrue(MagazinePattern.unknown.supportedCaliberNames.isEmpty)
+        XCTAssertTrue(MagazinePattern.unknown.compatiblePlatformNames.isEmpty)
+        XCTAssertTrue(MagazinePattern.unknown.isFallback)
+    }
+}

--- a/ArmoryInventoryTests/AccessoriesTests/MagazinePatternModelsTests.swift
+++ b/ArmoryInventoryTests/AccessoriesTests/MagazinePatternModelsTests.swift
@@ -12,11 +12,12 @@ final class MagazinePatternModelsTests: XCTestCase {
     func testAr15PatternSupportsMultipleCalibers() throws {
         let pattern = try XCTUnwrap(MagazinePatternCatalog.pattern(id: "ar15-stanag-223-556-300blk"))
 
-        XCTAssertEqual(pattern.family, .ar15Stanag)
+        XCTAssertEqual(pattern.familyLabel, "AR-15 STANAG")
         XCTAssertTrue(pattern.supports(caliberName: ".223 Rem"))
         XCTAssertTrue(pattern.supports(caliberName: "5.56 NATO"))
         XCTAssertTrue(pattern.supports(caliberName: ".300 Blackout"))
         XCTAssertFalse(pattern.supports(caliberName: "9mm"))
+        XCTAssertTrue(pattern.compatibility.platformTags.contains("AR-15"))
         XCTAssertTrue(pattern.isCompatible(with: .rifle, action: .semiAuto, caliberName: "5.56 NATO"))
         XCTAssertFalse(pattern.isCompatible(with: .pistol, action: .semiAuto, caliberName: "5.56 NATO"))
     }
@@ -25,15 +26,15 @@ final class MagazinePatternModelsTests: XCTestCase {
         let fullSize = try XCTUnwrap(MagazinePatternCatalog.pattern(id: "glock-double-stack-9mm-full-size-compact"))
         let compact = try XCTUnwrap(MagazinePatternCatalog.pattern(id: "glock-double-stack-9mm-compact"))
 
-        XCTAssertEqual(fullSize.supportedCaliberNames, ["9mm"])
-        XCTAssertEqual(compact.supportedCaliberNames, ["9mm"])
-        XCTAssertEqual(fullSize.family, .glockDoubleStack9mm)
-        XCTAssertEqual(compact.family, .glockDoubleStack9mm)
+        XCTAssertEqual(fullSize.compatibility.supportedCaliberNames, ["9mm"])
+        XCTAssertEqual(compact.compatibility.supportedCaliberNames, ["9mm"])
+        XCTAssertEqual(fullSize.familyLabel, "Glock Double-Stack 9mm")
+        XCTAssertEqual(compact.familyLabel, "Glock Double-Stack 9mm")
         XCTAssertNotEqual(fullSize.id, compact.id)
-        XCTAssertNotEqual(fullSize.fitProfile, compact.fitProfile)
-        XCTAssertTrue(fullSize.compatiblePlatformNames.contains("Glock 17"))
-        XCTAssertFalse(compact.compatiblePlatformNames.contains("Glock 17"))
-        XCTAssertTrue(compact.compatiblePlatformNames.contains("Glock 19"))
+        XCTAssertNotEqual(fullSize.compatibility.fitDescriptors, compact.compatibility.fitDescriptors)
+        XCTAssertTrue(fullSize.compatibility.platformTags.contains("Glock 17"))
+        XCTAssertFalse(compact.compatibility.platformTags.contains("Glock 17"))
+        XCTAssertTrue(compact.compatibility.platformTags.contains("Glock 19"))
     }
 
     func testSuggestedPatternsFilterByTypeActionAndCaliber() {
@@ -63,28 +64,30 @@ final class MagazinePatternModelsTests: XCTestCase {
     func testLegacyFallbackPreservesUserFacingDetails() {
         let legacyPattern = MagazinePattern.legacy(
             displayName: "CZ 75 Pattern",
+            familyLabel: "CZ 75",
             supportedCaliberNames: ["9mm"],
             compatibleFirearmTypes: [.pistol],
             compatibleFirearmActions: [.semiAuto],
-            compatiblePlatformNames: ["CZ 75", "Shadow 2"],
+            platformTags: ["CZ 75", "Shadow 2"],
+            fitDescriptors: ["double-stack steel-frame pistol"],
             notes: "Imported before catalog support existed."
         )
 
         XCTAssertEqual(legacyPattern.kind, .legacy)
-        XCTAssertEqual(legacyPattern.family, .legacy)
+        XCTAssertEqual(legacyPattern.familyLabel, "CZ 75")
         XCTAssertEqual(legacyPattern.displayName, "CZ 75 Pattern")
-        XCTAssertEqual(legacyPattern.fitProfile, .legacy)
-        XCTAssertEqual(legacyPattern.supportedCaliberNames, ["9mm"])
-        XCTAssertEqual(legacyPattern.compatiblePlatformNames, ["CZ 75", "Shadow 2"])
+        XCTAssertEqual(legacyPattern.compatibility.supportedCaliberNames, ["9mm"])
+        XCTAssertEqual(legacyPattern.compatibility.platformTags, ["CZ 75", "Shadow 2"])
+        XCTAssertEqual(legacyPattern.compatibility.fitDescriptors, ["double-stack steel-frame pistol"])
         XCTAssertTrue(legacyPattern.id.hasPrefix("legacy:"))
         XCTAssertTrue(legacyPattern.isFallback)
     }
 
     func testUnknownFallbackIsAvailableForUnmappedRecords() {
         XCTAssertEqual(MagazinePattern.unknown.kind, .unknown)
-        XCTAssertEqual(MagazinePattern.unknown.family, .unknown)
-        XCTAssertTrue(MagazinePattern.unknown.supportedCaliberNames.isEmpty)
-        XCTAssertTrue(MagazinePattern.unknown.compatiblePlatformNames.isEmpty)
+        XCTAssertEqual(MagazinePattern.unknown.familyLabel, "Unknown")
+        XCTAssertTrue(MagazinePattern.unknown.compatibility.supportedCaliberNames.isEmpty)
+        XCTAssertTrue(MagazinePattern.unknown.compatibility.platformTags.isEmpty)
         XCTAssertTrue(MagazinePattern.unknown.isFallback)
     }
 }


### PR DESCRIPTION
## Summary
- add a generic `MagazinePattern` foundation that treats family and fit as data instead of hard-coded enums
- model compatibility constraints explicitly so patterns can support multiple calibers and multiple distinct fit/platform variants within the same caliber
- add a seed catalog plus legacy and unknown fallbacks, with tests covering multi-caliber support, same-caliber distinct patterns, and fallback behavior

## Notes
- the catalog entries in this PR are examples and starter data, not a closed list of all supported pattern families
- this lays the groundwork for attaching one pattern to each magazine record and one or more supported patterns to each firearm in later stories

Closes #19