### PR TITLE
[Magazine Patterns Refactor] Migrate magazine data to pattern-based model

### DIFF
--- a/ArmoryInventory/Accessories/Magazines/AddMagazineViewModel.swift
+++ b/ArmoryInventory/Accessories/Magazines/AddMagazineViewModel.swift
@@ -151,6 +151,7 @@ final class AddMagazineViewModel {
             firearm: firearm,
             sortOrder: nextSortOrder(in: context)
         )
+        MagazinePatternMigration.applyResolvedPattern(to: magazine)
         context.insert(magazine)
 
         do {
@@ -194,6 +195,7 @@ final class AddMagazineViewModel {
         magazine.notes = notes
         magazine.caliber = caliber
         magazine.firearm = firearm
+        MagazinePatternMigration.applyResolvedPattern(to: magazine)
 
         do {
             try context.save()

--- a/ArmoryInventory/Accessories/Magazines/MagazineModels.swift
+++ b/ArmoryInventory/Accessories/Magazines/MagazineModels.swift
@@ -13,6 +13,9 @@ final class Magazine {
     var id: UUID?
     var brand: String
     var modelName: String
+    var patternID: String?
+    var patternKind: MagazinePatternKind.RawValue?
+    var patternDisplayName: String?
     var count: Int
     var capacity: Int
     var purchaseDate: Date
@@ -30,6 +33,9 @@ final class Magazine {
         id: UUID? = UUID(),
         brand: String,
         modelName: String,
+        patternID: String? = nil,
+        patternKind: MagazinePatternKind? = nil,
+        patternDisplayName: String? = nil,
         count: Int = 1,
         capacity: Int,
         purchaseDate: Date = .now,
@@ -45,6 +51,9 @@ final class Magazine {
         self.id = id
         self.brand = brand
         self.modelName = modelName
+        self.patternID = patternID
+        self.patternKind = patternKind?.rawValue
+        self.patternDisplayName = patternDisplayName
         self.count = count
         self.capacity = capacity
         self.purchaseDate = purchaseDate
@@ -60,6 +69,18 @@ final class Magazine {
 
     var displayName: String {
         "\(brand) \(modelName)"
+    }
+
+    var storedPatternKind: MagazinePatternKind? {
+        guard let patternKind else {
+            return nil
+        }
+
+        return MagazinePatternKind(rawValue: patternKind)
+    }
+
+    var resolvedPattern: MagazinePattern {
+        MagazinePatternMigration.resolvedPattern(for: self)
     }
 
     var capacityText: String {

--- a/ArmoryInventory/Accessories/Magazines/MagazinePatternMigration.swift
+++ b/ArmoryInventory/Accessories/Magazines/MagazinePatternMigration.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 import SwiftData
+import CryptoKit
 
 struct MagazinePatternMigration {
     nonisolated private static let ignoredMatchTokens: Set<String> = [
@@ -101,7 +102,7 @@ struct MagazinePatternMigration {
             return .unknown
         case .custom:
             return MagazinePattern.custom(
-                id: customPatternUUID(from: magazine.patternID),
+                id: customPatternUUID(from: magazine.patternID, fallbackSeed: customFallbackSeed(for: magazine)),
                 displayName: magazine.patternDisplayName ?? legacyDisplayName(for: magazine),
                 familyLabel: magazine.patternDisplayName ?? legacyDisplayName(for: magazine),
                 supportedCaliberNames: caliberNames,
@@ -133,6 +134,10 @@ struct MagazinePatternMigration {
     }
 
     private static func resolvedStoredPatternData(for magazine: Magazine) -> StoredPatternData {
+        if let storedPattern = existingStoredPatternData(for: magazine) {
+            return storedPattern
+        }
+
         let pattern = inferredPattern(for: magazine)
 
         switch pattern.kind {
@@ -147,6 +152,50 @@ struct MagazinePatternMigration {
                 id: pattern.id,
                 kind: pattern.kind,
                 displayName: pattern.displayName
+            )
+        }
+    }
+
+    private static func existingStoredPatternData(for magazine: Magazine) -> StoredPatternData? {
+        guard let kind = magazine.storedPatternKind else {
+            return nil
+        }
+
+        switch kind {
+        case .catalog:
+            guard let patternID = magazine.patternID,
+                  MagazinePatternCatalog.pattern(id: patternID) != nil else {
+                return nil
+            }
+
+            return StoredPatternData(
+                id: patternID,
+                kind: .catalog,
+                displayName: nil
+            )
+        case .legacy:
+            guard let patternID = magazine.patternID, !patternID.isEmpty else {
+                return nil
+            }
+
+            let displayName = resolvedStoredDisplayName(for: magazine)
+            return StoredPatternData(
+                id: patternID,
+                kind: .legacy,
+                displayName: displayName
+            )
+        case .custom:
+            let displayName = resolvedStoredDisplayName(for: magazine)
+            return StoredPatternData(
+                id: resolvedCustomPatternID(from: magazine.patternID, fallbackSeed: customFallbackSeed(for: magazine)),
+                kind: .custom,
+                displayName: displayName
+            )
+        case .unknown:
+            return StoredPatternData(
+                id: MagazinePattern.unknown.id,
+                kind: .unknown,
+                displayName: nil
             )
         }
     }
@@ -337,6 +386,15 @@ struct MagazinePatternMigration {
         magazine.displayName.trimmingCharacters(in: .whitespacesAndNewlines)
     }
 
+    private static func resolvedStoredDisplayName(for magazine: Magazine) -> String {
+        let storedDisplayName = magazine.patternDisplayName?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        if !storedDisplayName.isEmpty {
+            return storedDisplayName
+        }
+
+        return legacyDisplayName(for: magazine)
+    }
+
     private static func legacyPlatformTags(for magazine: Magazine) -> [String] {
         guard let firearm = magazine.firearm else {
             return []
@@ -345,13 +403,46 @@ struct MagazinePatternMigration {
         return [firearm.displayName]
     }
 
-    private static func customPatternUUID(from patternID: String?) -> UUID {
-        guard let patternID,
-              patternID.hasPrefix("custom:") else {
-            return UUID()
+    private static func resolvedCustomPatternID(from patternID: String?, fallbackSeed: String) -> String {
+        if let patternID,
+           patternID.hasPrefix("custom:"),
+           let rawValue = UUID(uuidString: String(patternID.dropFirst("custom:".count)))?.uuidString.lowercased() {
+            return "custom:\(rawValue)"
         }
 
-        let rawValue = String(patternID.dropFirst("custom:".count))
-        return UUID(uuidString: rawValue) ?? UUID()
+        return "custom:\(deterministicCustomPatternUUID(seed: fallbackSeed).uuidString.lowercased())"
     }
+
+    private static func customPatternUUID(from patternID: String?, fallbackSeed: String) -> UUID {
+        let resolvedID = resolvedCustomPatternID(from: patternID, fallbackSeed: fallbackSeed)
+        return UUID(uuidString: String(resolvedID.dropFirst("custom:".count))) ?? deterministicCustomPatternUUID(seed: fallbackSeed)
+    }
+
+    private static func customFallbackSeed(for magazine: Magazine) -> String {
+        [
+            magazine.patternID ?? "",
+            resolvedStoredDisplayName(for: magazine),
+            magazine.brand,
+            magazine.modelName,
+            magazine.caliber?.name ?? "",
+            magazine.firearm?.displayName ?? ""
+        ].joined(separator: "|")
+    }
+
+    private static func deterministicCustomPatternUUID(seed: String) -> UUID {
+        let digest = Insecure.SHA1.hash(data: Data(seed.utf8))
+        let bytes = Array(digest.prefix(16))
+        var uuidBytes = (
+            bytes[0], bytes[1], bytes[2], bytes[3],
+            bytes[4], bytes[5], bytes[6], bytes[7],
+            bytes[8], bytes[9], bytes[10], bytes[11],
+            bytes[12], bytes[13], bytes[14], bytes[15]
+        )
+
+        uuidBytes.6 = (uuidBytes.6 & 0x0F) | 0x50
+        uuidBytes.8 = (uuidBytes.8 & 0x3F) | 0x80
+
+        return UUID(uuid: uuidBytes)
+    }
+
 }

--- a/ArmoryInventory/Accessories/Magazines/MagazinePatternMigration.swift
+++ b/ArmoryInventory/Accessories/Magazines/MagazinePatternMigration.swift
@@ -1,0 +1,357 @@
+//
+//  MagazinePatternMigration.swift
+//  Armory Inventory
+//
+//  Created by Codex on 4/22/26.
+//
+
+import Foundation
+import SwiftData
+
+struct MagazinePatternMigration {
+    nonisolated private static let ignoredMatchTokens: Set<String> = [
+        "12",
+        "22",
+        "223",
+        "300",
+        "308",
+        "40",
+        "45",
+        "556",
+        "65",
+        "762x39",
+        "9mm",
+        "acp",
+        "body",
+        "blackout",
+        "compact",
+        "creedmoor",
+        "double",
+        "fits",
+        "frame",
+        "frames",
+        "full",
+        "gauge",
+        "magazine",
+        "magazines",
+        "nato",
+        "oem",
+        "only",
+        "pattern",
+        "pistol",
+        "rem",
+        "round",
+        "service",
+        "size",
+        "stack",
+        "sw",
+        "win"
+    ]
+
+    private struct StoredPatternData {
+        let id: String
+        let kind: MagazinePatternKind
+        let displayName: String?
+    }
+
+    @discardableResult
+    static func backfillMissingPatterns(in context: ModelContext) -> Bool {
+        guard let magazines = try? context.fetch(FetchDescriptor<Magazine>()) else {
+            return false
+        }
+
+        var didChange = false
+
+        for magazine in magazines where needsBackfill(magazine) {
+            applyResolvedPattern(to: magazine)
+            didChange = true
+        }
+
+        return didChange
+    }
+
+    static func applyResolvedPattern(to magazine: Magazine) {
+        let storedPattern = resolvedStoredPatternData(for: magazine)
+        magazine.patternID = storedPattern.id
+        magazine.patternKind = storedPattern.kind.rawValue
+        magazine.patternDisplayName = storedPattern.displayName
+    }
+
+    static func resolvedPattern(for magazine: Magazine) -> MagazinePattern {
+        let caliberNames = supportedCaliberNames(for: magazine)
+        let firearmTypes = compatibleFirearmTypes(for: magazine)
+        let firearmActions = compatibleFirearmActions(for: magazine)
+
+        switch magazine.storedPatternKind {
+        case .catalog:
+            if let patternID = magazine.patternID,
+               let pattern = MagazinePatternCatalog.pattern(id: patternID) {
+                return pattern
+            }
+        case .legacy:
+            return MagazinePattern.legacy(
+                displayName: magazine.patternDisplayName ?? legacyDisplayName(for: magazine),
+                familyLabel: magazine.patternDisplayName ?? legacyDisplayName(for: magazine),
+                supportedCaliberNames: caliberNames,
+                compatibleFirearmTypes: firearmTypes,
+                compatibleFirearmActions: firearmActions,
+                platformTags: legacyPlatformTags(for: magazine)
+            )
+        case .unknown:
+            return .unknown
+        case .custom:
+            return MagazinePattern.custom(
+                id: customPatternUUID(from: magazine.patternID),
+                displayName: magazine.patternDisplayName ?? legacyDisplayName(for: magazine),
+                familyLabel: magazine.patternDisplayName ?? legacyDisplayName(for: magazine),
+                supportedCaliberNames: caliberNames,
+                compatibleFirearmTypes: firearmTypes,
+                compatibleFirearmActions: firearmActions,
+                platformTags: legacyPlatformTags(for: magazine)
+            )
+        case nil:
+            break
+        }
+
+        return inferredPattern(for: magazine)
+    }
+
+    private static func needsBackfill(_ magazine: Magazine) -> Bool {
+        guard let patternID = magazine.patternID, !patternID.isEmpty,
+              let kind = magazine.storedPatternKind else {
+            return true
+        }
+
+        switch kind {
+        case .catalog:
+            return MagazinePatternCatalog.pattern(id: patternID) == nil
+        case .legacy, .custom:
+            return (magazine.patternDisplayName?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ?? true)
+        case .unknown:
+            return false
+        }
+    }
+
+    private static func resolvedStoredPatternData(for magazine: Magazine) -> StoredPatternData {
+        let pattern = inferredPattern(for: magazine)
+
+        switch pattern.kind {
+        case .catalog, .unknown:
+            return StoredPatternData(
+                id: pattern.id,
+                kind: pattern.kind,
+                displayName: nil
+            )
+        case .legacy, .custom:
+            return StoredPatternData(
+                id: pattern.id,
+                kind: pattern.kind,
+                displayName: pattern.displayName
+            )
+        }
+    }
+
+    private static func inferredPattern(for magazine: Magazine) -> MagazinePattern {
+        if let catalogPattern = inferredCatalogPattern(for: magazine) {
+            return catalogPattern
+        }
+
+        if legacyDisplayName(for: magazine).isEmpty {
+            return .unknown
+        }
+
+        return MagazinePattern.legacy(
+            displayName: legacyDisplayName(for: magazine),
+            familyLabel: legacyDisplayName(for: magazine),
+            supportedCaliberNames: supportedCaliberNames(for: magazine),
+            compatibleFirearmTypes: compatibleFirearmTypes(for: magazine),
+            compatibleFirearmActions: compatibleFirearmActions(for: magazine),
+            platformTags: legacyPlatformTags(for: magazine)
+        )
+    }
+
+    private static func inferredCatalogPattern(for magazine: Magazine) -> MagazinePattern? {
+        let caliberName = primaryCaliberName(for: magazine)
+        if caliberName == nil, magazine.firearm == nil {
+            return nil
+        }
+
+        let candidates: [MagazinePattern]
+        if let firearm = magazine.firearm {
+            candidates = MagazinePatternCatalog.suggestedPatterns(
+                firearmType: firearm.firearmType,
+                action: firearm.firearmAction,
+                caliberName: caliberName
+            )
+        } else {
+            candidates = MagazinePatternCatalog.canonicalPatterns.filter { pattern in
+                guard let caliberName else {
+                    return true
+                }
+
+                return pattern.supports(caliberName: caliberName)
+            }
+        }
+
+        guard !candidates.isEmpty else {
+            return nil
+        }
+
+        if candidates.count == 1 {
+            return candidates.first
+        }
+
+        let scoredCandidates = candidates
+            .map { (pattern: $0, score: matchScore(for: $0, magazine: magazine)) }
+            .sorted {
+                if $0.score == $1.score {
+                    return $0.pattern.id < $1.pattern.id
+                }
+
+                return $0.score > $1.score
+            }
+
+        guard let best = scoredCandidates.first,
+              best.score > 0 else {
+            return nil
+        }
+
+        if scoredCandidates.count > 1, scoredCandidates[1].score == best.score {
+            return nil
+        }
+
+        return best.pattern
+    }
+
+    private static func matchScore(for pattern: MagazinePattern, magazine: Magazine) -> Int {
+        let haystack = Set(searchTokens(for: magazine))
+        var matchedTokens = Set<String>()
+
+        for value in pattern.aliases + pattern.compatibility.platformTags {
+            let tokens = normalizedTokens(from: value)
+            guard !tokens.isEmpty else {
+                continue
+            }
+
+            matchedTokens.formUnion(haystack.intersection(tokens))
+        }
+
+        var score = matchedTokens.count
+
+        if let firearm = magazine.firearm,
+           magazine.brand.localizedCaseInsensitiveContains("glock") {
+            switch pattern.id {
+            case "catalog:glock-double-stack-9mm-full-size-compact" where firearm.brand.localizedCaseInsensitiveContains("glock") && magazine.capacity >= 17:
+                score += 3
+            case "catalog:glock-double-stack-9mm-compact" where firearm.brand.localizedCaseInsensitiveContains("glock") && magazine.capacity <= 15:
+                score += 3
+            default:
+                break
+            }
+        }
+
+        return score
+    }
+
+    private static func searchTokens(for magazine: Magazine) -> [String] {
+        var values = [
+            magazine.brand,
+            magazine.modelName,
+            magazine.notes ?? "",
+            magazine.caliber?.name ?? "",
+            String(magazine.capacity),
+            "\(magazine.capacity)-round"
+        ]
+
+        if let firearm = magazine.firearm {
+            values.append(contentsOf: [
+                firearm.brand,
+                firearm.modelName,
+                firearm.nickname ?? "",
+                firearm.caliber?.name ?? ""
+            ])
+        }
+
+        return values.flatMap(normalizedTokens(from:))
+    }
+
+    nonisolated private static func normalizedTokens(from value: String) -> [String] {
+        let normalizedValue = normalizedString(value)
+        guard !normalizedValue.isEmpty else {
+            return []
+        }
+
+        return normalizedValue
+            .split(separator: "-")
+            .map(String.init)
+            .filter { token in
+                token.count >= 2 &&
+                !ignoredMatchTokens.contains(token) &&
+                token.rangeOfCharacter(from: CharacterSet.decimalDigits.inverted) != nil
+            }
+    }
+
+    nonisolated private static func normalizedString(_ value: String) -> String {
+        value
+            .folding(options: [.caseInsensitive, .diacriticInsensitive], locale: Locale(identifier: "en_US_POSIX"))
+            .replacingOccurrences(of: "[^a-z0-9]+", with: "-", options: .regularExpression)
+            .trimmingCharacters(in: CharacterSet(charactersIn: "-"))
+    }
+
+    private static func primaryCaliberName(for magazine: Magazine) -> String? {
+        let names = supportedCaliberNames(for: magazine)
+        return names.first
+    }
+
+    private static func supportedCaliberNames(for magazine: Magazine) -> [String] {
+        if let caliberName = magazine.caliber?.name.trimmingCharacters(in: .whitespacesAndNewlines),
+           !caliberName.isEmpty {
+            return [caliberName]
+        }
+
+        if let caliberName = magazine.firearm?.caliber?.name.trimmingCharacters(in: .whitespacesAndNewlines),
+           !caliberName.isEmpty {
+            return [caliberName]
+        }
+
+        return []
+    }
+
+    private static func compatibleFirearmTypes(for magazine: Magazine) -> [FirearmType] {
+        guard let firearm = magazine.firearm else {
+            return []
+        }
+
+        return [firearm.firearmType]
+    }
+
+    private static func compatibleFirearmActions(for magazine: Magazine) -> [FirearmAction] {
+        guard let firearm = magazine.firearm else {
+            return []
+        }
+
+        return [firearm.firearmAction]
+    }
+
+    private static func legacyDisplayName(for magazine: Magazine) -> String {
+        magazine.displayName.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private static func legacyPlatformTags(for magazine: Magazine) -> [String] {
+        guard let firearm = magazine.firearm else {
+            return []
+        }
+
+        return [firearm.displayName]
+    }
+
+    private static func customPatternUUID(from patternID: String?) -> UUID {
+        guard let patternID,
+              patternID.hasPrefix("custom:") else {
+            return UUID()
+        }
+
+        let rawValue = String(patternID.dropFirst("custom:".count))
+        return UUID(uuidString: rawValue) ?? UUID()
+    }
+}

--- a/ArmoryInventory/ArmoryInventory.swift
+++ b/ArmoryInventory/ArmoryInventory.swift
@@ -107,6 +107,10 @@ struct ArmoryInventory: App {
             }
         }
 
+        if MagazinePatternMigration.backfillMissingPatterns(in: context) {
+            didChange = true
+        }
+
         if let attachments = try? context.fetch(FetchDescriptor<Attachment>()) {
             for attachment in attachments where attachment.id == nil {
                 attachment.id = UUID()

--- a/ArmoryInventory/Services/UserDataTransferService.swift
+++ b/ArmoryInventory/Services/UserDataTransferService.swift
@@ -173,6 +173,9 @@ final class UserDataTransferService: UserDataTransferServicing {
                     id: $0.id ?? UUID(),
                     brand: $0.brand,
                     modelName: $0.modelName,
+                    patternID: $0.patternID,
+                    patternKind: $0.patternKind,
+                    patternDisplayName: $0.patternDisplayName,
                     count: $0.count,
                     capacity: $0.capacity,
                     purchaseDate: $0.purchaseDate,
@@ -304,6 +307,9 @@ final class UserDataTransferService: UserDataTransferServicing {
                 id: snapshot.id,
                 brand: snapshot.brand,
                 modelName: snapshot.modelName,
+                patternID: snapshot.patternID,
+                patternKind: snapshot.patternKind.flatMap(MagazinePatternKind.init(rawValue:)),
+                patternDisplayName: snapshot.patternDisplayName,
                 count: snapshot.count,
                 capacity: snapshot.capacity,
                 purchaseDate: snapshot.purchaseDate,
@@ -318,6 +324,8 @@ final class UserDataTransferService: UserDataTransferServicing {
             )
             context.insert(magazine)
         }
+
+        _ = MagazinePatternMigration.backfillMissingPatterns(in: context)
 
         for snapshot in snapshot.attachments {
             let attachment = Attachment(
@@ -588,6 +596,9 @@ private struct MagazineSnapshot: Codable {
     let id: UUID
     let brand: String
     let modelName: String
+    let patternID: String?
+    let patternKind: String?
+    let patternDisplayName: String?
     let count: Int
     let capacity: Int
     let purchaseDate: Date

--- a/ArmoryInventoryTests/AccessoriesTests/AddMagazineViewModelTests.swift
+++ b/ArmoryInventoryTests/AccessoriesTests/AddMagazineViewModelTests.swift
@@ -110,6 +110,8 @@ final class AddMagazineViewModelTests: XCTestCase {
         XCTAssertEqual(magazines.first?.firearm?.displayName, "CZ P-10 C")
         XCTAssertEqual(magazines.first?.purchaseDate, purchaseDate)
         XCTAssertEqual(magazines.first?.sortOrder, 0)
+        XCTAssertEqual(magazines.first?.storedPatternKind, .legacy)
+        XCTAssertEqual(magazines.first?.patternDisplayName, "CZ OEM")
     }
 
     @MainActor
@@ -201,5 +203,8 @@ final class AddMagazineViewModelTests: XCTestCase {
         XCTAssertEqual(magazine.caliber?.name, ".45 ACP")
         XCTAssertEqual(magazine.firearm?.displayName, "Staccato XC")
         XCTAssertEqual(magazine.notes, "Updated")
+        XCTAssertEqual(magazine.storedPatternKind, .legacy)
+        XCTAssertEqual(magazine.patternID, "legacy:atlas-premium")
+        XCTAssertEqual(magazine.patternDisplayName, "Atlas Premium")
     }
 }

--- a/ArmoryInventoryTests/AccessoriesTests/MagazineModelsTests.swift
+++ b/ArmoryInventoryTests/AccessoriesTests/MagazineModelsTests.swift
@@ -38,6 +38,8 @@ final class MagazineModelsTests: XCTestCase {
         XCTAssertTrue(magazine.purchasePriceText.contains("210"))
         XCTAssertTrue(magazine.caliber === caliber)
         XCTAssertTrue(magazine.firearm === firearm)
+        XCTAssertEqual(magazine.resolvedPattern.kind, .catalog)
+        XCTAssertEqual(magazine.resolvedPattern.id, "catalog:2011-double-stack-9mm")
     }
 
     func testMagazineComputedPropertiesFallbackForSingularAndInvalidColor() {
@@ -60,5 +62,7 @@ final class MagazineModelsTests: XCTestCase {
 
         XCTAssertNil(magazine.magazineColor)
         XCTAssertNil(magazine.colorDisplayName)
+        XCTAssertEqual(magazine.resolvedPattern.kind, .legacy)
+        XCTAssertEqual(magazine.resolvedPattern.displayName, "Glock OEM")
     }
 }

--- a/ArmoryInventoryTests/AccessoriesTests/MagazinePatternMigrationTests.swift
+++ b/ArmoryInventoryTests/AccessoriesTests/MagazinePatternMigrationTests.swift
@@ -115,4 +115,53 @@ final class MagazinePatternMigrationTests: XCTestCase {
         XCTAssertEqual(magazine.patternID, "catalog:ar15-stanag-223-556-300blk")
         XCTAssertEqual(magazine.storedPatternKind, .catalog)
     }
+
+    func testResolvedPatternPreservesStoredCustomMetadata() {
+        let magazine = Magazine(
+            brand: "Custom",
+            modelName: "PCC",
+            patternID: "custom:12345678-1234-1234-1234-1234567890ab",
+            patternKind: .custom,
+            patternDisplayName: "Competition PCC",
+            count: 2,
+            capacity: 35,
+            purchasePriceCents: 4_000
+        )
+
+        let pattern = MagazinePatternMigration.resolvedPattern(for: magazine)
+
+        XCTAssertEqual(pattern.kind, .custom)
+        XCTAssertEqual(pattern.id, "custom:12345678-1234-1234-1234-1234567890ab")
+        XCTAssertEqual(pattern.displayName, "Competition PCC")
+    }
+
+    func testResolvedPatternUsesDeterministicFallbackForMalformedCustomID() {
+        let firstMagazine = Magazine(
+            brand: "Custom",
+            modelName: "PCC",
+            patternID: "custom:not-a-uuid",
+            patternKind: .custom,
+            patternDisplayName: "Competition PCC",
+            count: 2,
+            capacity: 35,
+            purchasePriceCents: 4_000
+        )
+        let secondMagazine = Magazine(
+            brand: "Custom",
+            modelName: "PCC",
+            patternID: "custom:not-a-uuid",
+            patternKind: .custom,
+            patternDisplayName: "Competition PCC",
+            count: 2,
+            capacity: 35,
+            purchasePriceCents: 4_000
+        )
+
+        let firstPattern = MagazinePatternMigration.resolvedPattern(for: firstMagazine)
+        let secondPattern = MagazinePatternMigration.resolvedPattern(for: secondMagazine)
+
+        XCTAssertEqual(firstPattern.kind, .custom)
+        XCTAssertEqual(firstPattern.id, secondPattern.id)
+        XCTAssertTrue(firstPattern.id.hasPrefix("custom:"))
+    }
 }

--- a/ArmoryInventoryTests/AccessoriesTests/MagazinePatternMigrationTests.swift
+++ b/ArmoryInventoryTests/AccessoriesTests/MagazinePatternMigrationTests.swift
@@ -1,0 +1,118 @@
+//
+//  MagazinePatternMigrationTests.swift
+//  Armory InventoryTests
+//
+//  Created by Codex on 4/22/26.
+//
+
+import XCTest
+import SwiftData
+@testable import ArmoryInventory
+
+final class MagazinePatternMigrationTests: XCTestCase {
+    @MainActor
+    func testBackfillAssignsCanonicalPatternWhenCompatibilityIsUnambiguous() throws {
+        let container = try makeInMemoryContainer()
+        let context = container.mainContext
+
+        let caliber = Caliber(name: KnownCaliber.blackout300.displayName)
+        let firearm = Firearm(
+            brand: "Daniel Defense",
+            modelName: "DDM4",
+            purchasePriceCents: 180_000,
+            type: .rifle,
+            action: .semiAuto,
+            caliber: caliber
+        )
+        let magazine = Magazine(
+            brand: "Magpul",
+            modelName: "PMAG 30",
+            count: 4,
+            capacity: 30,
+            purchasePriceCents: 7_500,
+            caliber: caliber,
+            firearm: firearm
+        )
+
+        context.insert(caliber)
+        context.insert(firearm)
+        context.insert(magazine)
+
+        XCTAssertTrue(MagazinePatternMigration.backfillMissingPatterns(in: context))
+        XCTAssertEqual(magazine.patternID, "catalog:ar15-stanag-223-556-300blk")
+        XCTAssertEqual(magazine.storedPatternKind, .catalog)
+        XCTAssertNil(magazine.patternDisplayName)
+        XCTAssertEqual(magazine.resolvedPattern.id, "catalog:ar15-stanag-223-556-300blk")
+    }
+
+    @MainActor
+    func testBackfillFallsBackToLegacyPatternWhenCatalogMatchIsUnknownToCatalog() throws {
+        let container = try makeInMemoryContainer()
+        let context = container.mainContext
+
+        let caliber = Caliber(name: KnownCaliber.mm9.displayName)
+        let firearm = Firearm(
+            brand: "CZ",
+            modelName: "P-10 C",
+            purchasePriceCents: 50_000,
+            type: .pistol,
+            action: .semiAuto,
+            caliber: caliber
+        )
+        let magazine = Magazine(
+            brand: "CZ",
+            modelName: "OEM",
+            count: 3,
+            capacity: 15,
+            purchasePriceCents: 5_000,
+            caliber: caliber,
+            firearm: firearm
+        )
+
+        context.insert(caliber)
+        context.insert(firearm)
+        context.insert(magazine)
+
+        XCTAssertTrue(MagazinePatternMigration.backfillMissingPatterns(in: context))
+        XCTAssertEqual(magazine.storedPatternKind, .legacy)
+        XCTAssertEqual(magazine.patternDisplayName, "CZ OEM")
+        XCTAssertEqual(magazine.resolvedPattern.displayName, "CZ OEM")
+        XCTAssertEqual(magazine.resolvedPattern.compatibility.supportedCaliberNames, [KnownCaliber.mm9.displayName])
+        XCTAssertTrue(magazine.resolvedPattern.id.hasPrefix("legacy:"))
+    }
+
+    @MainActor
+    func testBackfillIsIdempotentForMagazinesThatAlreadyHavePatternMetadata() throws {
+        let container = try makeInMemoryContainer()
+        let context = container.mainContext
+
+        let caliber = Caliber(name: KnownCaliber.blackout300.displayName)
+        let firearm = Firearm(
+            brand: "Daniel Defense",
+            modelName: "DDM4",
+            purchasePriceCents: 180_000,
+            type: .rifle,
+            action: .semiAuto,
+            caliber: caliber
+        )
+        let magazine = Magazine(
+            brand: "Magpul",
+            modelName: "PMAG 30",
+            patternID: "catalog:ar15-stanag-223-556-300blk",
+            patternKind: .catalog,
+            count: 2,
+            capacity: 30,
+            purchasePriceCents: 4_000,
+            caliber: caliber,
+            firearm: firearm
+        )
+
+        context.insert(caliber)
+        context.insert(firearm)
+        context.insert(magazine)
+
+        XCTAssertFalse(MagazinePatternMigration.backfillMissingPatterns(in: context))
+        XCTAssertEqual(magazine.patternID, "catalog:ar15-stanag-223-556-300blk")
+        XCTAssertEqual(magazine.storedPatternKind, .catalog)
+    }
+}

--- a/ArmoryInventoryTests/ServicesTests/UserDataTransferServiceTests.swift
+++ b/ArmoryInventoryTests/ServicesTests/UserDataTransferServiceTests.swift
@@ -147,6 +147,8 @@ final class UserDataTransferServiceTests: XCTestCase {
         XCTAssertEqual(importedFirearms.first?.caliber?.name, "9mm")
         XCTAssertEqual(importedOptics.first?.firearm?.id, firearmID)
         XCTAssertEqual(importedMagazines.first?.caliber?.name, "9mm")
+        XCTAssertEqual(importedMagazines.first?.storedPatternKind, .legacy)
+        XCTAssertEqual(importedMagazines.first?.patternDisplayName, "Magpul PMAG")
         XCTAssertEqual(importedAttachments.first?.firearm?.id, firearmID)
         XCTAssertEqual(importedParts.first?.firearm?.id, firearmID)
         XCTAssertEqual(importedRecords.first?.ammoType?.brand, "Federal")


### PR DESCRIPTION
## Summary
- add stored magazine pattern metadata plus a migration helper that backfills existing records into catalog or legacy pattern identities
- apply the migration path consistently on app startup, add/edit saves, and backup import/export so old data upgrades safely and new data stays normalized
- cover migration behavior with focused tests for idempotence, legacy fallback, catalog resolution, and backup round-tripping

## Notes
- catalog inference is intentionally conservative: it only promotes a record when the current firearm/caliber context provides a clear signal
- unresolved combinations remain legacy-backed instead of being forced into a catalog pattern

Closes #20