### PR TITLE
Centralize magazine compatibility validation

### DIFF
--- a/ArmoryInventory/Accessories/Magazines/AddMagazineView.swift
+++ b/ArmoryInventory/Accessories/Magazines/AddMagazineView.swift
@@ -133,6 +133,11 @@ struct AddMagazineView: View {
                 if let linkedFirearm = linkedFirearm {
                     Section("Linked Firearm") {
                         Text(linkedFirearm.displayName)
+                        if let compatibilityMessage {
+                            Text(compatibilityMessage)
+                                .font(.footnote)
+                                .foregroundStyle(.red)
+                        }
                         if isEditing {
                             Button(role: .destructive) {
                                 unlinkFirearm = true
@@ -211,8 +216,21 @@ struct AddMagazineView: View {
             capacityText: capacityText,
             selectedColor: selectedColor,
             colorDetail: resolvedColorDetail,
-            purchasePriceText: purchasePriceText
+            purchasePriceText: purchasePriceText,
+            selectedCaliber: selectedCaliber,
+            firearm: linkedFirearm,
+            existingMagazine: magazine
         )
+    }
+
+    private var compatibilityMessage: String? {
+        viewModel.compatibilityValidationResult(
+            brand: brand,
+            modelName: modelName,
+            selectedCaliber: selectedCaliber,
+            firearm: linkedFirearm,
+            existingMagazine: magazine
+        ).message
     }
 
     private func saveMagazine() {

--- a/ArmoryInventory/Accessories/Magazines/AddMagazineViewModel.swift
+++ b/ArmoryInventory/Accessories/Magazines/AddMagazineViewModel.swift
@@ -10,9 +10,14 @@ import SwiftData
 
 final class AddMagazineViewModel {
     private let priceInputParser: PriceInputParsing
+    private let compatibilityValidator: MagazineCompatibilityValidator
 
-    init(priceInputParser: PriceInputParsing = PriceInputParserService()) {
+    init(
+        priceInputParser: PriceInputParsing = PriceInputParserService(),
+        compatibilityValidator: MagazineCompatibilityValidator = MagazineCompatibilityValidator()
+    ) {
         self.priceInputParser = priceInputParser
+        self.compatibilityValidator = compatibilityValidator
     }
 
     func initialPurchasePriceText(for magazine: Magazine?) -> String {
@@ -105,7 +110,10 @@ final class AddMagazineViewModel {
         capacityText: String,
         selectedColor: FirearmColor?,
         colorDetail: String?,
-        purchasePriceText: String
+        purchasePriceText: String,
+        selectedCaliber: Caliber?,
+        firearm: Firearm?,
+        existingMagazine: Magazine? = nil
     ) -> Bool {
         guard !trimmedValue(brand).isEmpty else { return false }
         guard !trimmedValue(modelName).isEmpty else { return false }
@@ -115,7 +123,50 @@ final class AddMagazineViewModel {
         if selectedColor == .other, colorDetail == nil {
             return false
         }
-        return true
+
+        return compatibilityValidationResult(
+            brand: brand,
+            modelName: modelName,
+            selectedCaliber: selectedCaliber,
+            firearm: firearm,
+            existingMagazine: existingMagazine
+        ).isCompatible
+    }
+
+    func compatibilityValidationResult(
+        brand: String,
+        modelName: String,
+        selectedCaliber: Caliber?,
+        firearm: Firearm?,
+        existingMagazine: Magazine? = nil
+    ) -> MagazineCompatibilityValidationResult {
+        guard let firearm else {
+            return .compatible
+        }
+
+        let workingMagazine = Magazine(
+            brand: trimmedValue(brand),
+            modelName: trimmedValue(modelName),
+            patternID: existingMagazine?.patternID,
+            patternKind: existingMagazine?.storedPatternKind,
+            patternDisplayName: existingMagazine?.patternDisplayName,
+            capacity: existingMagazine?.capacity ?? 1,
+            purchasePriceCents: existingMagazine?.purchasePriceCents ?? 0,
+            caliber: selectedCaliber,
+            firearm: firearm
+        )
+        if existingMagazine == nil {
+            MagazinePatternMigration.applyResolvedPattern(to: workingMagazine)
+        }
+
+        return compatibilityValidator.validate(
+            pattern: workingMagazine.resolvedPattern,
+            selectedMagazineCaliber: selectedCaliber,
+            firearmType: firearm.firearmType,
+            action: firearm.firearmAction,
+            caliber: firearm.caliber,
+            firearmDescription: firearm.displayName
+        )
     }
 
     func addMagazine(
@@ -152,6 +203,16 @@ final class AddMagazineViewModel {
             sortOrder: nextSortOrder(in: context)
         )
         MagazinePatternMigration.applyResolvedPattern(to: magazine)
+        guard compatibilityValidator.validate(
+            pattern: magazine.resolvedPattern,
+            selectedMagazineCaliber: caliber,
+            firearmType: firearm?.firearmType ?? .other,
+            action: firearm?.firearmAction ?? .other,
+            caliber: firearm?.caliber,
+            firearmDescription: firearm?.displayName ?? "this firearm"
+        ).isCompatible else {
+            return false
+        }
         context.insert(magazine)
 
         do {
@@ -184,6 +245,37 @@ final class AddMagazineViewModel {
             return false
         }
 
+        let candidateMagazine = Magazine(
+            id: magazine.id,
+            brand: trimmedValue(brand),
+            modelName: trimmedValue(modelName),
+            count: count,
+            capacity: capacity,
+            purchaseDate: purchaseDate,
+            purchasePriceCents: purchasePriceCents,
+            color: color,
+            colorDetail: colorDetail,
+            notes: notes,
+            caliber: caliber,
+            firearm: firearm,
+            sortOrder: magazine.sortOrder,
+            createdAt: magazine.createdAt
+        )
+        candidateMagazine.patternID = magazine.patternID
+        candidateMagazine.patternKind = magazine.patternKind
+        candidateMagazine.patternDisplayName = magazine.patternDisplayName
+        MagazinePatternMigration.applyResolvedPattern(to: candidateMagazine)
+        guard compatibilityValidator.validate(
+            pattern: candidateMagazine.resolvedPattern,
+            selectedMagazineCaliber: caliber,
+            firearmType: firearm?.firearmType ?? .other,
+            action: firearm?.firearmAction ?? .other,
+            caliber: firearm?.caliber,
+            firearmDescription: firearm?.displayName ?? "this firearm"
+        ).isCompatible else {
+            return false
+        }
+
         magazine.brand = trimmedValue(brand)
         magazine.modelName = trimmedValue(modelName)
         magazine.count = count
@@ -195,7 +287,9 @@ final class AddMagazineViewModel {
         magazine.notes = notes
         magazine.caliber = caliber
         magazine.firearm = firearm
-        MagazinePatternMigration.applyResolvedPattern(to: magazine)
+        magazine.patternID = candidateMagazine.patternID
+        magazine.patternKind = candidateMagazine.patternKind
+        magazine.patternDisplayName = candidateMagazine.patternDisplayName
 
         do {
             try context.save()

--- a/ArmoryInventory/Accessories/Magazines/AddMagazineViewModel.swift
+++ b/ArmoryInventory/Accessories/Magazines/AddMagazineViewModel.swift
@@ -203,15 +203,17 @@ final class AddMagazineViewModel {
             sortOrder: nextSortOrder(in: context)
         )
         MagazinePatternMigration.applyResolvedPattern(to: magazine)
-        guard compatibilityValidator.validate(
-            pattern: magazine.resolvedPattern,
-            selectedMagazineCaliber: caliber,
-            firearmType: firearm?.firearmType ?? .other,
-            action: firearm?.firearmAction ?? .other,
-            caliber: firearm?.caliber,
-            firearmDescription: firearm?.displayName ?? "this firearm"
-        ).isCompatible else {
-            return false
+        if let firearm {
+            guard compatibilityValidator.validate(
+                pattern: magazine.resolvedPattern,
+                selectedMagazineCaliber: caliber,
+                firearmType: firearm.firearmType,
+                action: firearm.firearmAction,
+                caliber: firearm.caliber,
+                firearmDescription: firearm.displayName
+            ).isCompatible else {
+                return false
+            }
         }
         context.insert(magazine)
 
@@ -265,15 +267,17 @@ final class AddMagazineViewModel {
         candidateMagazine.patternKind = magazine.patternKind
         candidateMagazine.patternDisplayName = magazine.patternDisplayName
         MagazinePatternMigration.applyResolvedPattern(to: candidateMagazine)
-        guard compatibilityValidator.validate(
-            pattern: candidateMagazine.resolvedPattern,
-            selectedMagazineCaliber: caliber,
-            firearmType: firearm?.firearmType ?? .other,
-            action: firearm?.firearmAction ?? .other,
-            caliber: firearm?.caliber,
-            firearmDescription: firearm?.displayName ?? "this firearm"
-        ).isCompatible else {
-            return false
+        if let firearm {
+            guard compatibilityValidator.validate(
+                pattern: candidateMagazine.resolvedPattern,
+                selectedMagazineCaliber: caliber,
+                firearmType: firearm.firearmType,
+                action: firearm.firearmAction,
+                caliber: firearm.caliber,
+                firearmDescription: firearm.displayName
+            ).isCompatible else {
+                return false
+            }
         }
 
         magazine.brand = trimmedValue(brand)

--- a/ArmoryInventory/Accessories/Magazines/MagazineCompatibilityValidator.swift
+++ b/ArmoryInventory/Accessories/Magazines/MagazineCompatibilityValidator.swift
@@ -1,0 +1,132 @@
+//
+//  MagazineCompatibilityValidator.swift
+//  Armory Inventory
+//
+//  Created by Codex on 4/22/26.
+//
+
+import Foundation
+import SwiftData
+
+struct MagazineCompatibilityValidationResult: Equatable {
+    enum Failure: Equatable {
+        case linkedToDifferentFirearm(currentFirearmName: String)
+        case caliberMismatch(magazineCaliberName: String, firearmCaliberName: String)
+        case incompatiblePattern(patternName: String, firearmDescription: String)
+
+        var message: String {
+            switch self {
+            case let .linkedToDifferentFirearm(currentFirearmName):
+                return "This magazine is already linked to \(currentFirearmName)."
+            case let .caliberMismatch(magazineCaliberName, firearmCaliberName):
+                return "Magazine caliber \(magazineCaliberName) does not match firearm caliber \(firearmCaliberName)."
+            case let .incompatiblePattern(patternName, firearmDescription):
+                return "\(patternName) is not compatible with \(firearmDescription)."
+            }
+        }
+    }
+
+    let failure: Failure?
+
+    var isCompatible: Bool {
+        failure == nil
+    }
+
+    var message: String? {
+        failure?.message
+    }
+
+    static let compatible = MagazineCompatibilityValidationResult(failure: nil)
+}
+
+struct MagazineCompatibilityValidator {
+    func validate(
+        magazine: Magazine,
+        firearmType: FirearmType,
+        action: FirearmAction,
+        caliber: Caliber?,
+        owningFirearm: Firearm?
+    ) -> MagazineCompatibilityValidationResult {
+        if let linkedFirearm = magazine.firearm,
+           linkedFirearm.persistentModelID != owningFirearm?.persistentModelID {
+            return .init(failure: .linkedToDifferentFirearm(currentFirearmName: linkedFirearm.displayName))
+        }
+
+        return validate(
+            pattern: magazine.resolvedPattern,
+            selectedMagazineCaliber: magazine.caliber,
+            firearmType: firearmType,
+            action: action,
+            caliber: caliber,
+            firearmDescription: owningFirearm?.displayName ?? firearmDescription(type: firearmType, action: action)
+        )
+    }
+
+    func validate(
+        pattern: MagazinePattern,
+        selectedMagazineCaliber: Caliber?,
+        firearmType: FirearmType,
+        action: FirearmAction,
+        caliber: Caliber?,
+        firearmDescription: String
+    ) -> MagazineCompatibilityValidationResult {
+        if let selectedMagazineCaliberName = trimmedName(selectedMagazineCaliber?.name),
+           let firearmCaliberName = trimmedName(caliber?.name),
+           selectedMagazineCaliberName.caseInsensitiveCompare(firearmCaliberName) != .orderedSame {
+            return .init(
+                failure: .caliberMismatch(
+                    magazineCaliberName: selectedMagazineCaliberName,
+                    firearmCaliberName: firearmCaliberName
+                )
+            )
+        }
+
+        let effectiveCaliberName = trimmedName(caliber?.name) ?? trimmedName(selectedMagazineCaliber?.name)
+        guard pattern.isCompatible(with: firearmType, action: action, caliberName: effectiveCaliberName) else {
+            return .init(
+                failure: .incompatiblePattern(
+                    patternName: pattern.displayName,
+                    firearmDescription: firearmDescription
+                )
+            )
+        }
+
+        return .compatible
+    }
+
+    func firstFailure(
+        magazines: [Magazine],
+        firearmType: FirearmType,
+        action: FirearmAction,
+        caliber: Caliber?,
+        owningFirearm: Firearm?
+    ) -> MagazineCompatibilityValidationResult {
+        for magazine in magazines {
+            let result = validate(
+                magazine: magazine,
+                firearmType: firearmType,
+                action: action,
+                caliber: caliber,
+                owningFirearm: owningFirearm
+            )
+            if !result.isCompatible {
+                return result
+            }
+        }
+
+        return .compatible
+    }
+
+    private func firearmDescription(type: FirearmType, action: FirearmAction) -> String {
+        "\(type.displayName) (\(action.displayName))"
+    }
+
+    private func trimmedName(_ value: String?) -> String? {
+        guard let value else {
+            return nil
+        }
+
+        let trimmedValue = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmedValue.isEmpty ? nil : trimmedValue
+    }
+}

--- a/ArmoryInventory/Firearms/AddFirearmView.swift
+++ b/ArmoryInventory/Firearms/AddFirearmView.swift
@@ -278,12 +278,18 @@ struct AddFirearmView: View {
                         }
                     }
 
+                    if let compatibilityMessage = selectedMagazineCompatibilityMessage {
+                        Text(compatibilityMessage)
+                            .font(.footnote)
+                            .foregroundStyle(.red)
+                    }
+
                     if lookupData.magazines.isEmpty {
                         Text("Add magazines first to link them to this firearm.")
                             .font(.footnote)
                             .foregroundStyle(.secondary)
                     } else if availableMagazines.isEmpty {
-                        Text("No unlinked magazines available.")
+                        Text("No compatible magazines are currently available.")
                             .font(.footnote)
                             .foregroundStyle(.secondary)
                     } else if resolvedMagazines.isEmpty {
@@ -479,7 +485,7 @@ struct AddFirearmView: View {
                             ContentUnavailableView(
                                 "No Magazines Available",
                                 systemImage: "rectangle.stack.fill.badge.plus",
-                                description: Text("All saved magazines are linked to other firearms or none have been added yet.")
+                                description: Text("All compatible magazines are linked to other firearms or none have been added yet.")
                             )
                         } else {
                             List {
@@ -684,7 +690,24 @@ struct AddFirearmView: View {
     }
 
     private var availableMagazines: [Magazine] {
-        viewModel.availableMagazines(from: lookupData.magazines, selectedIDs: selectedMagazineIDs, firearm: firearm)
+        viewModel.availableMagazines(
+            from: lookupData.magazines,
+            selectedIDs: selectedMagazineIDs,
+            firearm: firearm,
+            firearmType: selectedType,
+            action: selectedAction,
+            caliber: selectedCaliber
+        )
+    }
+
+    private var selectedMagazineCompatibilityMessage: String? {
+        viewModel.selectedMagazineValidationResult(
+            magazines: resolvedMagazines,
+            firearmType: selectedType,
+            action: selectedAction,
+            caliber: selectedCaliber,
+            owningFirearm: firearm
+        ).message
     }
 
     private var availableAttachments: [Attachment] {
@@ -741,13 +764,17 @@ struct AddFirearmView: View {
             brand: brand,
             modelName: modelName,
             serialNumber: serialNumber,
+            selectedType: selectedType,
             selectedAction: selectedAction,
             actionDetail: resolvedActionDetail,
             selectedColor: selectedColor,
             colorDetail: resolvedColorDetail,
             purchasePriceText: purchasePriceText,
             barrelLengthText: barrelLengthText,
-            duplicateExists: duplicateExists
+            duplicateExists: duplicateExists,
+            magazines: resolvedMagazines,
+            caliber: selectedCaliber,
+            owningFirearm: firearm
         )
     }
 

--- a/ArmoryInventory/Firearms/AddFirearmViewModel.swift
+++ b/ArmoryInventory/Firearms/AddFirearmViewModel.swift
@@ -10,9 +10,14 @@ import SwiftData
 
 final class AddFirearmViewModel {
     private let priceInputParser: PriceInputParsing
+    private let compatibilityValidator: MagazineCompatibilityValidator
 
-    init(priceInputParser: PriceInputParsing = PriceInputParserService()) {
+    init(
+        priceInputParser: PriceInputParsing = PriceInputParserService(),
+        compatibilityValidator: MagazineCompatibilityValidator = MagazineCompatibilityValidator()
+    ) {
         self.priceInputParser = priceInputParser
+        self.compatibilityValidator = compatibilityValidator
     }
 
     func initialPurchasePriceText(for firearm: Firearm?) -> String {
@@ -138,23 +143,40 @@ final class AddFirearmViewModel {
     func availableMagazines(
         from magazines: [Magazine],
         selectedIDs: Set<PersistentIdentifier>,
-        firearm: Firearm?
+        firearm: Firearm?,
+        firearmType: FirearmType,
+        action: FirearmAction,
+        caliber: Caliber?
     ) -> [Magazine] {
         magazines.filter { magazine in
             if selectedIDs.contains(magazine.persistentModelID) {
                 return true
             }
 
-            guard let linkedFirearm = magazine.firearm else {
-                return true
-            }
-
-            guard let firearm else {
-                return false
-            }
-
-            return linkedFirearm.persistentModelID == firearm.persistentModelID
+            return compatibilityValidator.validate(
+                magazine: magazine,
+                firearmType: firearmType,
+                action: action,
+                caliber: caliber,
+                owningFirearm: firearm
+            ).isCompatible
         }
+    }
+
+    func selectedMagazineValidationResult(
+        magazines: [Magazine],
+        firearmType: FirearmType,
+        action: FirearmAction,
+        caliber: Caliber?,
+        owningFirearm: Firearm?
+    ) -> MagazineCompatibilityValidationResult {
+        compatibilityValidator.firstFailure(
+            magazines: magazines,
+            firearmType: firearmType,
+            action: action,
+            caliber: caliber,
+            owningFirearm: owningFirearm
+        )
     }
 
     func availableAttachments(
@@ -271,13 +293,17 @@ final class AddFirearmViewModel {
         brand: String,
         modelName: String,
         serialNumber: String,
+        selectedType: FirearmType,
         selectedAction: FirearmAction,
         actionDetail: String?,
         selectedColor: FirearmColor?,
         colorDetail: String?,
         purchasePriceText: String,
         barrelLengthText: String,
-        duplicateExists: Bool
+        duplicateExists: Bool,
+        magazines: [Magazine],
+        caliber: Caliber?,
+        owningFirearm: Firearm?
     ) -> Bool {
         guard !trimmedValue(brand).isEmpty else { return false }
         guard !trimmedValue(modelName).isEmpty else { return false }
@@ -294,7 +320,13 @@ final class AddFirearmViewModel {
             return false
         }
 
-        return true
+        return selectedMagazineValidationResult(
+            magazines: magazines,
+            firearmType: selectedType,
+            action: selectedAction,
+            caliber: caliber,
+            owningFirearm: owningFirearm
+        ).isCompatible
     }
 
     func addFirearm(
@@ -321,6 +353,15 @@ final class AddFirearmViewModel {
         to context: ModelContext
     ) -> Bool {
         guard canAdd else {
+            return false
+        }
+        guard selectedMagazineValidationResult(
+            magazines: magazines,
+            firearmType: type,
+            action: action,
+            caliber: caliber,
+            owningFirearm: nil
+        ).isCompatible else {
             return false
         }
 
@@ -383,6 +424,15 @@ final class AddFirearmViewModel {
         in context: ModelContext
     ) -> Bool {
         guard canSave else {
+            return false
+        }
+        guard selectedMagazineValidationResult(
+            magazines: magazines,
+            firearmType: type,
+            action: action,
+            caliber: caliber,
+            owningFirearm: firearm
+        ).isCompatible else {
             return false
         }
 

--- a/ArmoryInventoryTests/AccessoriesTests/AddMagazineViewModelTests.swift
+++ b/ArmoryInventoryTests/AccessoriesTests/AddMagazineViewModelTests.swift
@@ -38,7 +38,9 @@ final class AddMagazineViewModelTests: XCTestCase {
                 capacityText: "30",
                 selectedColor: nil,
                 colorDetail: nil,
-                purchasePriceText: "10"
+                purchasePriceText: "10",
+                selectedCaliber: nil,
+                firearm: nil
             )
         )
         XCTAssertFalse(
@@ -49,7 +51,9 @@ final class AddMagazineViewModelTests: XCTestCase {
                 capacityText: "30",
                 selectedColor: .other,
                 colorDetail: nil,
-                purchasePriceText: "10"
+                purchasePriceText: "10",
+                selectedCaliber: nil,
+                firearm: nil
             )
         )
         XCTAssertTrue(
@@ -60,7 +64,37 @@ final class AddMagazineViewModelTests: XCTestCase {
                 capacityText: "30",
                 selectedColor: .black,
                 colorDetail: nil,
-                purchasePriceText: "10"
+                purchasePriceText: "10",
+                selectedCaliber: nil,
+                firearm: nil
+            )
+        )
+    }
+
+    func testCanAddReturnsFalseForMagazineCaliberMismatchAgainstLinkedFirearm() {
+        let viewModel = AddMagazineViewModel()
+        let magazineCaliber = Caliber(name: "9mm")
+        let firearmCaliber = Caliber(name: ".45 ACP")
+        let firearm = Firearm(
+            brand: "Staccato",
+            modelName: "P",
+            purchasePriceCents: 250000,
+            type: .pistol,
+            action: .semiAuto,
+            caliber: firearmCaliber
+        )
+
+        XCTAssertFalse(
+            viewModel.canAdd(
+                brand: "Atlas",
+                modelName: "2011",
+                countText: "2",
+                capacityText: "20",
+                selectedColor: .black,
+                colorDetail: nil,
+                purchasePriceText: "75",
+                selectedCaliber: magazineCaliber,
+                firearm: firearm
             )
         )
     }
@@ -206,5 +240,58 @@ final class AddMagazineViewModelTests: XCTestCase {
         XCTAssertEqual(magazine.storedPatternKind, .legacy)
         XCTAssertEqual(magazine.patternID, "legacy:atlas-premium")
         XCTAssertEqual(magazine.patternDisplayName, "Atlas Premium")
+    }
+
+    @MainActor
+    func testUpdateMagazineReturnsFalseWithoutMutatingWhenCompatibilityFails() throws {
+        let container = try makeInMemoryContainer()
+        let context = container.mainContext
+        let originalCaliber = Caliber(name: "9mm")
+        let firearmCaliber = Caliber(name: ".45 ACP")
+        let firearm = Firearm(
+            brand: "Staccato",
+            modelName: "P",
+            purchasePriceCents: 250000,
+            type: .pistol,
+            action: .semiAuto,
+            caliber: firearmCaliber
+        )
+        let magazine = Magazine(
+            brand: "Glock",
+            modelName: "OEM",
+            count: 2,
+            capacity: 17,
+            purchasePriceCents: 5000,
+            caliber: originalCaliber
+        )
+        context.insert(originalCaliber)
+        context.insert(firearmCaliber)
+        context.insert(firearm)
+        context.insert(magazine)
+
+        let viewModel = AddMagazineViewModel()
+        let didSave = viewModel.updateMagazine(
+            magazine,
+            brand: "Atlas",
+            modelName: "2011",
+            count: 3,
+            capacity: 20,
+            purchaseDate: Date(timeIntervalSince1970: 9_999),
+            purchasePriceCents: 21000,
+            color: .black,
+            colorDetail: nil,
+            notes: "Updated",
+            caliber: originalCaliber,
+            firearm: firearm,
+            canSave: true,
+            in: context
+        )
+
+        XCTAssertFalse(didSave)
+        XCTAssertEqual(magazine.brand, "Glock")
+        XCTAssertEqual(magazine.modelName, "OEM")
+        XCTAssertEqual(magazine.count, 2)
+        XCTAssertEqual(magazine.capacity, 17)
+        XCTAssertNil(magazine.firearm)
     }
 }

--- a/ArmoryInventoryTests/AccessoriesTests/AddMagazineViewModelTests.swift
+++ b/ArmoryInventoryTests/AccessoriesTests/AddMagazineViewModelTests.swift
@@ -175,6 +175,39 @@ final class AddMagazineViewModelTests: XCTestCase {
     }
 
     @MainActor
+    func testAddMagazineAllowsUnlinkedCatalogPatternMagazine() throws {
+        let container = try makeInMemoryContainer()
+        let context = container.mainContext
+        let caliber = Caliber(name: "5.56 NATO")
+        context.insert(caliber)
+
+        let viewModel = AddMagazineViewModel()
+        let didAdd = viewModel.addMagazine(
+            brand: "Magpul",
+            modelName: "PMAG",
+            count: 3,
+            capacity: 30,
+            purchaseDate: .now,
+            purchasePriceCents: 4500,
+            color: .black,
+            colorDetail: nil,
+            notes: nil,
+            caliber: caliber,
+            firearm: nil,
+            canAdd: true,
+            to: context
+        )
+
+        let magazines = try context.fetch(FetchDescriptor<Magazine>())
+
+        XCTAssertTrue(didAdd)
+        XCTAssertEqual(magazines.count, 1)
+        XCTAssertNil(magazines.first?.firearm)
+        XCTAssertEqual(magazines.first?.storedPatternKind, .catalog)
+        XCTAssertEqual(magazines.first?.patternID, "catalog:ar15-stanag-223-556-300blk")
+    }
+
+    @MainActor
     func testUpdateMagazinePersistsEditedValues() throws {
         let container = try makeInMemoryContainer()
         let context = container.mainContext
@@ -293,5 +326,56 @@ final class AddMagazineViewModelTests: XCTestCase {
         XCTAssertEqual(magazine.count, 2)
         XCTAssertEqual(magazine.capacity, 17)
         XCTAssertNil(magazine.firearm)
+    }
+
+    @MainActor
+    func testUpdateMagazineAllowsUnlinkingCatalogPatternMagazine() throws {
+        let container = try makeInMemoryContainer()
+        let context = container.mainContext
+        let caliber = Caliber(name: "5.56 NATO")
+        let firearm = Firearm(
+            brand: "Daniel Defense",
+            modelName: "DDM4",
+            purchasePriceCents: 180000,
+            type: .rifle,
+            action: .semiAuto,
+            caliber: caliber
+        )
+        let magazine = Magazine(
+            brand: "Magpul",
+            modelName: "PMAG",
+            patternID: "catalog:ar15-stanag-223-556-300blk",
+            patternKind: .catalog,
+            capacity: 30,
+            purchasePriceCents: 1500,
+            caliber: caliber,
+            firearm: firearm
+        )
+        context.insert(caliber)
+        context.insert(firearm)
+        context.insert(magazine)
+
+        let viewModel = AddMagazineViewModel()
+        let didSave = viewModel.updateMagazine(
+            magazine,
+            brand: "Magpul",
+            modelName: "PMAG",
+            count: 1,
+            capacity: 30,
+            purchaseDate: .now,
+            purchasePriceCents: 1500,
+            color: nil,
+            colorDetail: nil,
+            notes: nil,
+            caliber: caliber,
+            firearm: nil,
+            canSave: true,
+            in: context
+        )
+
+        XCTAssertTrue(didSave)
+        XCTAssertNil(magazine.firearm)
+        XCTAssertEqual(magazine.storedPatternKind, .catalog)
+        XCTAssertEqual(magazine.patternID, "catalog:ar15-stanag-223-556-300blk")
     }
 }

--- a/ArmoryInventoryTests/AccessoriesTests/MagazineCompatibilityValidatorTests.swift
+++ b/ArmoryInventoryTests/AccessoriesTests/MagazineCompatibilityValidatorTests.swift
@@ -1,0 +1,114 @@
+//
+//  MagazineCompatibilityValidatorTests.swift
+//  Armory InventoryTests
+//
+//  Created by Codex on 4/22/26.
+//
+
+import XCTest
+@testable import ArmoryInventory
+
+final class MagazineCompatibilityValidatorTests: XCTestCase {
+    func testValidateReturnsLinkedToDifferentFirearmFailure() {
+        let validator = MagazineCompatibilityValidator()
+        let currentFirearm = Firearm(
+            brand: "Glock",
+            modelName: "19",
+            purchasePriceCents: 50000,
+            type: .pistol,
+            action: .semiAuto
+        )
+        let otherFirearm = Firearm(
+            brand: "SIG",
+            modelName: "P320",
+            purchasePriceCents: 65000,
+            type: .pistol,
+            action: .semiAuto
+        )
+        let magazine = Magazine(
+            brand: "SIG",
+            modelName: "OEM",
+            capacity: 17,
+            purchasePriceCents: 4500,
+            caliber: Caliber(name: "9mm"),
+            firearm: otherFirearm
+        )
+
+        let result = validator.validate(
+            magazine: magazine,
+            firearmType: .pistol,
+            action: .semiAuto,
+            caliber: currentFirearm.caliber,
+            owningFirearm: currentFirearm
+        )
+
+        XCTAssertEqual(
+            result.failure,
+            .linkedToDifferentFirearm(currentFirearmName: otherFirearm.displayName)
+        )
+    }
+
+    func testValidateReturnsCaliberMismatchFailure() {
+        let validator = MagazineCompatibilityValidator()
+        let result = validator.validate(
+            pattern: .legacy(displayName: "Atlas 2011"),
+            selectedMagazineCaliber: Caliber(name: "9mm"),
+            firearmType: .pistol,
+            action: .semiAuto,
+            caliber: Caliber(name: ".45 ACP"),
+            firearmDescription: "Staccato P"
+        )
+
+        XCTAssertEqual(
+            result.failure,
+            .caliberMismatch(magazineCaliberName: "9mm", firearmCaliberName: ".45 ACP")
+        )
+    }
+
+    func testValidateReturnsIncompatiblePatternFailure() {
+        let validator = MagazineCompatibilityValidator()
+        let arPattern = MagazinePattern(
+            id: "catalog:test-ar-pattern",
+            kind: .catalog,
+            displayName: "Test AR Pattern",
+            familyLabel: "AR-15 STANAG",
+            compatibility: MagazinePatternCompatibility(
+                supportedCaliberNames: ["5.56 NATO"],
+                compatibleFirearmTypes: [.rifle],
+                compatibleFirearmActions: [.semiAuto],
+                platformTags: ["AR-15"],
+                fitDescriptors: ["standard rifle magazine"]
+            ),
+            aliases: [],
+            notes: nil
+        )
+        let result = validator.validate(
+            pattern: arPattern,
+            selectedMagazineCaliber: Caliber(name: "5.56 NATO"),
+            firearmType: .pistol,
+            action: .semiAuto,
+            caliber: Caliber(name: "5.56 NATO"),
+            firearmDescription: "Glock 19"
+        )
+
+        XCTAssertEqual(
+            result.failure,
+            .incompatiblePattern(patternName: "Test AR Pattern", firearmDescription: "Glock 19")
+        )
+    }
+
+    func testValidateReturnsCompatibleForMatchingPatternAndCaliber() {
+        let validator = MagazineCompatibilityValidator()
+        let result = validator.validate(
+            pattern: MagazinePatternCatalog.canonicalPatterns.first { $0.id == "catalog:glock-double-stack-9mm-full-size-compact" }!,
+            selectedMagazineCaliber: Caliber(name: "9mm"),
+            firearmType: .pistol,
+            action: .semiAuto,
+            caliber: Caliber(name: "9mm"),
+            firearmDescription: "Glock 19"
+        )
+
+        XCTAssertTrue(result.isCompatible)
+        XCTAssertNil(result.message)
+    }
+}

--- a/ArmoryInventoryTests/FirearmsTests/AddFirearmViewModelTests.swift
+++ b/ArmoryInventoryTests/FirearmsTests/AddFirearmViewModelTests.swift
@@ -41,13 +41,17 @@ final class AddFirearmViewModelTests: XCTestCase {
                 brand: "Glock",
                 modelName: "19",
                 serialNumber: "ABC123",
+                selectedType: .pistol,
                 selectedAction: .semiAuto,
                 actionDetail: nil,
                 selectedColor: nil,
                 colorDetail: nil,
                 purchasePriceText: "bad",
                 barrelLengthText: "bad",
-                duplicateExists: false
+                duplicateExists: false,
+                magazines: [],
+                caliber: nil,
+                owningFirearm: nil
             )
         )
         XCTAssertFalse(
@@ -55,13 +59,17 @@ final class AddFirearmViewModelTests: XCTestCase {
                 brand: "Glock",
                 modelName: "19",
                 serialNumber: "ABC123",
+                selectedType: .pistol,
                 selectedAction: .other,
                 actionDetail: nil,
                 selectedColor: nil,
                 colorDetail: nil,
                 purchasePriceText: "100",
                 barrelLengthText: "",
-                duplicateExists: false
+                duplicateExists: false,
+                magazines: [],
+                caliber: nil,
+                owningFirearm: nil
             )
         )
         XCTAssertTrue(
@@ -69,13 +77,17 @@ final class AddFirearmViewModelTests: XCTestCase {
                 brand: "Glock",
                 modelName: "19",
                 serialNumber: "",
+                selectedType: .pistol,
                 selectedAction: .semiAuto,
                 actionDetail: nil,
                 selectedColor: nil,
                 colorDetail: nil,
                 purchasePriceText: "100",
                 barrelLengthText: "",
-                duplicateExists: false
+                duplicateExists: false,
+                magazines: [],
+                caliber: nil,
+                owningFirearm: nil
             )
         )
         XCTAssertFalse(
@@ -83,13 +95,17 @@ final class AddFirearmViewModelTests: XCTestCase {
                 brand: "Glock",
                 modelName: "19",
                 serialNumber: "ABC123",
+                selectedType: .pistol,
                 selectedAction: .semiAuto,
                 actionDetail: nil,
                 selectedColor: .other,
                 colorDetail: nil,
                 purchasePriceText: "100",
                 barrelLengthText: "",
-                duplicateExists: false
+                duplicateExists: false,
+                magazines: [],
+                caliber: nil,
+                owningFirearm: nil
             )
         )
     }
@@ -143,17 +159,21 @@ final class AddFirearmViewModelTests: XCTestCase {
             purchasePriceCents: 55000,
             firearm: otherFirearm
         )
+        let rifleCaliber = Caliber(name: "5.56 NATO")
+        let pistolCaliber = Caliber(name: "9mm")
         let freeMagazine = Magazine(
             brand: "Magpul",
             modelName: "PMAG",
             capacity: 30,
-            purchasePriceCents: 1500
+            purchasePriceCents: 1500,
+            caliber: rifleCaliber
         )
         let currentMagazine = Magazine(
             brand: "Glock",
             modelName: "OEM",
             capacity: 17,
             purchasePriceCents: 2500,
+            caliber: pistolCaliber,
             firearm: currentFirearm
         )
         let otherMagazine = Magazine(
@@ -161,6 +181,7 @@ final class AddFirearmViewModelTests: XCTestCase {
             modelName: "CZ 75",
             capacity: 16,
             purchasePriceCents: 3200,
+            caliber: pistolCaliber,
             firearm: otherFirearm
         )
         let freeAttachment = Attachment(
@@ -206,6 +227,8 @@ final class AddFirearmViewModelTests: XCTestCase {
 
         context.insert(currentFirearm)
         context.insert(otherFirearm)
+        context.insert(rifleCaliber)
+        context.insert(pistolCaliber)
         context.insert(freeOptic)
         context.insert(currentOptic)
         context.insert(otherOptic)
@@ -250,12 +273,15 @@ final class AddFirearmViewModelTests: XCTestCase {
             Set(
                 viewModel.availableMagazines(
                     from: [freeMagazine, currentMagazine, otherMagazine],
-                    selectedIDs: [],
-                    firearm: currentFirearm
+                    selectedIDs: selectedMagazineIDs,
+                    firearm: currentFirearm,
+                    firearmType: .pistol,
+                    action: .semiAuto,
+                    caliber: currentMagazine.caliber
                 )
                 .map(\.persistentModelID)
             ),
-            [freeMagazine.persistentModelID, currentMagazine.persistentModelID]
+            [currentMagazine.persistentModelID]
         )
         XCTAssertEqual(
             Set(
@@ -572,5 +598,95 @@ final class AddFirearmViewModelTests: XCTestCase {
         XCTAssertEqual(firearm.colorDetail, "Two Tone")
         XCTAssertEqual(firearm.caliber?.name, ".45 ACP")
         XCTAssertEqual(firearm.notes, "Updated")
+    }
+
+    func testCanAddReturnsFalseForSelectedMagazineCompatibilityFailure() {
+        let viewModel = AddFirearmViewModel()
+        let caliber = Caliber(name: "9mm")
+        let incompatibleMagazine = Magazine(
+            brand: "Magpul",
+            modelName: "PMAG",
+            capacity: 30,
+            purchasePriceCents: 1500,
+            caliber: Caliber(name: "5.56 NATO")
+        )
+
+        XCTAssertFalse(
+            viewModel.canAdd(
+                brand: "Glock",
+                modelName: "19",
+                serialNumber: "",
+                selectedType: .pistol,
+                selectedAction: .semiAuto,
+                actionDetail: nil,
+                selectedColor: nil,
+                colorDetail: nil,
+                purchasePriceText: "500",
+                barrelLengthText: "",
+                duplicateExists: false,
+                magazines: [incompatibleMagazine],
+                caliber: caliber,
+                owningFirearm: nil
+            )
+        )
+    }
+
+    @MainActor
+    func testUpdateFirearmReturnsFalseWithoutMutatingWhenSelectedMagazineBecomesInvalid() throws {
+        let container = try makeInMemoryContainer()
+        let context = container.mainContext
+        let originalCaliber = Caliber(name: "9mm")
+        let updatedCaliber = Caliber(name: ".45 ACP")
+        let firearm = Firearm(
+            brand: "Glock",
+            modelName: "19",
+            purchasePriceCents: 50000,
+            type: .pistol,
+            action: .semiAuto,
+            caliber: originalCaliber
+        )
+        let magazine = Magazine(
+            brand: "Glock",
+            modelName: "OEM",
+            capacity: 17,
+            purchasePriceCents: 2500,
+            caliber: originalCaliber,
+            firearm: firearm
+        )
+        context.insert(originalCaliber)
+        context.insert(updatedCaliber)
+        context.insert(firearm)
+        context.insert(magazine)
+
+        let viewModel = AddFirearmViewModel()
+        let didSave = viewModel.updateFirearm(
+            firearm,
+            brand: "Staccato",
+            modelName: "P",
+            nickname: nil,
+            serialNumber: "",
+            purchaseDate: .now,
+            lastCleanedDate: nil,
+            purchasePriceCents: 250000,
+            type: .pistol,
+            action: .semiAuto,
+            actionDetail: nil,
+            color: nil,
+            colorDetail: nil,
+            barrelLengthInches: 4.4,
+            notes: nil,
+            caliber: updatedCaliber,
+            optics: [],
+            magazines: [magazine],
+            attachments: [],
+            parts: [],
+            canSave: true,
+            in: context
+        )
+
+        XCTAssertFalse(didSave)
+        XCTAssertEqual(firearm.brand, "Glock")
+        XCTAssertEqual(firearm.modelName, "19")
+        XCTAssertEqual(firearm.caliber?.name, "9mm")
     }
 }


### PR DESCRIPTION
## Summary
- add a shared `MagazineCompatibilityValidator` used by both firearm and magazine flows
- validate selected and linked magazines in the UI and again on save so invalid combinations are blocked consistently
- surface clear compatibility messages and add regression coverage for filtering, save blocking, and backward-compatible behavior

## Testing
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test -scheme 'Armory Inventory' -destination 'platform=iOS Simulator,name=iPhone 17,OS=26.4.1' -only-testing:ArmoryInventoryTests/MagazineCompatibilityValidatorTests -only-testing:ArmoryInventoryTests/AddMagazineViewModelTests -only-testing:ArmoryInventoryTests/AddFirearmViewModelTests -only-testing:ArmoryInventoryTests/MagazinePatternModelsTests -only-testing:ArmoryInventoryTests/MagazinePatternMigrationTests`

Closes #21