### PR TITLE
Update magazine UI for pattern-driven selection

### DIFF
--- a/ArmoryInventory/Accessories/Magazines/AddMagazineView.swift
+++ b/ArmoryInventory/Accessories/Magazines/AddMagazineView.swift
@@ -19,7 +19,7 @@ struct AddMagazineView: View {
     @State private var modelName = ""
     @State private var countText = "1"
     @State private var capacityText = ""
-    @State private var selectedPatternSelection: MagazinePatternSelection = .automatic
+    @State private var selectedPatternSelection: MagazinePatternSelection = .custom
     @State private var manualPatternName = ""
     @State private var selectedCompatibleCaliberNames: Set<String> = []
     @State private var selectedColor: FirearmColor?
@@ -85,16 +85,6 @@ struct AddMagazineView: View {
                 Section("Configuration") {
                     LabeledContent("Pattern") {
                         Menu {
-                            Button {
-                                editingCustomPatternID = nil
-                                selectedPatternSelection = .automatic
-                            } label: {
-                                patternSelectionLabel(
-                                    title: "Automatic",
-                                    isSelected: selectedPatternSelection == .automatic
-                                )
-                            }
-
                             if !suggestedCatalogPatterns.isEmpty {
                                 Section("Suggested Catalog Patterns") {
                                     ForEach(suggestedCatalogPatterns) { pattern in
@@ -143,17 +133,7 @@ struct AddMagazineView: View {
                                 }
                             }
 
-                            Section("Manual Patterns") {
-                                Button {
-                                    editingCustomPatternID = nil
-                                    selectedPatternSelection = .legacy
-                                } label: {
-                                    patternSelectionLabel(
-                                        title: "Legacy Pattern",
-                                        isSelected: selectedPatternSelection == .legacy
-                                    )
-                                }
-
+                            Section("Custom Patterns") {
                                 Button {
                                     editingCustomPatternID = nil
                                     selectedPatternSelection = .custom

--- a/ArmoryInventory/Accessories/Magazines/AddMagazineView.swift
+++ b/ArmoryInventory/Accessories/Magazines/AddMagazineView.swift
@@ -31,6 +31,7 @@ struct AddMagazineView: View {
     @State private var isEditing = false
     @State private var calibers: [Caliber] = []
     @State private var savedCustomPatterns: [MagazinePattern] = []
+    @State private var editingCustomPatternID: UUID?
 
     let viewModel: AddMagazineViewModel
     private let caliberQueryService: CaliberQueryServicing
@@ -85,6 +86,7 @@ struct AddMagazineView: View {
                     LabeledContent("Pattern") {
                         Menu {
                             Button {
+                                editingCustomPatternID = nil
                                 selectedPatternSelection = .automatic
                             } label: {
                                 patternSelectionLabel(
@@ -97,6 +99,7 @@ struct AddMagazineView: View {
                                 Section("Suggested Catalog Patterns") {
                                     ForEach(suggestedCatalogPatterns) { pattern in
                                         Button {
+                                            editingCustomPatternID = nil
                                             selectedPatternSelection = .catalog(pattern.id)
                                         } label: {
                                             patternSelectionLabel(
@@ -112,6 +115,7 @@ struct AddMagazineView: View {
                                 Section("Other Catalog Patterns") {
                                     ForEach(additionalCatalogPatterns) { pattern in
                                         Button {
+                                            editingCustomPatternID = nil
                                             selectedPatternSelection = .catalog(pattern.id)
                                         } label: {
                                             patternSelectionLabel(
@@ -127,6 +131,7 @@ struct AddMagazineView: View {
                                 Section("Saved Custom Patterns") {
                                     ForEach(savedCustomPatterns) { pattern in
                                         Button {
+                                            editingCustomPatternID = nil
                                             selectedPatternSelection = .existingCustom(pattern)
                                         } label: {
                                             patternSelectionLabel(
@@ -140,6 +145,7 @@ struct AddMagazineView: View {
 
                             Section("Manual Patterns") {
                                 Button {
+                                    editingCustomPatternID = nil
                                     selectedPatternSelection = .legacy
                                 } label: {
                                     patternSelectionLabel(
@@ -149,6 +155,7 @@ struct AddMagazineView: View {
                                 }
 
                                 Button {
+                                    editingCustomPatternID = nil
                                     selectedPatternSelection = .custom
                                 } label: {
                                     patternSelectionLabel(
@@ -177,6 +184,14 @@ struct AddMagazineView: View {
                         LabeledContent(selectedPatternSelection == .legacy ? "Legacy Name" : "Custom Name") {
                             TextField("", text: $manualPatternName)
                                 .multilineTextAlignment(.trailing)
+                        }
+                    }
+
+                    if case let .existingCustom(pattern) = selectedPatternSelection, isEditing {
+                        Button {
+                            beginEditingCustomPattern(pattern)
+                        } label: {
+                            Text("Edit Saved Pattern")
                         }
                     }
 
@@ -433,6 +448,7 @@ struct AddMagazineView: View {
                 patternSelection: selectedPatternSelection,
                 manualPatternName: manualPatternName,
                 compatibleCaliberNames: selectedCompatibleCaliberNames,
+                existingCustomPatternIDOverride: editingCustomPatternID,
                 firearm: linkedFirearm,
                 canSave: canAdd,
                 in: context
@@ -451,6 +467,7 @@ struct AddMagazineView: View {
                 patternSelection: selectedPatternSelection,
                 manualPatternName: manualPatternName,
                 compatibleCaliberNames: selectedCompatibleCaliberNames,
+                existingCustomPatternIDOverride: editingCustomPatternID,
                 firearm: nil,
                 canAdd: canAdd,
                 to: context
@@ -495,6 +512,13 @@ struct AddMagazineView: View {
     private func reloadPickerData() {
         reloadCalibers()
         savedCustomPatterns = viewModel.availableCustomPatterns(in: context)
+    }
+
+    private func beginEditingCustomPattern(_ pattern: MagazinePattern) {
+        selectedPatternSelection = .custom
+        manualPatternName = pattern.displayName
+        selectedCompatibleCaliberNames = Set(pattern.compatibility.supportedCaliberNames)
+        editingCustomPatternID = viewModel.customPatternUUID(from: pattern.id)
     }
 
     @ViewBuilder

--- a/ArmoryInventory/Accessories/Magazines/AddMagazineView.swift
+++ b/ArmoryInventory/Accessories/Magazines/AddMagazineView.swift
@@ -19,9 +19,9 @@ struct AddMagazineView: View {
     @State private var modelName = ""
     @State private var countText = "1"
     @State private var capacityText = ""
-    @State private var selectedCaliber: Caliber?
     @State private var selectedPatternSelection: MagazinePatternSelection = .automatic
     @State private var manualPatternName = ""
+    @State private var selectedCompatibleCaliberNames: Set<String> = []
     @State private var selectedColor: FirearmColor?
     @State private var customColor = ""
     @State private var purchaseDate = Date.now
@@ -46,9 +46,9 @@ struct AddMagazineView: View {
         _modelName = State(initialValue: magazine?.modelName ?? "")
         _countText = State(initialValue: magazine.map { String($0.count) } ?? "1")
         _capacityText = State(initialValue: magazine.map { String($0.capacity) } ?? "")
-        _selectedCaliber = State(initialValue: magazine?.caliber)
         _selectedPatternSelection = State(initialValue: viewModel.initialPatternSelection(for: magazine))
         _manualPatternName = State(initialValue: viewModel.initialManualPatternName(for: magazine))
+        _selectedCompatibleCaliberNames = State(initialValue: viewModel.initialCompatibleCaliberNames(for: magazine))
         _selectedColor = State(initialValue: magazine?.magazineColor)
         _customColor = State(initialValue: magazine?.magazineColor == .other ? magazine?.colorDetail ?? "" : "")
         _purchaseDate = State(initialValue: magazine?.purchaseDate ?? .now)
@@ -81,13 +81,6 @@ struct AddMagazineView: View {
                 .disabled(isReadOnly)
 
                 Section("Configuration") {
-                    Picker("Caliber", selection: $selectedCaliber) {
-                        Text("None").tag(nil as Caliber?)
-                        ForEach(calibers) { caliber in
-                            Text(caliber.name).tag(Optional(caliber))
-                        }
-                    }
-
                     LabeledContent("Pattern") {
                         Menu {
                             Button {
@@ -169,6 +162,34 @@ struct AddMagazineView: View {
                             TextField("", text: $manualPatternName)
                                 .multilineTextAlignment(.trailing)
                         }
+                    }
+
+                    if selectedPatternSelection.allowsManualCaliberSelection {
+                        LabeledContent("Compatible Calibers") {
+                            Menu {
+                                ForEach(calibers) { caliber in
+                                    Button {
+                                        toggleCompatibleCaliberSelection(for: caliber.name)
+                                    } label: {
+                                        patternSelectionLabel(
+                                            title: caliber.name,
+                                            isSelected: selectedCompatibleCaliberNames.contains(caliber.name)
+                                        )
+                                    }
+                                }
+                            } label: {
+                                HStack(spacing: 6) {
+                                    Text(selectedCompatibleCaliberSummary)
+                                        .foregroundStyle(selectedCompatibleCaliberNames.isEmpty ? .secondary : .primary)
+                                    Image(systemName: "chevron.down")
+                                        .font(.caption.weight(.semibold))
+                                        .foregroundStyle(.secondary)
+                                }
+                            }
+                            .buttonStyle(.plain)
+                        }
+                    } else {
+                        LabeledContent("Compatible Calibers", value: selectedCompatibleCaliberSummary)
                     }
 
                     LabeledContent("Capacity") {
@@ -306,7 +327,7 @@ struct AddMagazineView: View {
             purchasePriceText: purchasePriceText,
             patternSelection: selectedPatternSelection,
             manualPatternName: manualPatternName,
-            selectedCaliber: selectedCaliber,
+            compatibleCaliberNames: selectedCompatibleCaliberNames,
             firearm: linkedFirearm,
             existingMagazine: magazine
         )
@@ -318,18 +339,18 @@ struct AddMagazineView: View {
             manualPatternName: manualPatternName,
             brand: brand,
             modelName: modelName,
-            selectedCaliber: selectedCaliber,
+            compatibleCaliberNames: selectedCompatibleCaliberNames,
             firearm: linkedFirearm,
             existingMagazine: magazine
         ).message
     }
 
     private var suggestedCatalogPatterns: [MagazinePattern] {
-        viewModel.suggestedCatalogPatterns(selectedCaliber: selectedCaliber, firearm: linkedFirearm)
+        viewModel.suggestedCatalogPatterns(firearm: linkedFirearm)
     }
 
     private var additionalCatalogPatterns: [MagazinePattern] {
-        viewModel.additionalCatalogPatterns(selectedCaliber: selectedCaliber, firearm: linkedFirearm)
+        viewModel.additionalCatalogPatterns(firearm: linkedFirearm)
     }
 
     private var selectedPatternTitle: String {
@@ -338,7 +359,7 @@ struct AddMagazineView: View {
             manualPatternName: manualPatternName,
             brand: brand,
             modelName: modelName,
-            selectedCaliber: selectedCaliber,
+            compatibleCaliberNames: selectedCompatibleCaliberNames,
             firearm: linkedFirearm,
             existingMagazine: magazine
         )
@@ -350,10 +371,27 @@ struct AddMagazineView: View {
             manualPatternName: manualPatternName,
             brand: brand,
             modelName: modelName,
-            selectedCaliber: selectedCaliber,
+            compatibleCaliberNames: selectedCompatibleCaliberNames,
             firearm: linkedFirearm,
             existingMagazine: magazine
         )
+    }
+
+    private var selectedCompatibleCaliberSummary: String {
+        let names = viewModel.resolvedSupportedCaliberNames(
+            selection: selectedPatternSelection,
+            manualPatternName: manualPatternName,
+            brand: brand,
+            modelName: modelName,
+            compatibleCaliberNames: selectedCompatibleCaliberNames,
+            firearm: linkedFirearm,
+            existingMagazine: magazine
+        )
+        guard !names.isEmpty else {
+            return selectedPatternSelection.allowsManualCaliberSelection ? "None" : "No Caliber"
+        }
+
+        return names.joined(separator: ", ")
     }
 
     private func saveMagazine() {
@@ -378,7 +416,7 @@ struct AddMagazineView: View {
                 notes: resolvedNotes,
                 patternSelection: selectedPatternSelection,
                 manualPatternName: manualPatternName,
-                caliber: selectedCaliber,
+                compatibleCaliberNames: selectedCompatibleCaliberNames,
                 firearm: linkedFirearm,
                 canSave: canAdd,
                 in: context
@@ -396,7 +434,7 @@ struct AddMagazineView: View {
                 notes: resolvedNotes,
                 patternSelection: selectedPatternSelection,
                 manualPatternName: manualPatternName,
-                caliber: selectedCaliber,
+                compatibleCaliberNames: selectedCompatibleCaliberNames,
                 firearm: nil,
                 canAdd: canAdd,
                 to: context
@@ -420,6 +458,14 @@ struct AddMagazineView: View {
             return
         }
         saveMagazine()
+    }
+
+    private func toggleCompatibleCaliberSelection(for caliberName: String) {
+        selectedCompatibleCaliberNames = viewModel.toggledCompatibleCaliberSelection(
+            currentSelection: selectedCompatibleCaliberNames,
+            caliberName: caliberName,
+            isEditing: isEditing
+        )
     }
 
     private func reloadCalibers() {

--- a/ArmoryInventory/Accessories/Magazines/AddMagazineView.swift
+++ b/ArmoryInventory/Accessories/Magazines/AddMagazineView.swift
@@ -20,6 +20,8 @@ struct AddMagazineView: View {
     @State private var countText = "1"
     @State private var capacityText = ""
     @State private var selectedCaliber: Caliber?
+    @State private var selectedPatternSelection: MagazinePatternSelection = .automatic
+    @State private var manualPatternName = ""
     @State private var selectedColor: FirearmColor?
     @State private var customColor = ""
     @State private var purchaseDate = Date.now
@@ -45,6 +47,8 @@ struct AddMagazineView: View {
         _countText = State(initialValue: magazine.map { String($0.count) } ?? "1")
         _capacityText = State(initialValue: magazine.map { String($0.capacity) } ?? "")
         _selectedCaliber = State(initialValue: magazine?.caliber)
+        _selectedPatternSelection = State(initialValue: viewModel.initialPatternSelection(for: magazine))
+        _manualPatternName = State(initialValue: viewModel.initialManualPatternName(for: magazine))
         _selectedColor = State(initialValue: magazine?.magazineColor)
         _customColor = State(initialValue: magazine?.magazineColor == .other ? magazine?.colorDetail ?? "" : "")
         _purchaseDate = State(initialValue: magazine?.purchaseDate ?? .now)
@@ -81,6 +85,89 @@ struct AddMagazineView: View {
                         Text("None").tag(nil as Caliber?)
                         ForEach(calibers) { caliber in
                             Text(caliber.name).tag(Optional(caliber))
+                        }
+                    }
+
+                    LabeledContent("Pattern") {
+                        Menu {
+                            Button {
+                                selectedPatternSelection = .automatic
+                            } label: {
+                                patternSelectionLabel(
+                                    title: "Automatic",
+                                    isSelected: selectedPatternSelection == .automatic
+                                )
+                            }
+
+                            if !suggestedCatalogPatterns.isEmpty {
+                                Section("Suggested Catalog Patterns") {
+                                    ForEach(suggestedCatalogPatterns) { pattern in
+                                        Button {
+                                            selectedPatternSelection = .catalog(pattern.id)
+                                        } label: {
+                                            patternSelectionLabel(
+                                                title: pattern.displayName,
+                                                isSelected: selectedPatternSelection == .catalog(pattern.id)
+                                            )
+                                        }
+                                    }
+                                }
+                            }
+
+                            if !additionalCatalogPatterns.isEmpty {
+                                Section("Other Catalog Patterns") {
+                                    ForEach(additionalCatalogPatterns) { pattern in
+                                        Button {
+                                            selectedPatternSelection = .catalog(pattern.id)
+                                        } label: {
+                                            patternSelectionLabel(
+                                                title: pattern.displayName,
+                                                isSelected: selectedPatternSelection == .catalog(pattern.id)
+                                            )
+                                        }
+                                    }
+                                }
+                            }
+
+                            Section("Manual Patterns") {
+                                Button {
+                                    selectedPatternSelection = .legacy
+                                } label: {
+                                    patternSelectionLabel(
+                                        title: "Legacy Pattern",
+                                        isSelected: selectedPatternSelection == .legacy
+                                    )
+                                }
+
+                                Button {
+                                    selectedPatternSelection = .custom
+                                } label: {
+                                    patternSelectionLabel(
+                                        title: "Custom Pattern",
+                                        isSelected: selectedPatternSelection == .custom
+                                    )
+                                }
+                            }
+                        } label: {
+                            HStack(spacing: 6) {
+                                Text(selectedPatternTitle)
+                                    .foregroundStyle(.primary)
+                                Image(systemName: "chevron.down")
+                                    .font(.caption.weight(.semibold))
+                                    .foregroundStyle(.secondary)
+                            }
+                        }
+                        .buttonStyle(.plain)
+                    }
+
+                    Text(selectedPatternDescription)
+                        .font(.footnote)
+                        .foregroundStyle(.secondary)
+
+                    if selectedPatternSelection.requiresManualName {
+                        LabeledContent(selectedPatternSelection == .legacy ? "Legacy Name" : "Custom Name") {
+                            TextField("", text: $manualPatternName)
+                                .multilineTextAlignment(.trailing)
                         }
                     }
 
@@ -217,6 +304,8 @@ struct AddMagazineView: View {
             selectedColor: selectedColor,
             colorDetail: resolvedColorDetail,
             purchasePriceText: purchasePriceText,
+            patternSelection: selectedPatternSelection,
+            manualPatternName: manualPatternName,
             selectedCaliber: selectedCaliber,
             firearm: linkedFirearm,
             existingMagazine: magazine
@@ -225,12 +314,46 @@ struct AddMagazineView: View {
 
     private var compatibilityMessage: String? {
         viewModel.compatibilityValidationResult(
+            patternSelection: selectedPatternSelection,
+            manualPatternName: manualPatternName,
             brand: brand,
             modelName: modelName,
             selectedCaliber: selectedCaliber,
             firearm: linkedFirearm,
             existingMagazine: magazine
         ).message
+    }
+
+    private var suggestedCatalogPatterns: [MagazinePattern] {
+        viewModel.suggestedCatalogPatterns(selectedCaliber: selectedCaliber, firearm: linkedFirearm)
+    }
+
+    private var additionalCatalogPatterns: [MagazinePattern] {
+        viewModel.additionalCatalogPatterns(selectedCaliber: selectedCaliber, firearm: linkedFirearm)
+    }
+
+    private var selectedPatternTitle: String {
+        viewModel.selectedPatternTitle(
+            selection: selectedPatternSelection,
+            manualPatternName: manualPatternName,
+            brand: brand,
+            modelName: modelName,
+            selectedCaliber: selectedCaliber,
+            firearm: linkedFirearm,
+            existingMagazine: magazine
+        )
+    }
+
+    private var selectedPatternDescription: String {
+        viewModel.selectedPatternDescription(
+            selection: selectedPatternSelection,
+            manualPatternName: manualPatternName,
+            brand: brand,
+            modelName: modelName,
+            selectedCaliber: selectedCaliber,
+            firearm: linkedFirearm,
+            existingMagazine: magazine
+        )
     }
 
     private func saveMagazine() {
@@ -253,6 +376,8 @@ struct AddMagazineView: View {
                 color: selectedColor,
                 colorDetail: resolvedColorDetail,
                 notes: resolvedNotes,
+                patternSelection: selectedPatternSelection,
+                manualPatternName: manualPatternName,
                 caliber: selectedCaliber,
                 firearm: linkedFirearm,
                 canSave: canAdd,
@@ -269,6 +394,8 @@ struct AddMagazineView: View {
                 color: selectedColor,
                 colorDetail: resolvedColorDetail,
                 notes: resolvedNotes,
+                patternSelection: selectedPatternSelection,
+                manualPatternName: manualPatternName,
                 caliber: selectedCaliber,
                 firearm: nil,
                 canAdd: canAdd,
@@ -300,6 +427,15 @@ struct AddMagazineView: View {
             calibers = try caliberQueryService.fetchCalibers(in: context)
         } catch {
             print("Calibers fetch error: \(error)")
+        }
+    }
+
+    @ViewBuilder
+    private func patternSelectionLabel(title: String, isSelected: Bool) -> some View {
+        if isSelected {
+            Label(title, systemImage: "checkmark")
+        } else {
+            Text(title)
         }
     }
 }

--- a/ArmoryInventory/Accessories/Magazines/AddMagazineView.swift
+++ b/ArmoryInventory/Accessories/Magazines/AddMagazineView.swift
@@ -30,6 +30,7 @@ struct AddMagazineView: View {
     @State private var unlinkFirearm = false
     @State private var isEditing = false
     @State private var calibers: [Caliber] = []
+    @State private var savedCustomPatterns: [MagazinePattern] = []
 
     let viewModel: AddMagazineViewModel
     private let caliberQueryService: CaliberQueryServicing
@@ -116,6 +117,21 @@ struct AddMagazineView: View {
                                             patternSelectionLabel(
                                                 title: pattern.displayName,
                                                 isSelected: selectedPatternSelection == .catalog(pattern.id)
+                                            )
+                                        }
+                                    }
+                                }
+                            }
+
+                            if !savedCustomPatterns.isEmpty {
+                                Section("Saved Custom Patterns") {
+                                    ForEach(savedCustomPatterns) { pattern in
+                                        Button {
+                                            selectedPatternSelection = .existingCustom(pattern)
+                                        } label: {
+                                            patternSelectionLabel(
+                                                title: pattern.displayName,
+                                                isSelected: selectedPatternSelection == .existingCustom(pattern)
                                             )
                                         }
                                     }
@@ -259,7 +275,7 @@ struct AddMagazineView: View {
             .navigationTitle(magazine == nil ? "New Magazine" : "Magazine Details")
             .navigationBarTitleDisplayMode(.inline)
             .task {
-                reloadCalibers()
+                reloadPickerData()
             }
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
@@ -474,6 +490,11 @@ struct AddMagazineView: View {
         } catch {
             print("Calibers fetch error: \(error)")
         }
+    }
+
+    private func reloadPickerData() {
+        reloadCalibers()
+        savedCustomPatterns = viewModel.availableCustomPatterns(in: context)
     }
 
     @ViewBuilder

--- a/ArmoryInventory/Accessories/Magazines/AddMagazineViewModel.swift
+++ b/ArmoryInventory/Accessories/Magazines/AddMagazineViewModel.swift
@@ -8,6 +8,35 @@
 import Foundation
 import SwiftData
 
+enum MagazinePatternSelection: Equatable, Identifiable {
+    case automatic
+    case catalog(String)
+    case legacy
+    case custom
+
+    var id: String {
+        switch self {
+        case .automatic:
+            return "automatic"
+        case let .catalog(patternID):
+            return "catalog:\(patternID)"
+        case .legacy:
+            return "legacy"
+        case .custom:
+            return "custom"
+        }
+    }
+
+    var requiresManualName: Bool {
+        switch self {
+        case .legacy, .custom:
+            return true
+        case .automatic, .catalog:
+            return false
+        }
+    }
+}
+
 final class AddMagazineViewModel {
     private let priceInputParser: PriceInputParsing
     private let compatibilityValidator: MagazineCompatibilityValidator
@@ -94,6 +123,112 @@ final class AddMagazineViewModel {
         return isEditing ? "Save" : "Edit"
     }
 
+    func initialPatternSelection(for magazine: Magazine?) -> MagazinePatternSelection {
+        guard let magazine else {
+            return .automatic
+        }
+
+        switch magazine.storedPatternKind {
+        case .catalog:
+            if let patternID = magazine.patternID,
+               MagazinePatternCatalog.pattern(id: patternID) != nil {
+                return .catalog(patternID)
+            }
+            return .automatic
+        case .legacy:
+            return .legacy
+        case .custom:
+            return .custom
+        case .unknown, nil:
+            return .automatic
+        }
+    }
+
+    func initialManualPatternName(for magazine: Magazine?) -> String {
+        guard let magazine,
+              let patternKind = magazine.storedPatternKind,
+              patternKind == .legacy || patternKind == .custom else {
+            return ""
+        }
+
+        return magazine.patternDisplayName ?? magazine.resolvedPattern.displayName
+    }
+
+    func suggestedCatalogPatterns(selectedCaliber: Caliber?, firearm: Firearm?) -> [MagazinePattern] {
+        if let firearm {
+            return MagazinePatternCatalog.suggestedPatterns(
+                firearmType: firearm.firearmType,
+                action: firearm.firearmAction,
+                caliberName: selectedCaliber?.name ?? firearm.caliber?.name
+            )
+        }
+
+        guard let selectedCaliberName = selectedCaliber?.name else {
+            return MagazinePatternCatalog.canonicalPatterns
+        }
+
+        return MagazinePatternCatalog.canonicalPatterns.filter {
+            $0.supports(caliberName: selectedCaliberName)
+        }
+    }
+
+    func additionalCatalogPatterns(selectedCaliber: Caliber?, firearm: Firearm?) -> [MagazinePattern] {
+        let suggestedIDs = Set(suggestedCatalogPatterns(selectedCaliber: selectedCaliber, firearm: firearm).map(\.id))
+        return MagazinePatternCatalog.canonicalPatterns.filter { !suggestedIDs.contains($0.id) }
+    }
+
+    func selectedPatternTitle(
+        selection: MagazinePatternSelection,
+        manualPatternName: String,
+        brand: String,
+        modelName: String,
+        selectedCaliber: Caliber?,
+        firearm: Firearm?,
+        existingMagazine: Magazine? = nil
+    ) -> String {
+        resolvedPatternDefinition(
+            selection: selection,
+            manualPatternName: manualPatternName,
+            brand: brand,
+            modelName: modelName,
+            selectedCaliber: selectedCaliber,
+            firearm: firearm,
+            existingMagazine: existingMagazine
+        ).pattern.displayName
+    }
+
+    func selectedPatternDescription(
+        selection: MagazinePatternSelection,
+        manualPatternName: String,
+        brand: String,
+        modelName: String,
+        selectedCaliber: Caliber?,
+        firearm: Firearm?,
+        existingMagazine: Magazine? = nil
+    ) -> String {
+        let definition = resolvedPatternDefinition(
+            selection: selection,
+            manualPatternName: manualPatternName,
+            brand: brand,
+            modelName: modelName,
+            selectedCaliber: selectedCaliber,
+            firearm: firearm,
+            existingMagazine: existingMagazine
+        )
+
+        switch selection {
+        case .automatic:
+            return "Automatically inferred from the magazine details and caliber."
+        case .catalog:
+            let calibers = definition.pattern.compatibility.supportedCaliberNames.joined(separator: ", ")
+            return calibers.isEmpty ? definition.pattern.familyLabel : calibers
+        case .legacy:
+            return "Legacy pattern names stay visible and editable for existing data."
+        case .custom:
+            return "Custom pattern names are stored exactly as entered."
+        }
+    }
+
     func nextSortOrder(in context: ModelContext) -> Int {
         var descriptor = FetchDescriptor<Magazine>(
             sortBy: [SortDescriptor(\.sortOrder, order: .reverse)]
@@ -111,6 +246,8 @@ final class AddMagazineViewModel {
         selectedColor: FirearmColor?,
         colorDetail: String?,
         purchasePriceText: String,
+        patternSelection: MagazinePatternSelection,
+        manualPatternName: String,
         selectedCaliber: Caliber?,
         firearm: Firearm?,
         existingMagazine: Magazine? = nil
@@ -123,8 +260,13 @@ final class AddMagazineViewModel {
         if selectedColor == .other, colorDetail == nil {
             return false
         }
+        if patternSelection.requiresManualName && trimmedValue(manualPatternName).isEmpty {
+            return false
+        }
 
         return compatibilityValidationResult(
+            patternSelection: patternSelection,
+            manualPatternName: manualPatternName,
             brand: brand,
             modelName: modelName,
             selectedCaliber: selectedCaliber,
@@ -134,6 +276,8 @@ final class AddMagazineViewModel {
     }
 
     func compatibilityValidationResult(
+        patternSelection: MagazinePatternSelection,
+        manualPatternName: String,
         brand: String,
         modelName: String,
         selectedCaliber: Caliber?,
@@ -144,23 +288,18 @@ final class AddMagazineViewModel {
             return .compatible
         }
 
-        let workingMagazine = Magazine(
-            brand: trimmedValue(brand),
-            modelName: trimmedValue(modelName),
-            patternID: existingMagazine?.patternID,
-            patternKind: existingMagazine?.storedPatternKind,
-            patternDisplayName: existingMagazine?.patternDisplayName,
-            capacity: existingMagazine?.capacity ?? 1,
-            purchasePriceCents: existingMagazine?.purchasePriceCents ?? 0,
-            caliber: selectedCaliber,
-            firearm: firearm
+        let definition = resolvedPatternDefinition(
+            selection: patternSelection,
+            manualPatternName: manualPatternName,
+            brand: brand,
+            modelName: modelName,
+            selectedCaliber: selectedCaliber,
+            firearm: firearm,
+            existingMagazine: existingMagazine
         )
-        if existingMagazine == nil {
-            MagazinePatternMigration.applyResolvedPattern(to: workingMagazine)
-        }
 
         return compatibilityValidator.validate(
-            pattern: workingMagazine.resolvedPattern,
+            pattern: definition.pattern,
             selectedMagazineCaliber: selectedCaliber,
             firearmType: firearm.firearmType,
             action: firearm.firearmAction,
@@ -179,6 +318,8 @@ final class AddMagazineViewModel {
         color: FirearmColor?,
         colorDetail: String?,
         notes: String?,
+        patternSelection: MagazinePatternSelection,
+        manualPatternName: String,
         caliber: Caliber?,
         firearm: Firearm? = nil,
         canAdd: Bool,
@@ -188,9 +329,21 @@ final class AddMagazineViewModel {
             return false
         }
 
+        let definition = resolvedPatternDefinition(
+            selection: patternSelection,
+            manualPatternName: manualPatternName,
+            brand: brand,
+            modelName: modelName,
+            selectedCaliber: caliber,
+            firearm: firearm,
+            existingMagazine: nil
+        )
         let magazine = Magazine(
             brand: trimmedValue(brand),
             modelName: trimmedValue(modelName),
+            patternID: definition.patternID,
+            patternKind: definition.patternKind,
+            patternDisplayName: definition.patternDisplayName,
             count: count,
             capacity: capacity,
             purchaseDate: purchaseDate,
@@ -202,10 +355,9 @@ final class AddMagazineViewModel {
             firearm: firearm,
             sortOrder: nextSortOrder(in: context)
         )
-        MagazinePatternMigration.applyResolvedPattern(to: magazine)
         if let firearm {
             guard compatibilityValidator.validate(
-                pattern: magazine.resolvedPattern,
+                pattern: definition.pattern,
                 selectedMagazineCaliber: caliber,
                 firearmType: firearm.firearmType,
                 action: firearm.firearmAction,
@@ -238,6 +390,8 @@ final class AddMagazineViewModel {
         color: FirearmColor?,
         colorDetail: String?,
         notes: String?,
+        patternSelection: MagazinePatternSelection,
+        manualPatternName: String,
         caliber: Caliber?,
         firearm: Firearm?,
         canSave: Bool,
@@ -247,29 +401,18 @@ final class AddMagazineViewModel {
             return false
         }
 
-        let candidateMagazine = Magazine(
-            id: magazine.id,
-            brand: trimmedValue(brand),
-            modelName: trimmedValue(modelName),
-            count: count,
-            capacity: capacity,
-            purchaseDate: purchaseDate,
-            purchasePriceCents: purchasePriceCents,
-            color: color,
-            colorDetail: colorDetail,
-            notes: notes,
-            caliber: caliber,
+        let definition = resolvedPatternDefinition(
+            selection: patternSelection,
+            manualPatternName: manualPatternName,
+            brand: brand,
+            modelName: modelName,
+            selectedCaliber: caliber,
             firearm: firearm,
-            sortOrder: magazine.sortOrder,
-            createdAt: magazine.createdAt
+            existingMagazine: magazine
         )
-        candidateMagazine.patternID = magazine.patternID
-        candidateMagazine.patternKind = magazine.patternKind
-        candidateMagazine.patternDisplayName = magazine.patternDisplayName
-        MagazinePatternMigration.applyResolvedPattern(to: candidateMagazine)
         if let firearm {
             guard compatibilityValidator.validate(
-                pattern: candidateMagazine.resolvedPattern,
+                pattern: definition.pattern,
                 selectedMagazineCaliber: caliber,
                 firearmType: firearm.firearmType,
                 action: firearm.firearmAction,
@@ -291,9 +434,9 @@ final class AddMagazineViewModel {
         magazine.notes = notes
         magazine.caliber = caliber
         magazine.firearm = firearm
-        magazine.patternID = candidateMagazine.patternID
-        magazine.patternKind = candidateMagazine.patternKind
-        magazine.patternDisplayName = candidateMagazine.patternDisplayName
+        magazine.patternID = definition.patternID
+        magazine.patternKind = definition.patternKind.rawValue
+        magazine.patternDisplayName = definition.patternDisplayName
 
         do {
             try context.save()
@@ -303,5 +446,157 @@ final class AddMagazineViewModel {
             print("Save error: \(error)")
             return false
         }
+    }
+
+    private struct ResolvedPatternDefinition {
+        let pattern: MagazinePattern
+        let patternID: String
+        let patternKind: MagazinePatternKind
+        let patternDisplayName: String?
+    }
+
+    private func resolvedPatternDefinition(
+        selection: MagazinePatternSelection,
+        manualPatternName: String,
+        brand: String,
+        modelName: String,
+        selectedCaliber: Caliber?,
+        firearm: Firearm?,
+        existingMagazine: Magazine?
+    ) -> ResolvedPatternDefinition {
+        switch selection {
+        case .automatic:
+            return inferredPatternDefinition(
+                brand: brand,
+                modelName: modelName,
+                selectedCaliber: selectedCaliber,
+                firearm: firearm
+            )
+        case let .catalog(patternID):
+            if let pattern = MagazinePatternCatalog.pattern(id: patternID) {
+                return ResolvedPatternDefinition(
+                    pattern: pattern,
+                    patternID: pattern.id,
+                    patternKind: .catalog,
+                    patternDisplayName: nil
+                )
+            }
+
+            return inferredPatternDefinition(
+                brand: brand,
+                modelName: modelName,
+                selectedCaliber: selectedCaliber,
+                firearm: firearm
+            )
+        case .legacy:
+            let name = resolvedManualPatternName(
+                manualPatternName,
+                brand: brand,
+                modelName: modelName,
+                fallback: "Legacy Pattern"
+            )
+            let pattern = MagazinePattern.legacy(
+                displayName: name,
+                familyLabel: name,
+                supportedCaliberNames: supportedCaliberNames(for: selectedCaliber),
+                compatibleFirearmTypes: compatibleFirearmTypes(for: firearm),
+                compatibleFirearmActions: compatibleFirearmActions(for: firearm)
+            )
+            return ResolvedPatternDefinition(
+                pattern: pattern,
+                patternID: pattern.id,
+                patternKind: .legacy,
+                patternDisplayName: pattern.displayName
+            )
+        case .custom:
+            let name = resolvedManualPatternName(
+                manualPatternName,
+                brand: brand,
+                modelName: modelName,
+                fallback: "Custom Pattern"
+            )
+            let pattern = MagazinePattern.custom(
+                id: existingCustomPatternID(for: existingMagazine),
+                displayName: name,
+                familyLabel: name,
+                supportedCaliberNames: supportedCaliberNames(for: selectedCaliber),
+                compatibleFirearmTypes: compatibleFirearmTypes(for: firearm),
+                compatibleFirearmActions: compatibleFirearmActions(for: firearm)
+            )
+            return ResolvedPatternDefinition(
+                pattern: pattern,
+                patternID: pattern.id,
+                patternKind: .custom,
+                patternDisplayName: pattern.displayName
+            )
+        }
+    }
+
+    private func inferredPatternDefinition(
+        brand: String,
+        modelName: String,
+        selectedCaliber: Caliber?,
+        firearm: Firearm?
+    ) -> ResolvedPatternDefinition {
+        let workingMagazine = Magazine(
+            brand: trimmedValue(brand),
+            modelName: trimmedValue(modelName),
+            capacity: 1,
+            purchasePriceCents: 0,
+            caliber: selectedCaliber,
+            firearm: firearm
+        )
+        MagazinePatternMigration.applyResolvedPattern(to: workingMagazine)
+        return ResolvedPatternDefinition(
+            pattern: workingMagazine.resolvedPattern,
+            patternID: workingMagazine.patternID ?? workingMagazine.resolvedPattern.id,
+            patternKind: workingMagazine.storedPatternKind ?? workingMagazine.resolvedPattern.kind,
+            patternDisplayName: workingMagazine.patternDisplayName
+        )
+    }
+
+    private func resolvedManualPatternName(
+        _ manualPatternName: String,
+        brand: String,
+        modelName: String,
+        fallback: String
+    ) -> String {
+        let trimmedManualName = trimmedValue(manualPatternName)
+        if !trimmedManualName.isEmpty {
+            return trimmedManualName
+        }
+
+        let fallbackName = [trimmedValue(brand), trimmedValue(modelName)]
+            .filter { !$0.isEmpty }
+            .joined(separator: " ")
+
+        return fallbackName.isEmpty ? fallback : fallbackName
+    }
+
+    private func supportedCaliberNames(for caliber: Caliber?) -> [String] {
+        guard let caliberName = optionalValue(caliber?.name ?? "") else {
+            return []
+        }
+
+        return [caliberName]
+    }
+
+    private func compatibleFirearmTypes(for firearm: Firearm?) -> [FirearmType] {
+        firearm.map { [$0.firearmType] } ?? []
+    }
+
+    private func compatibleFirearmActions(for firearm: Firearm?) -> [FirearmAction] {
+        firearm.map { [$0.firearmAction] } ?? []
+    }
+
+    private func existingCustomPatternID(for magazine: Magazine?) -> UUID {
+        guard magazine?.storedPatternKind == .custom,
+              let patternID = magazine?.patternID,
+              patternID.hasPrefix("custom:"),
+              let customID = UUID(uuidString: String(patternID.dropFirst("custom:".count))) else {
+            return UUID()
+        }
+
+        return customID
     }
 }

--- a/ArmoryInventory/Accessories/Magazines/AddMagazineViewModel.swift
+++ b/ArmoryInventory/Accessories/Magazines/AddMagazineViewModel.swift
@@ -184,6 +184,14 @@ final class AddMagazineViewModel {
         }
     }
 
+    func customPatternUUID(from patternID: String) -> UUID? {
+        guard patternID.hasPrefix("custom:") else {
+            return nil
+        }
+
+        return UUID(uuidString: String(patternID.dropFirst("custom:".count)))
+    }
+
     func initialManualPatternName(for magazine: Magazine?) -> String {
         guard let magazine,
               let patternKind = magazine.storedPatternKind,
@@ -253,6 +261,7 @@ final class AddMagazineViewModel {
             brand: brand,
             modelName: modelName,
             compatibleCaliberNames: compatibleCaliberNames,
+            existingCustomPatternIDOverride: nil,
             firearm: firearm,
             existingMagazine: existingMagazine
         ).pattern.displayName
@@ -273,6 +282,7 @@ final class AddMagazineViewModel {
             brand: brand,
             modelName: modelName,
             compatibleCaliberNames: compatibleCaliberNames,
+            existingCustomPatternIDOverride: nil,
             firearm: firearm,
             existingMagazine: existingMagazine
         )
@@ -308,6 +318,7 @@ final class AddMagazineViewModel {
             brand: brand,
             modelName: modelName,
             compatibleCaliberNames: compatibleCaliberNames,
+            existingCustomPatternIDOverride: nil,
             firearm: firearm,
             existingMagazine: existingMagazine
         ).pattern.compatibility.supportedCaliberNames
@@ -378,6 +389,7 @@ final class AddMagazineViewModel {
             brand: brand,
             modelName: modelName,
             compatibleCaliberNames: compatibleCaliberNames,
+            existingCustomPatternIDOverride: nil,
             firearm: firearm,
             existingMagazine: existingMagazine
         )
@@ -405,6 +417,7 @@ final class AddMagazineViewModel {
         patternSelection: MagazinePatternSelection,
         manualPatternName: String,
         compatibleCaliberNames: Set<String>,
+        existingCustomPatternIDOverride: UUID? = nil,
         firearm: Firearm? = nil,
         canAdd: Bool,
         to context: ModelContext
@@ -419,6 +432,7 @@ final class AddMagazineViewModel {
             brand: brand,
             modelName: modelName,
             compatibleCaliberNames: compatibleCaliberNames,
+            existingCustomPatternIDOverride: existingCustomPatternIDOverride,
             firearm: firearm,
             existingMagazine: nil
         )
@@ -453,6 +467,7 @@ final class AddMagazineViewModel {
             }
         }
         context.insert(magazine)
+        synchronizeCustomPatternIfNeeded(definition.pattern, in: context)
 
         do {
             try context.save()
@@ -478,6 +493,7 @@ final class AddMagazineViewModel {
         patternSelection: MagazinePatternSelection,
         manualPatternName: String,
         compatibleCaliberNames: Set<String>,
+        existingCustomPatternIDOverride: UUID? = nil,
         firearm: Firearm?,
         canSave: Bool,
         in context: ModelContext
@@ -492,6 +508,7 @@ final class AddMagazineViewModel {
             brand: brand,
             modelName: modelName,
             compatibleCaliberNames: compatibleCaliberNames,
+            existingCustomPatternIDOverride: existingCustomPatternIDOverride,
             firearm: firearm,
             existingMagazine: magazine
         )
@@ -523,6 +540,7 @@ final class AddMagazineViewModel {
         magazine.patternKind = definition.patternKind.rawValue
         magazine.patternDisplayName = definition.patternDisplayName
         magazine.storedPatternSupportedCaliberNames = definition.pattern.compatibility.supportedCaliberNames
+        synchronizeCustomPatternIfNeeded(definition.pattern, in: context)
 
         do {
             try context.save()
@@ -547,6 +565,7 @@ final class AddMagazineViewModel {
         brand: String,
         modelName: String,
         compatibleCaliberNames: Set<String>,
+        existingCustomPatternIDOverride: UUID?,
         firearm: Firearm?,
         existingMagazine: Magazine?
     ) -> ResolvedPatternDefinition {
@@ -607,7 +626,7 @@ final class AddMagazineViewModel {
                 fallback: "Custom Pattern"
             )
             let pattern = MagazinePattern.custom(
-                id: existingCustomPatternID(for: existingMagazine),
+                id: existingCustomPatternIDOverride ?? existingCustomPatternID(for: existingMagazine),
                 displayName: name,
                 familyLabel: name,
                 supportedCaliberNames: supportedCaliberNames(for: compatibleCaliberNames),
@@ -642,6 +661,39 @@ final class AddMagazineViewModel {
             patternKind: workingMagazine.storedPatternKind ?? workingMagazine.resolvedPattern.kind,
             patternDisplayName: workingMagazine.patternDisplayName
         )
+    }
+
+    private func synchronizeCustomPatternIfNeeded(_ pattern: MagazinePattern, in context: ModelContext) {
+        guard pattern.kind == .custom else {
+            return
+        }
+
+        if let magazines = try? context.fetch(FetchDescriptor<Magazine>()) {
+            for magazine in magazines where magazine.storedPatternKind == .custom && magazine.patternID == pattern.id {
+                magazine.patternDisplayName = pattern.displayName
+                magazine.storedPatternSupportedCaliberNames = pattern.compatibility.supportedCaliberNames
+            }
+        }
+
+        if let firearms = try? context.fetch(FetchDescriptor<Firearm>()) {
+            for firearm in firearms {
+                let updatedPatterns = firearm.supportedMagazinePatterns.map { reference in
+                    guard reference.id == pattern.id else {
+                        return reference
+                    }
+
+                    return FirearmMagazinePatternReference(
+                        id: reference.id,
+                        kind: reference.kind,
+                        displayName: pattern.displayName
+                    )
+                }
+
+                if updatedPatterns != firearm.supportedMagazinePatterns {
+                    firearm.supportedMagazinePatterns = updatedPatterns
+                }
+            }
+        }
     }
 
     private func resolvedManualPatternName(

--- a/ArmoryInventory/Accessories/Magazines/AddMagazineViewModel.swift
+++ b/ArmoryInventory/Accessories/Magazines/AddMagazineViewModel.swift
@@ -11,6 +11,7 @@ import SwiftData
 enum MagazinePatternSelection: Equatable, Identifiable {
     case automatic
     case catalog(String)
+    case existingCustom(MagazinePattern)
     case legacy
     case custom
 
@@ -20,6 +21,8 @@ enum MagazinePatternSelection: Equatable, Identifiable {
             return "automatic"
         case let .catalog(patternID):
             return "catalog:\(patternID)"
+        case let .existingCustom(pattern):
+            return "existing-custom:\(pattern.id)"
         case .legacy:
             return "legacy"
         case .custom:
@@ -31,7 +34,7 @@ enum MagazinePatternSelection: Equatable, Identifiable {
         switch self {
         case .legacy, .custom:
             return true
-        case .automatic, .catalog:
+        case .automatic, .catalog, .existingCustom:
             return false
         }
     }
@@ -40,7 +43,7 @@ enum MagazinePatternSelection: Equatable, Identifiable {
         switch self {
         case .legacy, .custom:
             return true
-        case .automatic, .catalog:
+        case .automatic, .catalog, .existingCustom:
             return false
         }
     }
@@ -147,9 +150,37 @@ final class AddMagazineViewModel {
         case .legacy:
             return .legacy
         case .custom:
-            return .custom
+            return .existingCustom(magazine.resolvedPattern)
         case .unknown, nil:
             return .automatic
+        }
+    }
+
+    func availableCustomPatterns(in context: ModelContext) -> [MagazinePattern] {
+        let descriptor = FetchDescriptor<Magazine>(
+            sortBy: [SortDescriptor(\.createdAt), SortDescriptor(\.sortOrder)]
+        )
+        guard let magazines = try? context.fetch(descriptor) else {
+            return []
+        }
+
+        var patternsByID: [String: MagazinePattern] = [:]
+        for magazine in magazines where magazine.storedPatternKind == .custom {
+            let pattern = magazine.resolvedPattern
+            guard pattern.kind == .custom else {
+                continue
+            }
+
+            patternsByID[pattern.id] = patternsByID[pattern.id] ?? pattern
+        }
+
+        return patternsByID.values.sorted {
+            let nameComparison = $0.displayName.localizedCaseInsensitiveCompare($1.displayName)
+            if nameComparison != .orderedSame {
+                return nameComparison == .orderedAscending
+            }
+
+            return $0.id.localizedCaseInsensitiveCompare($1.id) == .orderedAscending
         }
     }
 
@@ -252,6 +283,9 @@ final class AddMagazineViewModel {
         case .catalog:
             let calibers = definition.pattern.compatibility.supportedCaliberNames.joined(separator: ", ")
             return calibers.isEmpty ? definition.pattern.familyLabel : calibers
+        case .existingCustom:
+            let calibers = definition.pattern.compatibility.supportedCaliberNames.joined(separator: ", ")
+            return calibers.isEmpty ? "Saved custom pattern." : calibers
         case .legacy:
             return "Legacy pattern names stay visible and editable for existing data."
         case .custom:
@@ -537,6 +571,13 @@ final class AddMagazineViewModel {
                 brand: brand,
                 modelName: modelName,
                 firearm: firearm
+            )
+        case let .existingCustom(pattern):
+            return ResolvedPatternDefinition(
+                pattern: pattern,
+                patternID: pattern.id,
+                patternKind: .custom,
+                patternDisplayName: pattern.displayName
             )
         case .legacy:
             let name = resolvedManualPatternName(

--- a/ArmoryInventory/Accessories/Magazines/AddMagazineViewModel.swift
+++ b/ArmoryInventory/Accessories/Magazines/AddMagazineViewModel.swift
@@ -9,7 +9,6 @@ import Foundation
 import SwiftData
 
 enum MagazinePatternSelection: Equatable, Identifiable {
-    case automatic
     case catalog(String)
     case existingCustom(MagazinePattern)
     case legacy
@@ -17,8 +16,6 @@ enum MagazinePatternSelection: Equatable, Identifiable {
 
     var id: String {
         switch self {
-        case .automatic:
-            return "automatic"
         case let .catalog(patternID):
             return "catalog:\(patternID)"
         case let .existingCustom(pattern):
@@ -34,7 +31,7 @@ enum MagazinePatternSelection: Equatable, Identifiable {
         switch self {
         case .legacy, .custom:
             return true
-        case .automatic, .catalog, .existingCustom:
+        case .catalog, .existingCustom:
             return false
         }
     }
@@ -43,7 +40,7 @@ enum MagazinePatternSelection: Equatable, Identifiable {
         switch self {
         case .legacy, .custom:
             return true
-        case .automatic, .catalog, .existingCustom:
+        case .catalog, .existingCustom:
             return false
         }
     }
@@ -136,9 +133,7 @@ final class AddMagazineViewModel {
     }
 
     func initialPatternSelection(for magazine: Magazine?) -> MagazinePatternSelection {
-        guard let magazine else {
-            return .automatic
-        }
+        guard let magazine else { return .custom }
 
         switch magazine.storedPatternKind {
         case .catalog:
@@ -146,13 +141,19 @@ final class AddMagazineViewModel {
                MagazinePatternCatalog.pattern(id: patternID) != nil {
                 return .catalog(patternID)
             }
-            return .automatic
+            if magazine.resolvedPattern.kind == .catalog {
+                return .catalog(magazine.resolvedPattern.id)
+            }
+            return .custom
         case .legacy:
             return .legacy
         case .custom:
             return .existingCustom(magazine.resolvedPattern)
         case .unknown, nil:
-            return .automatic
+            if magazine.resolvedPattern.kind == .catalog {
+                return .catalog(magazine.resolvedPattern.id)
+            }
+            return .custom
         }
     }
 
@@ -288,8 +289,6 @@ final class AddMagazineViewModel {
         )
 
         switch selection {
-        case .automatic:
-            return "Automatically inferred from the magazine details and existing pattern catalog."
         case .catalog:
             let calibers = definition.pattern.compatibility.supportedCaliberNames.joined(separator: ", ")
             return calibers.isEmpty ? definition.pattern.familyLabel : calibers
@@ -570,12 +569,6 @@ final class AddMagazineViewModel {
         existingMagazine: Magazine?
     ) -> ResolvedPatternDefinition {
         switch selection {
-        case .automatic:
-            return inferredPatternDefinition(
-                brand: brand,
-                modelName: modelName,
-                firearm: firearm
-            )
         case let .catalog(patternID):
             if let pattern = MagazinePatternCatalog.pattern(id: patternID) {
                 return ResolvedPatternDefinition(
@@ -586,10 +579,25 @@ final class AddMagazineViewModel {
                 )
             }
 
-            return inferredPatternDefinition(
+            let fallbackName = resolvedManualPatternName(
+                manualPatternName,
                 brand: brand,
                 modelName: modelName,
-                firearm: firearm
+                fallback: "Custom Pattern"
+            )
+            let fallbackPattern = MagazinePattern.custom(
+                id: existingCustomPatternIDOverride ?? existingCustomPatternID(for: existingMagazine),
+                displayName: fallbackName,
+                familyLabel: fallbackName,
+                supportedCaliberNames: supportedCaliberNames(for: compatibleCaliberNames),
+                compatibleFirearmTypes: compatibleFirearmTypes(for: firearm),
+                compatibleFirearmActions: compatibleFirearmActions(for: firearm)
+            )
+            return ResolvedPatternDefinition(
+                pattern: fallbackPattern,
+                patternID: fallbackPattern.id,
+                patternKind: .custom,
+                patternDisplayName: fallbackPattern.displayName
             )
         case let .existingCustom(pattern):
             return ResolvedPatternDefinition(
@@ -640,27 +648,6 @@ final class AddMagazineViewModel {
                 patternDisplayName: pattern.displayName
             )
         }
-    }
-
-    private func inferredPatternDefinition(
-        brand: String,
-        modelName: String,
-        firearm: Firearm?
-    ) -> ResolvedPatternDefinition {
-        let workingMagazine = Magazine(
-            brand: trimmedValue(brand),
-            modelName: trimmedValue(modelName),
-            capacity: 1,
-            purchasePriceCents: 0,
-            firearm: firearm
-        )
-        MagazinePatternMigration.applyResolvedPattern(to: workingMagazine)
-        return ResolvedPatternDefinition(
-            pattern: workingMagazine.resolvedPattern,
-            patternID: workingMagazine.patternID ?? workingMagazine.resolvedPattern.id,
-            patternKind: workingMagazine.storedPatternKind ?? workingMagazine.resolvedPattern.kind,
-            patternDisplayName: workingMagazine.patternDisplayName
-        )
     }
 
     private func synchronizeCustomPatternIfNeeded(_ pattern: MagazinePattern, in context: ModelContext) {

--- a/ArmoryInventory/Accessories/Magazines/AddMagazineViewModel.swift
+++ b/ArmoryInventory/Accessories/Magazines/AddMagazineViewModel.swift
@@ -35,6 +35,15 @@ enum MagazinePatternSelection: Equatable, Identifiable {
             return false
         }
     }
+
+    var allowsManualCaliberSelection: Bool {
+        switch self {
+        case .legacy, .custom:
+            return true
+        case .automatic, .catalog:
+            return false
+        }
+    }
 }
 
 final class AddMagazineViewModel {
@@ -154,26 +163,47 @@ final class AddMagazineViewModel {
         return magazine.patternDisplayName ?? magazine.resolvedPattern.displayName
     }
 
-    func suggestedCatalogPatterns(selectedCaliber: Caliber?, firearm: Firearm?) -> [MagazinePattern] {
+    func initialCompatibleCaliberNames(for magazine: Magazine?) -> Set<String> {
+        Set(magazine?.supportedCaliberNames ?? [])
+    }
+
+    func toggledCompatibleCaliberSelection(
+        currentSelection: Set<String>,
+        caliberName: String,
+        isEditing: Bool
+    ) -> Set<String> {
+        guard isEditing else {
+            return currentSelection
+        }
+
+        let trimmedCaliberName = trimmedValue(caliberName)
+        guard !trimmedCaliberName.isEmpty else {
+            return currentSelection
+        }
+
+        var selection = currentSelection
+        if selection.contains(trimmedCaliberName) {
+            selection.remove(trimmedCaliberName)
+        } else {
+            selection.insert(trimmedCaliberName)
+        }
+        return selection
+    }
+
+    func suggestedCatalogPatterns(firearm: Firearm?) -> [MagazinePattern] {
         if let firearm {
             return MagazinePatternCatalog.suggestedPatterns(
                 firearmType: firearm.firearmType,
                 action: firearm.firearmAction,
-                caliberName: selectedCaliber?.name ?? firearm.caliber?.name
+                caliberName: firearm.caliber?.name
             )
         }
 
-        guard let selectedCaliberName = selectedCaliber?.name else {
-            return MagazinePatternCatalog.canonicalPatterns
-        }
-
-        return MagazinePatternCatalog.canonicalPatterns.filter {
-            $0.supports(caliberName: selectedCaliberName)
-        }
+        return MagazinePatternCatalog.canonicalPatterns
     }
 
-    func additionalCatalogPatterns(selectedCaliber: Caliber?, firearm: Firearm?) -> [MagazinePattern] {
-        let suggestedIDs = Set(suggestedCatalogPatterns(selectedCaliber: selectedCaliber, firearm: firearm).map(\.id))
+    func additionalCatalogPatterns(firearm: Firearm?) -> [MagazinePattern] {
+        let suggestedIDs = Set(suggestedCatalogPatterns(firearm: firearm).map(\.id))
         return MagazinePatternCatalog.canonicalPatterns.filter { !suggestedIDs.contains($0.id) }
     }
 
@@ -182,7 +212,7 @@ final class AddMagazineViewModel {
         manualPatternName: String,
         brand: String,
         modelName: String,
-        selectedCaliber: Caliber?,
+        compatibleCaliberNames: Set<String>,
         firearm: Firearm?,
         existingMagazine: Magazine? = nil
     ) -> String {
@@ -191,7 +221,7 @@ final class AddMagazineViewModel {
             manualPatternName: manualPatternName,
             brand: brand,
             modelName: modelName,
-            selectedCaliber: selectedCaliber,
+            compatibleCaliberNames: compatibleCaliberNames,
             firearm: firearm,
             existingMagazine: existingMagazine
         ).pattern.displayName
@@ -202,7 +232,7 @@ final class AddMagazineViewModel {
         manualPatternName: String,
         brand: String,
         modelName: String,
-        selectedCaliber: Caliber?,
+        compatibleCaliberNames: Set<String>,
         firearm: Firearm?,
         existingMagazine: Magazine? = nil
     ) -> String {
@@ -211,14 +241,14 @@ final class AddMagazineViewModel {
             manualPatternName: manualPatternName,
             brand: brand,
             modelName: modelName,
-            selectedCaliber: selectedCaliber,
+            compatibleCaliberNames: compatibleCaliberNames,
             firearm: firearm,
             existingMagazine: existingMagazine
         )
 
         switch selection {
         case .automatic:
-            return "Automatically inferred from the magazine details and caliber."
+            return "Automatically inferred from the magazine details and existing pattern catalog."
         case .catalog:
             let calibers = definition.pattern.compatibility.supportedCaliberNames.joined(separator: ", ")
             return calibers.isEmpty ? definition.pattern.familyLabel : calibers
@@ -227,6 +257,26 @@ final class AddMagazineViewModel {
         case .custom:
             return "Custom pattern names are stored exactly as entered."
         }
+    }
+
+    func resolvedSupportedCaliberNames(
+        selection: MagazinePatternSelection,
+        manualPatternName: String,
+        brand: String,
+        modelName: String,
+        compatibleCaliberNames: Set<String>,
+        firearm: Firearm?,
+        existingMagazine: Magazine? = nil
+    ) -> [String] {
+        resolvedPatternDefinition(
+            selection: selection,
+            manualPatternName: manualPatternName,
+            brand: brand,
+            modelName: modelName,
+            compatibleCaliberNames: compatibleCaliberNames,
+            firearm: firearm,
+            existingMagazine: existingMagazine
+        ).pattern.compatibility.supportedCaliberNames
     }
 
     func nextSortOrder(in context: ModelContext) -> Int {
@@ -248,7 +298,7 @@ final class AddMagazineViewModel {
         purchasePriceText: String,
         patternSelection: MagazinePatternSelection,
         manualPatternName: String,
-        selectedCaliber: Caliber?,
+        compatibleCaliberNames: Set<String>,
         firearm: Firearm?,
         existingMagazine: Magazine? = nil
     ) -> Bool {
@@ -269,7 +319,7 @@ final class AddMagazineViewModel {
             manualPatternName: manualPatternName,
             brand: brand,
             modelName: modelName,
-            selectedCaliber: selectedCaliber,
+            compatibleCaliberNames: compatibleCaliberNames,
             firearm: firearm,
             existingMagazine: existingMagazine
         ).isCompatible
@@ -280,7 +330,7 @@ final class AddMagazineViewModel {
         manualPatternName: String,
         brand: String,
         modelName: String,
-        selectedCaliber: Caliber?,
+        compatibleCaliberNames: Set<String>,
         firearm: Firearm?,
         existingMagazine: Magazine? = nil
     ) -> MagazineCompatibilityValidationResult {
@@ -293,14 +343,14 @@ final class AddMagazineViewModel {
             manualPatternName: manualPatternName,
             brand: brand,
             modelName: modelName,
-            selectedCaliber: selectedCaliber,
+            compatibleCaliberNames: compatibleCaliberNames,
             firearm: firearm,
             existingMagazine: existingMagazine
         )
 
         return compatibilityValidator.validate(
             pattern: definition.pattern,
-            selectedMagazineCaliber: selectedCaliber,
+            selectedMagazineCaliber: nil,
             firearmType: firearm.firearmType,
             action: firearm.firearmAction,
             caliber: firearm.caliber,
@@ -320,7 +370,7 @@ final class AddMagazineViewModel {
         notes: String?,
         patternSelection: MagazinePatternSelection,
         manualPatternName: String,
-        caliber: Caliber?,
+        compatibleCaliberNames: Set<String>,
         firearm: Firearm? = nil,
         canAdd: Bool,
         to context: ModelContext
@@ -334,7 +384,7 @@ final class AddMagazineViewModel {
             manualPatternName: manualPatternName,
             brand: brand,
             modelName: modelName,
-            selectedCaliber: caliber,
+            compatibleCaliberNames: compatibleCaliberNames,
             firearm: firearm,
             existingMagazine: nil
         )
@@ -344,6 +394,7 @@ final class AddMagazineViewModel {
             patternID: definition.patternID,
             patternKind: definition.patternKind,
             patternDisplayName: definition.patternDisplayName,
+            patternSupportedCaliberNames: definition.pattern.compatibility.supportedCaliberNames,
             count: count,
             capacity: capacity,
             purchaseDate: purchaseDate,
@@ -351,14 +402,14 @@ final class AddMagazineViewModel {
             color: color,
             colorDetail: colorDetail,
             notes: notes,
-            caliber: caliber,
+            caliber: resolvedStoredCaliber(for: definition.pattern, existingMagazine: nil, in: context),
             firearm: firearm,
             sortOrder: nextSortOrder(in: context)
         )
         if let firearm {
             guard compatibilityValidator.validate(
                 pattern: definition.pattern,
-                selectedMagazineCaliber: caliber,
+                selectedMagazineCaliber: nil,
                 firearmType: firearm.firearmType,
                 action: firearm.firearmAction,
                 caliber: firearm.caliber,
@@ -392,7 +443,7 @@ final class AddMagazineViewModel {
         notes: String?,
         patternSelection: MagazinePatternSelection,
         manualPatternName: String,
-        caliber: Caliber?,
+        compatibleCaliberNames: Set<String>,
         firearm: Firearm?,
         canSave: Bool,
         in context: ModelContext
@@ -406,14 +457,14 @@ final class AddMagazineViewModel {
             manualPatternName: manualPatternName,
             brand: brand,
             modelName: modelName,
-            selectedCaliber: caliber,
+            compatibleCaliberNames: compatibleCaliberNames,
             firearm: firearm,
             existingMagazine: magazine
         )
         if let firearm {
             guard compatibilityValidator.validate(
                 pattern: definition.pattern,
-                selectedMagazineCaliber: caliber,
+                selectedMagazineCaliber: nil,
                 firearmType: firearm.firearmType,
                 action: firearm.firearmAction,
                 caliber: firearm.caliber,
@@ -432,11 +483,12 @@ final class AddMagazineViewModel {
         magazine.color = color?.rawValue
         magazine.colorDetail = colorDetail
         magazine.notes = notes
-        magazine.caliber = caliber
+        magazine.caliber = resolvedStoredCaliber(for: definition.pattern, existingMagazine: magazine, in: context)
         magazine.firearm = firearm
         magazine.patternID = definition.patternID
         magazine.patternKind = definition.patternKind.rawValue
         magazine.patternDisplayName = definition.patternDisplayName
+        magazine.storedPatternSupportedCaliberNames = definition.pattern.compatibility.supportedCaliberNames
 
         do {
             try context.save()
@@ -460,7 +512,7 @@ final class AddMagazineViewModel {
         manualPatternName: String,
         brand: String,
         modelName: String,
-        selectedCaliber: Caliber?,
+        compatibleCaliberNames: Set<String>,
         firearm: Firearm?,
         existingMagazine: Magazine?
     ) -> ResolvedPatternDefinition {
@@ -469,7 +521,6 @@ final class AddMagazineViewModel {
             return inferredPatternDefinition(
                 brand: brand,
                 modelName: modelName,
-                selectedCaliber: selectedCaliber,
                 firearm: firearm
             )
         case let .catalog(patternID):
@@ -485,7 +536,6 @@ final class AddMagazineViewModel {
             return inferredPatternDefinition(
                 brand: brand,
                 modelName: modelName,
-                selectedCaliber: selectedCaliber,
                 firearm: firearm
             )
         case .legacy:
@@ -498,7 +548,7 @@ final class AddMagazineViewModel {
             let pattern = MagazinePattern.legacy(
                 displayName: name,
                 familyLabel: name,
-                supportedCaliberNames: supportedCaliberNames(for: selectedCaliber),
+                supportedCaliberNames: supportedCaliberNames(for: compatibleCaliberNames),
                 compatibleFirearmTypes: compatibleFirearmTypes(for: firearm),
                 compatibleFirearmActions: compatibleFirearmActions(for: firearm)
             )
@@ -519,7 +569,7 @@ final class AddMagazineViewModel {
                 id: existingCustomPatternID(for: existingMagazine),
                 displayName: name,
                 familyLabel: name,
-                supportedCaliberNames: supportedCaliberNames(for: selectedCaliber),
+                supportedCaliberNames: supportedCaliberNames(for: compatibleCaliberNames),
                 compatibleFirearmTypes: compatibleFirearmTypes(for: firearm),
                 compatibleFirearmActions: compatibleFirearmActions(for: firearm)
             )
@@ -535,7 +585,6 @@ final class AddMagazineViewModel {
     private func inferredPatternDefinition(
         brand: String,
         modelName: String,
-        selectedCaliber: Caliber?,
         firearm: Firearm?
     ) -> ResolvedPatternDefinition {
         let workingMagazine = Magazine(
@@ -543,7 +592,6 @@ final class AddMagazineViewModel {
             modelName: trimmedValue(modelName),
             capacity: 1,
             purchasePriceCents: 0,
-            caliber: selectedCaliber,
             firearm: firearm
         )
         MagazinePatternMigration.applyResolvedPattern(to: workingMagazine)
@@ -573,12 +621,11 @@ final class AddMagazineViewModel {
         return fallbackName.isEmpty ? fallback : fallbackName
     }
 
-    private func supportedCaliberNames(for caliber: Caliber?) -> [String] {
-        guard let caliberName = optionalValue(caliber?.name ?? "") else {
-            return []
-        }
-
-        return [caliberName]
+    private func supportedCaliberNames(for caliberNames: Set<String>) -> [String] {
+        caliberNames
+            .map(trimmedValue)
+            .filter { !$0.isEmpty }
+            .sorted { $0.localizedCaseInsensitiveCompare($1) == .orderedAscending }
     }
 
     private func compatibleFirearmTypes(for firearm: Firearm?) -> [FirearmType] {
@@ -598,5 +645,33 @@ final class AddMagazineViewModel {
         }
 
         return customID
+    }
+
+    private func resolvedStoredCaliber(
+        for pattern: MagazinePattern,
+        existingMagazine: Magazine?,
+        in context: ModelContext
+    ) -> Caliber? {
+        let supportedCaliberNames = pattern.compatibility.supportedCaliberNames
+            .map(trimmedValue)
+            .filter { !$0.isEmpty }
+
+        guard supportedCaliberNames.count == 1,
+              let caliberName = supportedCaliberNames.first else {
+            return nil
+        }
+
+        if let existingCaliber = existingMagazine?.caliber,
+           trimmedValue(existingCaliber.name).caseInsensitiveCompare(caliberName) == .orderedSame {
+            return existingCaliber
+        }
+
+        guard let calibers = try? context.fetch(FetchDescriptor<Caliber>()) else {
+            return nil
+        }
+
+        return calibers.first {
+            trimmedValue($0.name).caseInsensitiveCompare(caliberName) == .orderedSame
+        }
     }
 }

--- a/ArmoryInventory/Accessories/Magazines/MagazineCompatibilityValidator.swift
+++ b/ArmoryInventory/Accessories/Magazines/MagazineCompatibilityValidator.swift
@@ -13,6 +13,7 @@ struct MagazineCompatibilityValidationResult: Equatable {
         case linkedToDifferentFirearm(currentFirearmName: String)
         case caliberMismatch(magazineCaliberName: String, firearmCaliberName: String)
         case incompatiblePattern(patternName: String, firearmDescription: String)
+        case patternNotSelected(patternName: String)
 
         var message: String {
             switch self {
@@ -22,6 +23,8 @@ struct MagazineCompatibilityValidationResult: Equatable {
                 return "Magazine caliber \(magazineCaliberName) does not match firearm caliber \(firearmCaliberName)."
             case let .incompatiblePattern(patternName, firearmDescription):
                 return "\(patternName) is not compatible with \(firearmDescription)."
+            case let .patternNotSelected(patternName):
+                return "\(patternName) is not included in this firearm's selected magazine patterns."
             }
         }
     }

--- a/ArmoryInventory/Accessories/Magazines/MagazineCompatibilityValidator.swift
+++ b/ArmoryInventory/Accessories/Magazines/MagazineCompatibilityValidator.swift
@@ -10,19 +10,13 @@ import SwiftData
 
 struct MagazineCompatibilityValidationResult: Equatable {
     enum Failure: Equatable {
-        case linkedToDifferentFirearm(currentFirearmName: String)
         case caliberMismatch(magazineCaliberName: String, firearmCaliberName: String)
-        case incompatiblePattern(patternName: String, firearmDescription: String)
         case patternNotSelected(patternName: String)
 
         var message: String {
             switch self {
-            case let .linkedToDifferentFirearm(currentFirearmName):
-                return "This magazine is already linked to \(currentFirearmName)."
             case let .caliberMismatch(magazineCaliberName, firearmCaliberName):
                 return "Magazine caliber \(magazineCaliberName) does not match firearm caliber \(firearmCaliberName)."
-            case let .incompatiblePattern(patternName, firearmDescription):
-                return "\(patternName) is not compatible with \(firearmDescription)."
             case let .patternNotSelected(patternName):
                 return "\(patternName) is not included in this firearm's selected magazine patterns."
             }
@@ -50,18 +44,13 @@ struct MagazineCompatibilityValidator {
         caliber: Caliber?,
         owningFirearm: Firearm?
     ) -> MagazineCompatibilityValidationResult {
-        if let linkedFirearm = magazine.firearm,
-           linkedFirearm.persistentModelID != owningFirearm?.persistentModelID {
-            return .init(failure: .linkedToDifferentFirearm(currentFirearmName: linkedFirearm.displayName))
-        }
-
         return validate(
             pattern: magazine.resolvedPattern,
             selectedMagazineCaliber: magazine.caliber,
             firearmType: firearmType,
             action: action,
             caliber: caliber,
-            firearmDescription: owningFirearm?.displayName ?? firearmDescription(type: firearmType, action: action)
+            firearmDescription: owningFirearm?.displayName ?? ""
         )
     }
 
@@ -73,25 +62,32 @@ struct MagazineCompatibilityValidator {
         caliber: Caliber?,
         firearmDescription: String
     ) -> MagazineCompatibilityValidationResult {
-        if let selectedMagazineCaliberName = trimmedName(selectedMagazineCaliber?.name),
-           let firearmCaliberName = trimmedName(caliber?.name),
-           selectedMagazineCaliberName.caseInsensitiveCompare(firearmCaliberName) != .orderedSame {
-            return .init(
-                failure: .caliberMismatch(
-                    magazineCaliberName: selectedMagazineCaliberName,
-                    firearmCaliberName: firearmCaliberName
-                )
-            )
-        }
+        if let firearmCaliberName = trimmedName(caliber?.name) {
+            let supportedMagazineCalibers = pattern.compatibility.supportedCaliberNames
+                .compactMap(trimmedName)
 
-        let effectiveCaliberName = trimmedName(caliber?.name) ?? trimmedName(selectedMagazineCaliber?.name)
-        guard pattern.isCompatible(with: firearmType, action: action, caliberName: effectiveCaliberName) else {
-            return .init(
-                failure: .incompatiblePattern(
-                    patternName: pattern.displayName,
-                    firearmDescription: firearmDescription
+            if !supportedMagazineCalibers.isEmpty,
+               !supportedMagazineCalibers.contains(where: {
+                   $0.caseInsensitiveCompare(firearmCaliberName) == .orderedSame
+               }) {
+                return .init(
+                    failure: .caliberMismatch(
+                        magazineCaliberName: supportedMagazineCalibers.joined(separator: ", "),
+                        firearmCaliberName: firearmCaliberName
+                    )
                 )
-            )
+            }
+
+            if supportedMagazineCalibers.isEmpty,
+               let selectedMagazineCaliberName = trimmedName(selectedMagazineCaliber?.name),
+               selectedMagazineCaliberName.caseInsensitiveCompare(firearmCaliberName) != .orderedSame {
+                return .init(
+                    failure: .caliberMismatch(
+                        magazineCaliberName: selectedMagazineCaliberName,
+                        firearmCaliberName: firearmCaliberName
+                    )
+                )
+            }
         }
 
         return .compatible
@@ -119,11 +115,6 @@ struct MagazineCompatibilityValidator {
 
         return .compatible
     }
-
-    private func firearmDescription(type: FirearmType, action: FirearmAction) -> String {
-        "\(type.displayName) (\(action.displayName))"
-    }
-
     private func trimmedName(_ value: String?) -> String? {
         guard let value else {
             return nil

--- a/ArmoryInventory/Accessories/Magazines/MagazineModels.swift
+++ b/ArmoryInventory/Accessories/Magazines/MagazineModels.swift
@@ -91,6 +91,14 @@ final class Magazine {
         count == 1 ? "1 magazine" : "\(count) magazines"
     }
 
+    var totalRoundCapacity: Int {
+        max(0, count) * max(0, capacity)
+    }
+
+    var totalRoundCapacityText: String {
+        AmmoType.roundsText(for: totalRoundCapacity)
+    }
+
     var magazineColor: FirearmColor? {
         guard let color else {
             return nil

--- a/ArmoryInventory/Accessories/Magazines/MagazineModels.swift
+++ b/ArmoryInventory/Accessories/Magazines/MagazineModels.swift
@@ -16,6 +16,7 @@ final class Magazine {
     var patternID: String?
     var patternKind: MagazinePatternKind.RawValue?
     var patternDisplayName: String?
+    var patternSupportedCaliberNamesData: String?
     var count: Int
     var capacity: Int
     var purchaseDate: Date
@@ -36,6 +37,7 @@ final class Magazine {
         patternID: String? = nil,
         patternKind: MagazinePatternKind? = nil,
         patternDisplayName: String? = nil,
+        patternSupportedCaliberNames: [String] = [],
         count: Int = 1,
         capacity: Int,
         purchaseDate: Date = .now,
@@ -54,6 +56,7 @@ final class Magazine {
         self.patternID = patternID
         self.patternKind = patternKind?.rawValue
         self.patternDisplayName = patternDisplayName
+        self.patternSupportedCaliberNamesData = Self.encodePatternSupportedCaliberNames(patternSupportedCaliberNames)
         self.count = count
         self.capacity = capacity
         self.purchaseDate = purchaseDate
@@ -83,6 +86,36 @@ final class Magazine {
         MagazinePatternMigration.resolvedPattern(for: self)
     }
 
+    var supportedCaliberNames: [String] {
+        let patternCalibers = resolvedPattern.compatibility.supportedCaliberNames
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+        if !patternCalibers.isEmpty {
+            return patternCalibers
+        }
+
+        guard let caliberName = caliber?.name.trimmingCharacters(in: .whitespacesAndNewlines),
+              !caliberName.isEmpty else {
+            return []
+        }
+
+        return [caliberName]
+    }
+
+    var storedPatternSupportedCaliberNames: [String] {
+        get { Self.decodePatternSupportedCaliberNames(from: patternSupportedCaliberNamesData) }
+        set { patternSupportedCaliberNamesData = Self.encodePatternSupportedCaliberNames(newValue) }
+    }
+
+    var caliberDisplayText: String {
+        let names = supportedCaliberNames
+        guard !names.isEmpty else {
+            return "No Caliber"
+        }
+
+        return names.joined(separator: ", ")
+    }
+
     var capacityText: String {
         "\(capacity) rounds"
     }
@@ -97,6 +130,24 @@ final class Magazine {
 
     var totalRoundCapacityText: String {
         AmmoType.roundsText(for: totalRoundCapacity)
+    }
+
+    func linkedFirearms(from firearms: [Firearm]) -> [Firearm] {
+        var linkedByID: [PersistentIdentifier: Firearm] = [:]
+
+        for firearm in firearms {
+            let matchesPattern = firearm.supportedMagazinePatternIDs.contains(resolvedPattern.id)
+            let matchesLegacyLink = firearm.magazines.contains { $0.persistentModelID == persistentModelID }
+            guard matchesPattern || matchesLegacyLink else {
+                continue
+            }
+
+            linkedByID[firearm.persistentModelID] = firearm
+        }
+
+        return linkedByID.values.sorted {
+            $0.displayName.localizedCaseInsensitiveCompare($1.displayName) == .orderedAscending
+        }
     }
 
     var magazineColor: FirearmColor? {
@@ -119,5 +170,30 @@ final class Magazine {
     var purchasePriceText: String {
         let amount = Decimal(purchasePriceCents) / 100
         return amount.formatted(.currency(code: Locale.current.currency?.identifier ?? "USD"))
+    }
+
+    private static func encodePatternSupportedCaliberNames(_ caliberNames: [String]) -> String? {
+        let normalizedNames = caliberNames
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+        guard !normalizedNames.isEmpty,
+              let data = try? JSONEncoder().encode(normalizedNames),
+              let json = String(data: data, encoding: .utf8) else {
+            return nil
+        }
+
+        return json
+    }
+
+    private static func decodePatternSupportedCaliberNames(from value: String?) -> [String] {
+        guard let value,
+              let data = value.data(using: .utf8),
+              let names = try? JSONDecoder().decode([String].self, from: data) else {
+            return []
+        }
+
+        return names
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
     }
 }

--- a/ArmoryInventory/Accessories/Magazines/MagazineModels.swift
+++ b/ArmoryInventory/Accessories/Magazines/MagazineModels.swift
@@ -117,11 +117,25 @@ final class Magazine {
     }
 
     var capacityText: String {
-        "\(capacity) rounds"
+        String.localizedStringWithFormat(
+            String(localized: "magazineCapacityText"),
+            Int64(capacity)
+        )
     }
 
     var countText: String {
-        count == 1 ? "1 magazine" : "\(count) magazines"
+        String.localizedStringWithFormat(
+            String(localized: "magazineCount"),
+            Int64(count)
+        )
+    }
+
+    var countCapacityText: String {
+        String.localizedStringWithFormat(
+            String(localized: "magazineCountAndCapacity"),
+            Int64(count),
+            Int64(capacity)
+        )
     }
 
     var totalRoundCapacity: Int {

--- a/ArmoryInventory/Accessories/Magazines/MagazinePatternMigration.swift
+++ b/ArmoryInventory/Accessories/Magazines/MagazinePatternMigration.swift
@@ -53,6 +53,7 @@ struct MagazinePatternMigration {
         let id: String
         let kind: MagazinePatternKind
         let displayName: String?
+        let supportedCaliberNames: [String]
     }
 
     @discardableResult
@@ -76,10 +77,13 @@ struct MagazinePatternMigration {
         magazine.patternID = storedPattern.id
         magazine.patternKind = storedPattern.kind.rawValue
         magazine.patternDisplayName = storedPattern.displayName
+        magazine.storedPatternSupportedCaliberNames = storedPattern.supportedCaliberNames
     }
 
     static func resolvedPattern(for magazine: Magazine) -> MagazinePattern {
-        let caliberNames = supportedCaliberNames(for: magazine)
+        let caliberNames = storedSupportedCaliberNames(for: magazine).isEmpty
+            ? supportedCaliberNames(for: magazine)
+            : storedSupportedCaliberNames(for: magazine)
         let firearmTypes = compatibleFirearmTypes(for: magazine)
         let firearmActions = compatibleFirearmActions(for: magazine)
 
@@ -145,13 +149,15 @@ struct MagazinePatternMigration {
             return StoredPatternData(
                 id: pattern.id,
                 kind: pattern.kind,
-                displayName: nil
+                displayName: nil,
+                supportedCaliberNames: []
             )
         case .legacy, .custom:
             return StoredPatternData(
                 id: pattern.id,
                 kind: pattern.kind,
-                displayName: pattern.displayName
+                displayName: pattern.displayName,
+                supportedCaliberNames: pattern.compatibility.supportedCaliberNames
             )
         }
     }
@@ -171,7 +177,8 @@ struct MagazinePatternMigration {
             return StoredPatternData(
                 id: patternID,
                 kind: .catalog,
-                displayName: nil
+                displayName: nil,
+                supportedCaliberNames: []
             )
         case .legacy:
             guard let patternID = magazine.patternID, !patternID.isEmpty else {
@@ -182,20 +189,23 @@ struct MagazinePatternMigration {
             return StoredPatternData(
                 id: patternID,
                 kind: .legacy,
-                displayName: displayName
+                displayName: displayName,
+                supportedCaliberNames: storedSupportedCaliberNames(for: magazine)
             )
         case .custom:
             let displayName = resolvedStoredDisplayName(for: magazine)
             return StoredPatternData(
                 id: resolvedCustomPatternID(from: magazine.patternID, fallbackSeed: customFallbackSeed(for: magazine)),
                 kind: .custom,
-                displayName: displayName
+                displayName: displayName,
+                supportedCaliberNames: storedSupportedCaliberNames(for: magazine)
             )
         case .unknown:
             return StoredPatternData(
                 id: MagazinePattern.unknown.id,
                 kind: .unknown,
-                displayName: nil
+                displayName: nil,
+                supportedCaliberNames: []
             )
         }
     }
@@ -221,9 +231,6 @@ struct MagazinePatternMigration {
 
     private static func inferredCatalogPattern(for magazine: Magazine) -> MagazinePattern? {
         let caliberName = primaryCaliberName(for: magazine)
-        if caliberName == nil, magazine.firearm == nil {
-            return nil
-        }
 
         let candidates: [MagazinePattern]
         if let firearm = magazine.firearm {
@@ -364,6 +371,12 @@ struct MagazinePatternMigration {
         }
 
         return []
+    }
+
+    private static func storedSupportedCaliberNames(for magazine: Magazine) -> [String] {
+        magazine.storedPatternSupportedCaliberNames
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
     }
 
     private static func compatibleFirearmTypes(for magazine: Magazine) -> [FirearmType] {

--- a/ArmoryInventory/Accessories/Magazines/MagazinePatternModels.swift
+++ b/ArmoryInventory/Accessories/Magazines/MagazinePatternModels.swift
@@ -219,8 +219,8 @@ enum MagazinePatternCatalog {
         MagazinePattern(
             id: "catalog:glock-double-stack-9mm-full-size-compact",
             kind: .catalog,
-            displayName: "Glock Double-Stack 9mm Full-Size",
-            familyLabel: "Glock Double-Stack 9mm",
+            displayName: "Glock 17 Pattern",
+            familyLabel: "Glock 17 Pattern",
             compatibility: MagazinePatternCompatibility(
                 supportedCalibers: [.mm9],
                 compatibleFirearmTypes: [.pistol],
@@ -234,8 +234,8 @@ enum MagazinePatternCatalog {
         MagazinePattern(
             id: "catalog:glock-double-stack-9mm-compact",
             kind: .catalog,
-            displayName: "Glock Double-Stack 9mm Compact",
-            familyLabel: "Glock Double-Stack 9mm",
+            displayName: "Glock 19 Pattern",
+            familyLabel: "Glock 19 Pattern",
             compatibility: MagazinePatternCompatibility(
                 supportedCalibers: [.mm9],
                 compatibleFirearmTypes: [.pistol],
@@ -245,21 +245,6 @@ enum MagazinePatternCatalog {
             ),
             aliases: ["G19-only 9mm", "Glock OEM 15-round", "Glock compact 9mm"],
             notes: "Shorter Glock-pattern 9mm magazines that do not fit the same set of firearms as full-size bodies."
-        ),
-        MagazinePattern(
-            id: "catalog:sig-p320-double-stack-9mm",
-            kind: .catalog,
-            displayName: "SIG P320 9mm",
-            familyLabel: "SIG P320 9mm",
-            compatibility: MagazinePatternCompatibility(
-                supportedCalibers: [.mm9],
-                compatibleFirearmTypes: [.pistol],
-                compatibleFirearmActions: [.semiAuto],
-                platformTags: ["SIG P320", "SIG M17", "SIG M18", "AXG Pro"],
-                fitDescriptors: ["double-stack service pistol body"]
-            ),
-            aliases: ["P320 9mm", "M17/M18 9mm", "SIG 320 full-size 9mm"],
-            notes: "Double-stack SIG P320 family magazines."
         ),
         MagazinePattern(
             id: "catalog:2011-double-stack-9mm",

--- a/ArmoryInventory/Accessories/Magazines/MagazinePatternModels.swift
+++ b/ArmoryInventory/Accessories/Magazines/MagazinePatternModels.swift
@@ -288,7 +288,7 @@ enum MagazinePatternCatalog {
         caliberName: String?
     ) -> [MagazinePattern] {
         canonicalPatterns.filter {
-            $0.isCompatible(with: firearmType, action: action, caliberName: caliberName)
+            $0.compatibility.supportedCaliberNames.isEmpty || caliberName == nil || $0.supports(caliberName: caliberName)
         }
     }
 }

--- a/ArmoryInventory/Accessories/Magazines/MagazinesView.swift
+++ b/ArmoryInventory/Accessories/Magazines/MagazinesView.swift
@@ -164,17 +164,22 @@ struct MagazinesView: View {
 
     private var groupedMagazines: [MagazinePatternGroup] {
         let grouped = Dictionary(grouping: magazines) { magazine in
-            let pattern = magazine.resolvedPattern
-            return MagazinePatternGroup(
-                id: pattern.id,
-                displayName: pattern.displayName,
-                caliberText: pattern.compatibility.supportedCaliberNames.joined(separator: ", ")
-            )
+            magazine.resolvedPattern.id
         }
 
         return grouped
-            .map { key, magazines in
-                key.with(magazines: magazines)
+            .compactMap { _, magazines in
+                guard let firstMagazine = magazines.first else {
+                    return nil
+                }
+
+                let pattern = firstMagazine.resolvedPattern
+                return MagazinePatternGroup(
+                    id: pattern.id,
+                    displayName: pattern.displayName,
+                    caliberText: pattern.compatibility.supportedCaliberNames.joined(separator: ", "),
+                    magazines: magazines
+                )
             }
             .sorted {
                 $0.displayName.localizedCaseInsensitiveCompare($1.displayName) == .orderedAscending
@@ -203,14 +208,5 @@ private struct MagazinePatternGroup: Identifiable {
         }
 
         return "\(caliberText) • \(countText)"
-    }
-
-    func with(magazines: [Magazine]) -> MagazinePatternGroup {
-        MagazinePatternGroup(
-            id: id,
-            displayName: displayName,
-            caliberText: caliberText,
-            magazines: magazines
-        )
     }
 }

--- a/ArmoryInventory/Accessories/Magazines/MagazinesView.swift
+++ b/ArmoryInventory/Accessories/Magazines/MagazinesView.swift
@@ -42,9 +42,7 @@ struct MagazinesView: View {
                                         HStack {
                                             Text(magazine.caliberDisplayText)
                                             Text("•")
-                                            Text(magazine.countText)
-                                            Text("•")
-                                            Text(magazine.capacityText)
+                                            Text(magazine.countCapacityText)
                                         }
                                         .font(.subheadline)
                                         .foregroundStyle(.secondary)
@@ -233,7 +231,10 @@ private struct MagazinePatternGroup: Identifiable {
 
     var summaryText: String {
         let totalCount = magazines.reduce(0) { $0 + max(0, $1.count) }
-        let countText = totalCount == 1 ? "1 magazine" : "\(totalCount) magazines"
+        let countText = String.localizedStringWithFormat(
+            String(localized: "magazineCount"),
+            Int64(totalCount)
+        )
         guard !caliberText.isEmpty else {
             return countText
         }

--- a/ArmoryInventory/Accessories/Magazines/MagazinesView.swift
+++ b/ArmoryInventory/Accessories/Magazines/MagazinesView.swift
@@ -182,7 +182,25 @@ struct MagazinesView: View {
                 )
             }
             .sorted {
-                $0.displayName.localizedCaseInsensitiveCompare($1.displayName) == .orderedAscending
+                switch ($0.primaryCaliberName, $1.primaryCaliberName) {
+                case let (lhs?, rhs?):
+                    if lhs.caseInsensitiveCompare(rhs) != .orderedSame {
+                        return CaliberSort.areInAscendingOrder(lhs, rhs)
+                    }
+                case (.some, .none):
+                    return true
+                case (.none, .some):
+                    return false
+                case (.none, .none):
+                    break
+                }
+
+                let nameComparison = $0.displayName.localizedCaseInsensitiveCompare($1.displayName)
+                if nameComparison != .orderedSame {
+                    return nameComparison == .orderedAscending
+                }
+
+                return $0.id.localizedCaseInsensitiveCompare($1.id) == .orderedAscending
             }
     }
 }
@@ -208,5 +226,14 @@ private struct MagazinePatternGroup: Identifiable {
         }
 
         return "\(caliberText) • \(countText)"
+    }
+
+    var primaryCaliberName: String? {
+        let caliberNames = caliberText
+            .split(separator: ",")
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+
+        return caliberNames.first
     }
 }

--- a/ArmoryInventory/Accessories/Magazines/MagazinesView.swift
+++ b/ArmoryInventory/Accessories/Magazines/MagazinesView.swift
@@ -29,43 +29,56 @@ struct MagazinesView: View {
                 )
             } else {
                 List {
-                    ForEach(magazines) { magazine in
-                        Button {
-                            selectedMagazine = magazine
-                        } label: {
-                            let linkedFirearms = magazine.linkedFirearms(from: firearms)
+                    ForEach(groupedMagazines) { group in
+                        Section {
+                            ForEach(group.magazines) { magazine in
+                                Button {
+                                    selectedMagazine = magazine
+                                } label: {
+                                    let linkedFirearms = magazine.linkedFirearms(from: firearms)
 
-                            VStack(alignment: .leading, spacing: 6) {
-                                Text(magazine.displayName)
-                                    .font(.headline)
+                                    VStack(alignment: .leading, spacing: 6) {
+                                        Text(magazine.displayName)
+                                            .font(.headline)
 
-                                HStack {
-                                    Text(magazine.caliberDisplayText)
-                                    Text("•")
-                                    Text(magazine.countText)
-                                    Text("•")
-                                    Text(magazine.capacityText)
+                                        HStack {
+                                            Text(magazine.caliberDisplayText)
+                                            Text("•")
+                                            Text(magazine.countText)
+                                            Text("•")
+                                            Text(magazine.capacityText)
+                                        }
+                                        .font(.subheadline)
+                                        .foregroundStyle(.secondary)
+
+                                        if showValueInCard, magazine.purchasePriceCents > 0 {
+                                            LabeledContent("Value", value: magazine.purchasePriceText)
+                                        }
+
+                                        if !linkedFirearms.isEmpty {
+                                            LabeledContent(
+                                                linkedFirearms.count == 1 ? "Linked Firearm" : "Linked Firearms",
+                                                value: linkedFirearms.map(\.displayName).joined(separator: ", ")
+                                            )
+                                        }
+                                    }
+                                    .padding(.vertical, 6)
+                                    .contentShape(Rectangle())
                                 }
-                                .font(.subheadline)
-                                .foregroundStyle(.secondary)
-
-                                if showValueInCard, magazine.purchasePriceCents > 0 {
-                                    LabeledContent("Value", value: magazine.purchasePriceText)
-                                }
-
-                                if !linkedFirearms.isEmpty {
-                                    LabeledContent(
-                                        linkedFirearms.count == 1 ? "Linked Firearm" : "Linked Firearms",
-                                        value: linkedFirearms.map(\.displayName).joined(separator: ", ")
-                                    )
-                                }
+                                .buttonStyle(.plain)
                             }
-                            .padding(.vertical, 6)
-                            .contentShape(Rectangle())
+                            .onDelete { offsets in
+                                deleteMagazines(in: group.magazines, at: offsets)
+                            }
+                        } header: {
+                            VStack(alignment: .leading, spacing: 2) {
+                                Text(group.displayName)
+                                Text(group.summaryText)
+                                    .font(.caption)
+                                    .foregroundStyle(.secondary)
+                            }
                         }
-                        .buttonStyle(.plain)
                     }
-                    .onDelete(perform: deleteMagazines)
 
                     if showTotalValue {
                         Section {
@@ -114,9 +127,9 @@ struct MagazinesView: View {
         }
     }
 
-    private func deleteMagazines(at offsets: IndexSet) {
+    private func deleteMagazines(in group: [Magazine], at offsets: IndexSet) {
         for index in offsets {
-            context.delete(magazines[index])
+            context.delete(group[index])
         }
         resequenceMagazines()
 
@@ -147,5 +160,57 @@ struct MagazinesView: View {
         let totalCents = magazines.reduce(0) { $0 + max(0, $1.purchasePriceCents) }
         let amount = Decimal(totalCents) / 100
         return amount.formatted(.currency(code: Locale.current.currency?.identifier ?? "USD"))
+    }
+
+    private var groupedMagazines: [MagazinePatternGroup] {
+        let grouped = Dictionary(grouping: magazines) { magazine in
+            let pattern = magazine.resolvedPattern
+            return MagazinePatternGroup(
+                id: pattern.id,
+                displayName: pattern.displayName,
+                caliberText: pattern.compatibility.supportedCaliberNames.joined(separator: ", ")
+            )
+        }
+
+        return grouped
+            .map { key, magazines in
+                key.with(magazines: magazines)
+            }
+            .sorted {
+                $0.displayName.localizedCaseInsensitiveCompare($1.displayName) == .orderedAscending
+            }
+    }
+}
+
+private struct MagazinePatternGroup: Identifiable {
+    let id: String
+    let displayName: String
+    let caliberText: String
+    let magazines: [Magazine]
+
+    init(id: String, displayName: String, caliberText: String, magazines: [Magazine] = []) {
+        self.id = id
+        self.displayName = displayName
+        self.caliberText = caliberText
+        self.magazines = magazines
+    }
+
+    var summaryText: String {
+        let totalCount = magazines.reduce(0) { $0 + max(0, $1.count) }
+        let countText = totalCount == 1 ? "1 magazine" : "\(totalCount) magazines"
+        guard !caliberText.isEmpty else {
+            return countText
+        }
+
+        return "\(caliberText) • \(countText)"
+    }
+
+    func with(magazines: [Magazine]) -> MagazinePatternGroup {
+        MagazinePatternGroup(
+            id: id,
+            displayName: displayName,
+            caliberText: caliberText,
+            magazines: magazines
+        )
     }
 }

--- a/ArmoryInventory/Accessories/Magazines/MagazinesView.swift
+++ b/ArmoryInventory/Accessories/Magazines/MagazinesView.swift
@@ -10,6 +10,7 @@ import SwiftData
 
 struct MagazinesView: View {
     @Environment(\.modelContext) private var context
+    @Query(sort: [SortDescriptor(\Firearm.brand), SortDescriptor(\Firearm.modelName)]) private var firearms: [Firearm]
     @AppStorage(InventorySettingsKeys.showValueInCard) private var showValueInCard = true
     @AppStorage(InventorySettingsKeys.showTotalValue) private var showTotalValue = true
     @State private var showingAddMagazine = false
@@ -24,7 +25,7 @@ struct MagazinesView: View {
                 ContentUnavailableView(
                     "No Magazines Yet",
                     systemImage: "rectangle.stack.fill.badge.plus",
-                    description: Text("Add your first magazine to track capacity, caliber, and assigned firearm.")
+                    description: Text("Add your first magazine to track capacity, supported calibers, and linked firearms.")
                 )
             } else {
                 List {
@@ -32,12 +33,14 @@ struct MagazinesView: View {
                         Button {
                             selectedMagazine = magazine
                         } label: {
+                            let linkedFirearms = magazine.linkedFirearms(from: firearms)
+
                             VStack(alignment: .leading, spacing: 6) {
                                 Text(magazine.displayName)
                                     .font(.headline)
 
                                 HStack {
-                                    Text(magazine.caliber?.name ?? "No Caliber")
+                                    Text(magazine.caliberDisplayText)
                                     Text("•")
                                     Text(magazine.countText)
                                     Text("•")
@@ -50,8 +53,11 @@ struct MagazinesView: View {
                                     LabeledContent("Value", value: magazine.purchasePriceText)
                                 }
 
-                                if let firearm = magazine.firearm {
-                                    LabeledContent("Linked Firearm", value: firearm.displayName)
+                                if !linkedFirearms.isEmpty {
+                                    LabeledContent(
+                                        linkedFirearms.count == 1 ? "Linked Firearm" : "Linked Firearms",
+                                        value: linkedFirearms.map(\.displayName).joined(separator: ", ")
+                                    )
                                 }
                             }
                             .padding(.vertical, 6)

--- a/ArmoryInventory/Accessories/Magazines/MagazinesView.swift
+++ b/ArmoryInventory/Accessories/Magazines/MagazinesView.swift
@@ -35,8 +35,6 @@ struct MagazinesView: View {
                                 Button {
                                     selectedMagazine = magazine
                                 } label: {
-                                    let linkedFirearms = magazine.linkedFirearms(from: firearms)
-
                                     VStack(alignment: .leading, spacing: 6) {
                                         Text(magazine.displayName)
                                             .font(.headline)
@@ -54,13 +52,6 @@ struct MagazinesView: View {
                                         if showValueInCard, magazine.purchasePriceCents > 0 {
                                             LabeledContent("Value", value: magazine.purchasePriceText)
                                         }
-
-                                        if !linkedFirearms.isEmpty {
-                                            LabeledContent(
-                                                linkedFirearms.count == 1 ? "Linked Firearm" : "Linked Firearms",
-                                                value: linkedFirearms.map(\.displayName).joined(separator: ", ")
-                                            )
-                                        }
                                     }
                                     .padding(.vertical, 6)
                                     .contentShape(Rectangle())
@@ -76,6 +67,11 @@ struct MagazinesView: View {
                                 Text(group.summaryText)
                                     .font(.caption)
                                     .foregroundStyle(.secondary)
+                                if let linkedFirearmsText = group.linkedFirearmsText {
+                                    Text(linkedFirearmsText)
+                                        .font(.caption)
+                                        .foregroundStyle(.secondary)
+                                }
                             }
                         }
                     }
@@ -162,6 +158,20 @@ struct MagazinesView: View {
         return amount.formatted(.currency(code: Locale.current.currency?.identifier ?? "USD"))
     }
 
+    private func linkedFirearmNames(for magazines: [Magazine]) -> [String] {
+        var uniqueNames: Set<String> = []
+
+        for magazine in magazines {
+            for firearm in magazine.linkedFirearms(from: firearms) {
+                uniqueNames.insert(firearm.displayName)
+            }
+        }
+
+        return uniqueNames.sorted {
+            $0.localizedCaseInsensitiveCompare($1) == .orderedAscending
+        }
+    }
+
     private var groupedMagazines: [MagazinePatternGroup] {
         let grouped = Dictionary(grouping: magazines) { magazine in
             magazine.resolvedPattern.id
@@ -178,6 +188,7 @@ struct MagazinesView: View {
                     id: pattern.id,
                     displayName: pattern.displayName,
                     caliberText: pattern.compatibility.supportedCaliberNames.joined(separator: ", "),
+                    linkedFirearmNames: linkedFirearmNames(for: magazines),
                     magazines: magazines
                 )
             }
@@ -209,12 +220,14 @@ private struct MagazinePatternGroup: Identifiable {
     let id: String
     let displayName: String
     let caliberText: String
+    let linkedFirearmNames: [String]
     let magazines: [Magazine]
 
-    init(id: String, displayName: String, caliberText: String, magazines: [Magazine] = []) {
+    init(id: String, displayName: String, caliberText: String, linkedFirearmNames: [String] = [], magazines: [Magazine] = []) {
         self.id = id
         self.displayName = displayName
         self.caliberText = caliberText
+        self.linkedFirearmNames = linkedFirearmNames
         self.magazines = magazines
     }
 
@@ -235,5 +248,17 @@ private struct MagazinePatternGroup: Identifiable {
             .filter { !$0.isEmpty }
 
         return caliberNames.first
+    }
+
+    var linkedFirearmsText: String? {
+        let baseText = String.localizedStringWithFormat(
+            String(localized: "usedByFirearm"),
+            Int64(linkedFirearmNames.count)
+        )
+        guard !linkedFirearmNames.isEmpty else {
+            return baseText
+        }
+
+        return "\(baseText)\(linkedFirearmNames.joined(separator: ", "))"
     }
 }

--- a/ArmoryInventory/Firearms/AddFirearmView.swift
+++ b/ArmoryInventory/Firearms/AddFirearmView.swift
@@ -32,13 +32,11 @@ struct AddFirearmView: View {
     @State private var notes = ""
     @State private var selectedCaliber: Caliber?
     @State private var selectedOpticIDs: Set<PersistentIdentifier> = []
-    @State private var selectedMagazineIDs: Set<PersistentIdentifier> = []
     @State private var selectedMagazinePatterns: [FirearmMagazinePatternReference] = []
     @State private var selectedAttachmentIDs: Set<PersistentIdentifier> = []
     @State private var selectedPartIDs: Set<PersistentIdentifier> = []
     @State private var showingOpticsPicker = false
     @State private var showingMagazinePatternsPicker = false
-    @State private var showingMagazinesPicker = false
     @State private var showingAttachmentsPicker = false
     @State private var showingPartsPicker = false
     @State private var showingAddCaliber = false
@@ -75,7 +73,6 @@ struct AddFirearmView: View {
         _customColor = State(initialValue: firearm?.firearmColor == .other ? firearm?.colorDetail ?? "" : "")
         _selectedCaliber = State(initialValue: firearm?.caliber)
         _selectedOpticIDs = State(initialValue: viewModel.selectedOpticIDs(for: firearm))
-        _selectedMagazineIDs = State(initialValue: viewModel.selectedMagazineIDs(for: firearm))
         _selectedMagazinePatterns = State(initialValue: viewModel.selectedMagazinePatterns(for: firearm))
         _selectedAttachmentIDs = State(initialValue: viewModel.selectedAttachmentIDs(for: firearm))
         _selectedPartIDs = State(initialValue: viewModel.selectedPartIDs(for: firearm))
@@ -272,7 +269,7 @@ struct AddFirearmView: View {
                     }
                 }
 
-                Section("Linked Magazines") {
+                Section("Magazine Patterns") {
                     if isEditing {
                         Button {
                             showingMagazinePatternsPicker = true
@@ -285,7 +282,7 @@ struct AddFirearmView: View {
                     }
 
                     if selectedMagazinePatterns.isEmpty {
-                        Text("No magazine patterns selected. All compatible magazines remain available.")
+                        Text("No magazine patterns selected.")
                             .font(.footnote)
                             .foregroundStyle(.secondary)
                     } else {
@@ -298,15 +295,9 @@ struct AddFirearmView: View {
                             }
                         }
                     }
+                }
 
-                    if isEditing {
-                        Button {
-                            showingMagazinesPicker = true
-                        } label: {
-                            Label(selectedMagazineIDs.isEmpty ? "Add Magazines" : "Manage Magazines", systemImage: "plus.circle")
-                        }
-                    }
-
+                Section("Linked Magazines") {
                     if let compatibilityMessage = selectedMagazineCompatibilityMessage {
                         Text(compatibilityMessage)
                             .font(.footnote)
@@ -317,12 +308,12 @@ struct AddFirearmView: View {
                         Text("Add magazines first to link them to this firearm.")
                             .font(.footnote)
                             .foregroundStyle(.secondary)
-                    } else if availableMagazines.isEmpty {
-                        Text("No compatible magazines are currently available.")
+                    } else if selectedMagazinePatterns.isEmpty {
+                        Text("Select one or more magazine patterns to see linked magazines.")
                             .font(.footnote)
                             .foregroundStyle(.secondary)
                     } else if resolvedMagazines.isEmpty {
-                        Text("No magazines linked.")
+                        Text("No magazines currently match the selected patterns.")
                             .font(.footnote)
                             .foregroundStyle(.secondary)
                     } else {
@@ -558,57 +549,6 @@ struct AddFirearmView: View {
                 }
                 .presentationDetents([.medium, .large])
             }
-            .sheet(isPresented: $showingMagazinesPicker) {
-                NavigationStack {
-                    Group {
-                        if availableMagazines.isEmpty {
-                            ContentUnavailableView(
-                                "No Magazines Available",
-                                systemImage: "rectangle.stack.fill.badge.plus",
-                                description: Text("All compatible magazines are linked to other firearms or none have been added yet.")
-                            )
-                        } else {
-                            List {
-                                ForEach(availableMagazines) { magazine in
-                                    Button {
-                                        toggleMagazineSelection(for: magazine)
-                                    } label: {
-                                        HStack {
-                                            VStack(alignment: .leading, spacing: 2) {
-                                                Text(magazine.displayName)
-                                                    .foregroundStyle(.primary)
-                                                Text("\(magazine.caliber?.name ?? "No Caliber") • \(magazine.capacityText)")
-                                                    .font(.footnote)
-                                                    .foregroundStyle(.secondary)
-                                            }
-                                            Spacer()
-                                            if selectedMagazineIDs.contains(magazine.persistentModelID) {
-                                                Image(systemName: "checkmark.circle.fill")
-                                                    .foregroundStyle(.tint)
-                                            } else {
-                                                Image(systemName: "circle")
-                                                    .foregroundStyle(.tertiary)
-                                            }
-                                        }
-                                        .contentShape(Rectangle())
-                                    }
-                                    .buttonStyle(.plain)
-                                }
-                            }
-                        }
-                    }
-                    .navigationTitle("Link Magazines")
-                    .navigationBarTitleDisplayMode(.inline)
-                    .toolbar {
-                        ToolbarItem(placement: .cancellationAction) {
-                            Button("Done") {
-                                showingMagazinesPicker = false
-                            }
-                        }
-                    }
-                }
-                .presentationDetents([.medium, .large])
-            }
             .sheet(isPresented: $showingAttachmentsPicker) {
                 NavigationStack {
                     Group {
@@ -754,7 +694,13 @@ struct AddFirearmView: View {
     }
 
     private var resolvedMagazines: [Magazine] {
-        viewModel.resolvedMagazines(from: lookupData.magazines, selectedIDs: selectedMagazineIDs)
+        viewModel.linkedMagazines(
+            from: lookupData.magazines,
+            selectedPatterns: selectedMagazinePatterns,
+            firearmType: selectedType,
+            action: selectedAction,
+            caliber: selectedCaliber
+        )
     }
 
     private var resolvedAttachments: [Attachment] {
@@ -767,18 +713,6 @@ struct AddFirearmView: View {
 
     private var availableOptics: [Optic] {
         viewModel.availableOptics(from: lookupData.optics, selectedIDs: selectedOpticIDs, firearm: firearm)
-    }
-
-    private var availableMagazines: [Magazine] {
-        viewModel.availableMagazines(
-            from: lookupData.magazines,
-            selectedIDs: selectedMagazineIDs,
-            selectedPatterns: selectedMagazinePatterns,
-            firearm: firearm,
-            firearmType: selectedType,
-            action: selectedAction,
-            caliber: selectedCaliber
-        )
     }
 
     private var selectedMagazineCompatibilityMessage: String? {
@@ -976,14 +910,6 @@ struct AddFirearmView: View {
         selectedOpticIDs = viewModel.toggledSelection(
             currentSelection: selectedOpticIDs,
             itemID: optic.persistentModelID,
-            isEditing: isEditing
-        )
-    }
-
-    private func toggleMagazineSelection(for magazine: Magazine) {
-        selectedMagazineIDs = viewModel.toggledSelection(
-            currentSelection: selectedMagazineIDs,
-            itemID: magazine.persistentModelID,
             isEditing: isEditing
         )
     }

--- a/ArmoryInventory/Firearms/AddFirearmView.swift
+++ b/ArmoryInventory/Firearms/AddFirearmView.swift
@@ -320,7 +320,7 @@ struct AddFirearmView: View {
                         ForEach(resolvedMagazines) { magazine in
                             VStack(alignment: .leading, spacing: 2) {
                                 Text(magazine.displayName)
-                                Text("\(magazine.caliber?.name ?? "No Caliber") • \(magazine.countText) • \(magazine.capacityText)")
+                                Text("\(magazine.caliberDisplayText) • \(magazine.countText) • \(magazine.capacityText)")
                                     .font(.footnote)
                                     .foregroundStyle(.secondary)
                             }
@@ -1094,7 +1094,7 @@ private struct FirearmSnapshotCard: View {
             }
 
             linkedSection("Linked Optics", items: optics.map { "\($0.displayName) • \($0.magnificationText)" })
-            linkedSection("Linked Magazines", items: magazines.map { "\($0.displayName) • \($0.countText) • \($0.capacityText)" })
+            linkedSection("Linked Magazines", items: magazines.map { "\($0.displayName) • \($0.caliberDisplayText) • \($0.countText) • \($0.capacityText)" })
             linkedSection("Linked Attachments", items: attachments.map { "\($0.displayName) • \($0.typeDisplayName)" })
             linkedSection("Linked Parts", items: parts.map { "\($0.displayName) • \($0.typeDisplayName)" })
 

--- a/ArmoryInventory/Firearms/AddFirearmView.swift
+++ b/ArmoryInventory/Firearms/AddFirearmView.swift
@@ -829,12 +829,11 @@ struct AddFirearmView: View {
 
     private func patternDetailText(for pattern: FirearmMagazinePatternReference) -> String {
         let magazines = resolvedMagazines.filter { $0.resolvedPattern.id == pattern.id }
-        let patternKindText = pattern.kind == .catalog ? "Catalog pattern" : pattern.kind.id.capitalized
         guard !magazines.isEmpty else {
-            return patternKindText
+            return ""
         }
 
-        return "\(patternKindText) • \(currentFirearmForSummary.linkedMagazineCountText(using: magazines)) • \(currentFirearmForSummary.linkedMagazineCapacityText(using: magazines))"
+        return "\(currentFirearmForSummary.linkedMagazineCountText(using: magazines)) • \(currentFirearmForSummary.linkedMagazineCapacityText(using: magazines))"
     }
 
     private func saveFirearm() {

--- a/ArmoryInventory/Firearms/AddFirearmView.swift
+++ b/ArmoryInventory/Firearms/AddFirearmView.swift
@@ -317,10 +317,13 @@ struct AddFirearmView: View {
                             .font(.footnote)
                             .foregroundStyle(.secondary)
                     } else {
+                        LabeledContent("Magazine Count", value: firearmMagazineCountText)
+                        LabeledContent("Total Capacity", value: firearmMagazineCapacityText)
+
                         ForEach(resolvedMagazines) { magazine in
                             VStack(alignment: .leading, spacing: 2) {
                                 Text(magazine.displayName)
-                                Text("\(magazine.caliber?.name ?? "No Caliber") • \(magazine.capacityText)")
+                                Text("\(magazine.caliber?.name ?? "No Caliber") • \(magazine.countText) • \(magazine.capacityText)")
                                     .font(.footnote)
                                     .foregroundStyle(.secondary)
                             }
@@ -781,6 +784,24 @@ struct AddFirearmView: View {
         return opticsTotal + magazinesTotal + attachmentsTotal + partsTotal
     }
 
+    private var firearmMagazineCountText: String {
+        currentFirearmForSummary.linkedMagazineCountText(using: resolvedMagazines)
+    }
+
+    private var firearmMagazineCapacityText: String {
+        currentFirearmForSummary.linkedMagazineCapacityText(using: resolvedMagazines)
+    }
+
+    private var currentFirearmForSummary: Firearm {
+        firearm ?? Firearm(
+            brand: brand,
+            modelName: modelName,
+            purchasePriceCents: resolvedPurchasePriceCents ?? 0,
+            type: selectedType,
+            action: selectedAction
+        )
+    }
+
     private var primaryButtonTitle: String {
         viewModel.primaryButtonTitle(hasFirearm: firearm != nil, isEditing: isEditing)
     }
@@ -1074,7 +1095,7 @@ private struct FirearmSnapshotCard: View {
             }
 
             linkedSection("Linked Optics", items: optics.map { "\($0.displayName) • \($0.magnificationText)" })
-            linkedSection("Linked Magazines", items: magazines.map { "\($0.displayName) • \($0.capacityText)" })
+            linkedSection("Linked Magazines", items: magazines.map { "\($0.displayName) • \($0.countText) • \($0.capacityText)" })
             linkedSection("Linked Attachments", items: attachments.map { "\($0.displayName) • \($0.typeDisplayName)" })
             linkedSection("Linked Parts", items: parts.map { "\($0.displayName) • \($0.typeDisplayName)" })
 
@@ -1146,6 +1167,11 @@ private struct FirearmSnapshotCard: View {
 
             if let lastCleaned = firearm.lastCleanedDateText {
                 snapshotMetric("Last Cleaned", lastCleaned)
+            }
+
+            if !magazines.isEmpty {
+                snapshotMetric("Magazine Count", firearm.linkedMagazineCountText(using: magazines))
+                snapshotMetric("Total Capacity", firearm.linkedMagazineCapacityText(using: magazines))
             }
 
             if showsValue {

--- a/ArmoryInventory/Firearms/AddFirearmView.swift
+++ b/ArmoryInventory/Firearms/AddFirearmView.swift
@@ -289,7 +289,7 @@ struct AddFirearmView: View {
                         ForEach(selectedMagazinePatterns, id: \.id) { pattern in
                             VStack(alignment: .leading, spacing: 2) {
                                 Text(pattern.resolvedDisplayName)
-                                Text(pattern.kind == .catalog ? "Catalog pattern" : pattern.kind.id.capitalized)
+                                Text(patternDetailText(for: pattern))
                                     .font(.footnote)
                                     .foregroundStyle(.secondary)
                             }
@@ -317,9 +317,6 @@ struct AddFirearmView: View {
                             .font(.footnote)
                             .foregroundStyle(.secondary)
                     } else {
-                        LabeledContent("Magazine Count", value: firearmMagazineCountText)
-                        LabeledContent("Total Capacity", value: firearmMagazineCapacityText)
-
                         ForEach(resolvedMagazines) { magazine in
                             VStack(alignment: .leading, spacing: 2) {
                                 Text(magazine.displayName)
@@ -784,14 +781,6 @@ struct AddFirearmView: View {
         return opticsTotal + magazinesTotal + attachmentsTotal + partsTotal
     }
 
-    private var firearmMagazineCountText: String {
-        currentFirearmForSummary.linkedMagazineCountText(using: resolvedMagazines)
-    }
-
-    private var firearmMagazineCapacityText: String {
-        currentFirearmForSummary.linkedMagazineCapacityText(using: resolvedMagazines)
-    }
-
     private var currentFirearmForSummary: Firearm {
         firearm ?? Firearm(
             brand: brand,
@@ -836,6 +825,16 @@ struct AddFirearmView: View {
 
     private func taxedAmountCents(baseAmountCents: Int, taxRate: Double) -> Int {
         Int((Double(baseAmountCents) * (1 + max(0, taxRate) / 100)).rounded())
+    }
+
+    private func patternDetailText(for pattern: FirearmMagazinePatternReference) -> String {
+        let magazines = resolvedMagazines.filter { $0.resolvedPattern.id == pattern.id }
+        let patternKindText = pattern.kind == .catalog ? "Catalog pattern" : pattern.kind.id.capitalized
+        guard !magazines.isEmpty else {
+            return patternKindText
+        }
+
+        return "\(patternKindText) • \(currentFirearmForSummary.linkedMagazineCountText(using: magazines)) • \(currentFirearmForSummary.linkedMagazineCapacityText(using: magazines))"
     }
 
     private func saveFirearm() {

--- a/ArmoryInventory/Firearms/AddFirearmView.swift
+++ b/ArmoryInventory/Firearms/AddFirearmView.swift
@@ -33,9 +33,11 @@ struct AddFirearmView: View {
     @State private var selectedCaliber: Caliber?
     @State private var selectedOpticIDs: Set<PersistentIdentifier> = []
     @State private var selectedMagazineIDs: Set<PersistentIdentifier> = []
+    @State private var selectedMagazinePatterns: [FirearmMagazinePatternReference] = []
     @State private var selectedAttachmentIDs: Set<PersistentIdentifier> = []
     @State private var selectedPartIDs: Set<PersistentIdentifier> = []
     @State private var showingOpticsPicker = false
+    @State private var showingMagazinePatternsPicker = false
     @State private var showingMagazinesPicker = false
     @State private var showingAttachmentsPicker = false
     @State private var showingPartsPicker = false
@@ -74,6 +76,7 @@ struct AddFirearmView: View {
         _selectedCaliber = State(initialValue: firearm?.caliber)
         _selectedOpticIDs = State(initialValue: viewModel.selectedOpticIDs(for: firearm))
         _selectedMagazineIDs = State(initialValue: viewModel.selectedMagazineIDs(for: firearm))
+        _selectedMagazinePatterns = State(initialValue: viewModel.selectedMagazinePatterns(for: firearm))
         _selectedAttachmentIDs = State(initialValue: viewModel.selectedAttachmentIDs(for: firearm))
         _selectedPartIDs = State(initialValue: viewModel.selectedPartIDs(for: firearm))
         _barrelLengthText = State(initialValue: viewModel.initialBarrelLengthText(for: firearm))
@@ -270,6 +273,32 @@ struct AddFirearmView: View {
                 }
 
                 Section("Linked Magazines") {
+                    if isEditing {
+                        Button {
+                            showingMagazinePatternsPicker = true
+                        } label: {
+                            Label(
+                                selectedMagazinePatterns.isEmpty ? "Select Magazine Patterns" : "Manage Magazine Patterns",
+                                systemImage: "square.stack.3d.down.right.fill"
+                            )
+                        }
+                    }
+
+                    if selectedMagazinePatterns.isEmpty {
+                        Text("No magazine patterns selected. All compatible magazines remain available.")
+                            .font(.footnote)
+                            .foregroundStyle(.secondary)
+                    } else {
+                        ForEach(selectedMagazinePatterns, id: \.id) { pattern in
+                            VStack(alignment: .leading, spacing: 2) {
+                                Text(pattern.resolvedDisplayName)
+                                Text(pattern.kind == .catalog ? "Catalog pattern" : pattern.kind.id.capitalized)
+                                    .font(.footnote)
+                                    .foregroundStyle(.secondary)
+                            }
+                        }
+                    }
+
                     if isEditing {
                         Button {
                             showingMagazinesPicker = true
@@ -472,6 +501,57 @@ struct AddFirearmView: View {
                         ToolbarItem(placement: .cancellationAction) {
                             Button("Done") {
                                 showingOpticsPicker = false
+                            }
+                        }
+                    }
+                }
+                .presentationDetents([.medium, .large])
+            }
+            .sheet(isPresented: $showingMagazinePatternsPicker) {
+                NavigationStack {
+                    Group {
+                        if availableMagazinePatterns.isEmpty {
+                            ContentUnavailableView(
+                                "No Magazine Patterns Available",
+                                systemImage: "square.stack.3d.down.right.fill",
+                                description: Text("Add magazines or select a caliber to surface compatible patterns.")
+                            )
+                        } else {
+                            List {
+                                ForEach(availableMagazinePatterns, id: \.id) { pattern in
+                                    Button {
+                                        toggleMagazinePatternSelection(for: pattern)
+                                    } label: {
+                                        HStack {
+                                            VStack(alignment: .leading, spacing: 2) {
+                                                Text(pattern.resolvedDisplayName)
+                                                    .foregroundStyle(.primary)
+                                                Text(pattern.kind == .catalog ? "Catalog pattern" : pattern.kind.id.capitalized)
+                                                    .font(.footnote)
+                                                    .foregroundStyle(.secondary)
+                                            }
+                                            Spacer()
+                                            if selectedMagazinePatterns.contains(where: { $0.id == pattern.id }) {
+                                                Image(systemName: "checkmark.circle.fill")
+                                                    .foregroundStyle(.tint)
+                                            } else {
+                                                Image(systemName: "circle")
+                                                    .foregroundStyle(.tertiary)
+                                            }
+                                        }
+                                        .contentShape(Rectangle())
+                                    }
+                                    .buttonStyle(.plain)
+                                }
+                            }
+                        }
+                    }
+                    .navigationTitle("Magazine Patterns")
+                    .navigationBarTitleDisplayMode(.inline)
+                    .toolbar {
+                        ToolbarItem(placement: .cancellationAction) {
+                            Button("Done") {
+                                showingMagazinePatternsPicker = false
                             }
                         }
                     }
@@ -693,6 +773,7 @@ struct AddFirearmView: View {
         viewModel.availableMagazines(
             from: lookupData.magazines,
             selectedIDs: selectedMagazineIDs,
+            selectedPatterns: selectedMagazinePatterns,
             firearm: firearm,
             firearmType: selectedType,
             action: selectedAction,
@@ -703,11 +784,22 @@ struct AddFirearmView: View {
     private var selectedMagazineCompatibilityMessage: String? {
         viewModel.selectedMagazineValidationResult(
             magazines: resolvedMagazines,
+            selectedPatterns: selectedMagazinePatterns,
             firearmType: selectedType,
             action: selectedAction,
             caliber: selectedCaliber,
             owningFirearm: firearm
         ).message
+    }
+
+    private var availableMagazinePatterns: [FirearmMagazinePatternReference] {
+        viewModel.availableMagazinePatterns(
+            from: lookupData.magazines,
+            firearmType: selectedType,
+            action: selectedAction,
+            caliber: selectedCaliber,
+            selectedPatterns: selectedMagazinePatterns
+        )
     }
 
     private var availableAttachments: [Attachment] {
@@ -773,6 +865,7 @@ struct AddFirearmView: View {
             barrelLengthText: barrelLengthText,
             duplicateExists: duplicateExists,
             magazines: resolvedMagazines,
+            selectedMagazinePatterns: selectedMagazinePatterns,
             caliber: selectedCaliber,
             owningFirearm: firearm
         )
@@ -809,6 +902,7 @@ struct AddFirearmView: View {
                 colorDetail: resolvedColorDetail,
                 barrelLengthInches: resolvedBarrelLength,
                 notes: resolvedNotes,
+                supportedMagazinePatterns: selectedMagazinePatterns,
                 caliber: selectedCaliber,
                 optics: resolvedOptics,
                 magazines: resolvedMagazines,
@@ -833,6 +927,7 @@ struct AddFirearmView: View {
                 colorDetail: resolvedColorDetail,
                 barrelLengthInches: resolvedBarrelLength,
                 notes: resolvedNotes,
+                supportedMagazinePatterns: selectedMagazinePatterns,
                 caliber: selectedCaliber,
                 optics: resolvedOptics,
                 magazines: resolvedMagazines,
@@ -889,6 +984,14 @@ struct AddFirearmView: View {
         selectedMagazineIDs = viewModel.toggledSelection(
             currentSelection: selectedMagazineIDs,
             itemID: magazine.persistentModelID,
+            isEditing: isEditing
+        )
+    }
+
+    private func toggleMagazinePatternSelection(for pattern: FirearmMagazinePatternReference) {
+        selectedMagazinePatterns = viewModel.toggledMagazinePatternSelection(
+            currentSelection: selectedMagazinePatterns,
+            pattern: pattern,
             isEditing: isEditing
         )
     }

--- a/ArmoryInventory/Firearms/AddFirearmView.swift
+++ b/ArmoryInventory/Firearms/AddFirearmView.swift
@@ -320,7 +320,7 @@ struct AddFirearmView: View {
                         ForEach(resolvedMagazines) { magazine in
                             VStack(alignment: .leading, spacing: 2) {
                                 Text(magazine.displayName)
-                                Text("\(magazine.caliberDisplayText) • \(magazine.countText) • \(magazine.capacityText)")
+                                Text("\(magazine.caliberDisplayText) • \(magazine.countCapacityText)")
                                     .font(.footnote)
                                     .foregroundStyle(.secondary)
                             }
@@ -1094,7 +1094,7 @@ private struct FirearmSnapshotCard: View {
             }
 
             linkedSection("Linked Optics", items: optics.map { "\($0.displayName) • \($0.magnificationText)" })
-            linkedSection("Linked Magazines", items: magazines.map { "\($0.displayName) • \($0.caliberDisplayText) • \($0.countText) • \($0.capacityText)" })
+            linkedSection("Linked Magazines", items: magazines.map { "\($0.displayName) • \($0.caliberDisplayText) • \($0.countCapacityText)" })
             linkedSection("Linked Attachments", items: attachments.map { "\($0.displayName) • \($0.typeDisplayName)" })
             linkedSection("Linked Parts", items: parts.map { "\($0.displayName) • \($0.typeDisplayName)" })
 

--- a/ArmoryInventory/Firearms/AddFirearmView.swift
+++ b/ArmoryInventory/Firearms/AddFirearmView.swift
@@ -297,7 +297,7 @@ struct AddFirearmView: View {
                     }
                 }
 
-                Section("Linked Magazines") {
+                Section("Compatible Magazines") {
                     if let compatibilityMessage = selectedMagazineCompatibilityMessage {
                         Text(compatibilityMessage)
                             .font(.footnote)
@@ -305,15 +305,15 @@ struct AddFirearmView: View {
                     }
 
                     if lookupData.magazines.isEmpty {
-                        Text("Add magazines first to link them to this firearm.")
+                        Text("Add magazines first to see which ones are compatible with this firearm.")
                             .font(.footnote)
                             .foregroundStyle(.secondary)
                     } else if selectedMagazinePatterns.isEmpty {
-                        Text("Select one or more magazine patterns to see linked magazines.")
+                        Text("Select one or more magazine patterns to see compatible magazines.")
                             .font(.footnote)
                             .foregroundStyle(.secondary)
                     } else if resolvedMagazines.isEmpty {
-                        Text("No magazines currently match the selected patterns.")
+                        Text("No magazines are currently compatible with the selected patterns.")
                             .font(.footnote)
                             .foregroundStyle(.secondary)
                     } else {

--- a/ArmoryInventory/Firearms/AddFirearmViewModel.swift
+++ b/ArmoryInventory/Firearms/AddFirearmViewModel.swift
@@ -36,12 +36,16 @@ final class AddFirearmViewModel {
         Set(firearm?.optics.map(\.persistentModelID) ?? [])
     }
 
-    func selectedMagazineIDs(for firearm: Firearm?) -> Set<PersistentIdentifier> {
-        Set(firearm?.magazines.map(\.persistentModelID) ?? [])
-    }
-
     func selectedMagazinePatterns(for firearm: Firearm?) -> [FirearmMagazinePatternReference] {
-        firearm?.supportedMagazinePatterns ?? []
+        guard let firearm else {
+            return []
+        }
+
+        if !firearm.supportedMagazinePatterns.isEmpty {
+            return firearm.supportedMagazinePatterns
+        }
+
+        return inferredMagazinePatterns(from: firearm.magazines)
     }
 
     func selectedAttachmentIDs(for firearm: Firearm?) -> Set<PersistentIdentifier> {
@@ -108,10 +112,6 @@ final class AddFirearmViewModel {
 
     func resolvedOptics(from optics: [Optic], selectedIDs: Set<PersistentIdentifier>) -> [Optic] {
         optics.filter { selectedIDs.contains($0.persistentModelID) }
-    }
-
-    func resolvedMagazines(from magazines: [Magazine], selectedIDs: Set<PersistentIdentifier>) -> [Magazine] {
-        magazines.filter { selectedIDs.contains($0.persistentModelID) }
     }
 
     func availableMagazinePatterns(
@@ -192,31 +192,34 @@ final class AddFirearmViewModel {
         }
     }
 
-    func availableMagazines(
+    func linkedMagazines(
         from magazines: [Magazine],
-        selectedIDs: Set<PersistentIdentifier>,
         selectedPatterns: [FirearmMagazinePatternReference],
-        firearm: Firearm?,
         firearmType: FirearmType,
         action: FirearmAction,
         caliber: Caliber?
     ) -> [Magazine] {
-        let selectedPatternIDs = Set(selectedPatterns.map(\.id))
-        return magazines.filter { magazine in
-            if selectedIDs.contains(magazine.persistentModelID) {
-                return true
-            }
+        let effectivePatterns = effectiveSelectedMagazinePatterns(
+            selectedPatterns: selectedPatterns,
+            magazines: []
+        )
+        let selectedPatternIDs = Set(effectivePatterns.map(\.id))
+        guard !selectedPatternIDs.isEmpty else {
+            return []
+        }
 
-            if !selectedPatternIDs.isEmpty, !selectedPatternIDs.contains(magazine.resolvedPattern.id) {
+        return magazines.filter { magazine in
+            if !selectedPatternIDs.contains(magazine.resolvedPattern.id) {
                 return false
             }
 
             return compatibilityValidator.validate(
-                magazine: magazine,
+                pattern: magazine.resolvedPattern,
+                selectedMagazineCaliber: magazine.caliber,
                 firearmType: firearmType,
                 action: action,
                 caliber: caliber,
-                owningFirearm: firearm
+                firearmDescription: "\(firearmType.displayName) (\(action.displayName))"
             ).isCompatible
         }
     }
@@ -229,7 +232,12 @@ final class AddFirearmViewModel {
         caliber: Caliber?,
         owningFirearm: Firearm?
     ) -> MagazineCompatibilityValidationResult {
-        let selectedPatternIDs = Set(selectedPatterns.map(\.id))
+        let selectedPatternIDs = Set(
+            effectiveSelectedMagazinePatterns(
+                selectedPatterns: selectedPatterns,
+                magazines: magazines
+            ).map(\.id)
+        )
         if !selectedPatternIDs.isEmpty,
            let magazine = magazines.first(where: { !selectedPatternIDs.contains($0.resolvedPattern.id) }) {
             return .init(failure: .patternNotSelected(patternName: magazine.resolvedPattern.displayName))
@@ -455,6 +463,10 @@ final class AddFirearmViewModel {
             return false
         }
 
+        let persistedMagazinePatterns = effectiveSelectedMagazinePatterns(
+            selectedPatterns: supportedMagazinePatterns,
+            magazines: magazines
+        )
         let firearm = Firearm(
             brand: trimmedValue(brand),
             modelName: trimmedValue(modelName),
@@ -470,10 +482,10 @@ final class AddFirearmViewModel {
             colorDetail: colorDetail,
             barrelLengthInches: barrelLengthInches,
             notes: notes,
-            supportedMagazinePatterns: supportedMagazinePatterns,
+            supportedMagazinePatterns: persistedMagazinePatterns,
             caliber: caliber,
             optics: optics,
-            magazines: magazines,
+            magazines: [],
             attachments: attachments,
             parts: parts,
             sortOrder: nextSortOrder(in: context)
@@ -529,6 +541,10 @@ final class AddFirearmViewModel {
             return false
         }
 
+        let persistedMagazinePatterns = effectiveSelectedMagazinePatterns(
+            selectedPatterns: supportedMagazinePatterns,
+            magazines: magazines
+        )
         firearm.brand = trimmedValue(brand)
         firearm.modelName = trimmedValue(modelName)
         firearm.nickname = optionalValue(nickname ?? "")
@@ -543,10 +559,9 @@ final class AddFirearmViewModel {
         firearm.colorDetail = colorDetail
         firearm.barrelLengthInches = barrelLengthInches
         firearm.notes = notes
-        firearm.supportedMagazinePatterns = supportedMagazinePatterns
+        firearm.supportedMagazinePatterns = persistedMagazinePatterns
         firearm.caliber = caliber
         firearm.optics = optics
-        firearm.magazines = magazines
         firearm.attachments = attachments
         firearm.parts = parts
 
@@ -557,6 +572,33 @@ final class AddFirearmViewModel {
         } catch {
             print("Save error: \(error)")
             return false
+        }
+    }
+
+    private func effectiveSelectedMagazinePatterns(
+        selectedPatterns: [FirearmMagazinePatternReference],
+        magazines: [Magazine]
+    ) -> [FirearmMagazinePatternReference] {
+        if !selectedPatterns.isEmpty {
+            return selectedPatterns
+        }
+
+        return inferredMagazinePatterns(from: magazines)
+    }
+
+    private func inferredMagazinePatterns(from magazines: [Magazine]) -> [FirearmMagazinePatternReference] {
+        var seenIDs: Set<String> = []
+        var patterns: [FirearmMagazinePatternReference] = []
+
+        for magazine in magazines {
+            let reference = FirearmMagazinePatternReference(pattern: magazine.resolvedPattern)
+            if seenIDs.insert(reference.id).inserted {
+                patterns.append(reference)
+            }
+        }
+
+        return patterns.sorted {
+            $0.resolvedDisplayName.localizedCaseInsensitiveCompare($1.resolvedDisplayName) == .orderedAscending
         }
     }
 }

--- a/ArmoryInventory/Firearms/AddFirearmViewModel.swift
+++ b/ArmoryInventory/Firearms/AddFirearmViewModel.swift
@@ -136,11 +136,14 @@ final class AddFirearmViewModel {
             let pattern = magazine.resolvedPattern
             let reference = FirearmMagazinePatternReference(pattern: pattern)
             let isSelected = selectedPatternMap[reference.id] != nil
-            let isCompatible = pattern.isCompatible(
-                with: firearmType,
+            let isCompatible = compatibilityValidator.validate(
+                pattern: pattern,
+                selectedMagazineCaliber: magazine.caliber,
+                firearmType: firearmType,
                 action: action,
-                caliberName: caliber?.name
-            )
+                caliber: caliber,
+                firearmDescription: ""
+            ).isCompatible
 
             if isSelected || isCompatible {
                 patternMap[reference.id] = patternMap[reference.id] ?? reference

--- a/ArmoryInventory/Firearms/AddFirearmViewModel.swift
+++ b/ArmoryInventory/Firearms/AddFirearmViewModel.swift
@@ -40,6 +40,10 @@ final class AddFirearmViewModel {
         Set(firearm?.magazines.map(\.persistentModelID) ?? [])
     }
 
+    func selectedMagazinePatterns(for firearm: Firearm?) -> [FirearmMagazinePatternReference] {
+        firearm?.supportedMagazinePatterns ?? []
+    }
+
     func selectedAttachmentIDs(for firearm: Firearm?) -> Set<PersistentIdentifier> {
         Set(firearm?.attachments.map(\.persistentModelID) ?? [])
     }
@@ -110,6 +114,54 @@ final class AddFirearmViewModel {
         magazines.filter { selectedIDs.contains($0.persistentModelID) }
     }
 
+    func availableMagazinePatterns(
+        from magazines: [Magazine],
+        firearmType: FirearmType,
+        action: FirearmAction,
+        caliber: Caliber?,
+        selectedPatterns: [FirearmMagazinePatternReference]
+    ) -> [FirearmMagazinePatternReference] {
+        let selectedPatternMap = Dictionary(uniqueKeysWithValues: selectedPatterns.map { ($0.id, $0) })
+        var patternMap = selectedPatternMap
+
+        for pattern in MagazinePatternCatalog.suggestedPatterns(
+            firearmType: firearmType,
+            action: action,
+            caliberName: caliber?.name
+        ) {
+            patternMap[pattern.id] = patternMap[pattern.id] ?? FirearmMagazinePatternReference(pattern: pattern)
+        }
+
+        for magazine in magazines {
+            let pattern = magazine.resolvedPattern
+            let reference = FirearmMagazinePatternReference(pattern: pattern)
+            let isSelected = selectedPatternMap[reference.id] != nil
+            let isCompatible = pattern.isCompatible(
+                with: firearmType,
+                action: action,
+                caliberName: caliber?.name
+            )
+
+            if isSelected || isCompatible {
+                patternMap[reference.id] = patternMap[reference.id] ?? reference
+            }
+        }
+
+        return patternMap.values.sorted {
+            let lhsSelected = selectedPatternMap[$0.id] != nil
+            let rhsSelected = selectedPatternMap[$1.id] != nil
+            if lhsSelected != rhsSelected {
+                return lhsSelected && !rhsSelected
+            }
+
+            if $0.kind != $1.kind {
+                return $0.kind.rawValue < $1.kind.rawValue
+            }
+
+            return $0.resolvedDisplayName.localizedCaseInsensitiveCompare($1.resolvedDisplayName) == .orderedAscending
+        }
+    }
+
     func resolvedAttachments(from attachments: [Attachment], selectedIDs: Set<PersistentIdentifier>) -> [Attachment] {
         attachments.filter { selectedIDs.contains($0.persistentModelID) }
     }
@@ -143,14 +195,20 @@ final class AddFirearmViewModel {
     func availableMagazines(
         from magazines: [Magazine],
         selectedIDs: Set<PersistentIdentifier>,
+        selectedPatterns: [FirearmMagazinePatternReference],
         firearm: Firearm?,
         firearmType: FirearmType,
         action: FirearmAction,
         caliber: Caliber?
     ) -> [Magazine] {
-        magazines.filter { magazine in
+        let selectedPatternIDs = Set(selectedPatterns.map(\.id))
+        return magazines.filter { magazine in
             if selectedIDs.contains(magazine.persistentModelID) {
                 return true
+            }
+
+            if !selectedPatternIDs.isEmpty, !selectedPatternIDs.contains(magazine.resolvedPattern.id) {
+                return false
             }
 
             return compatibilityValidator.validate(
@@ -165,12 +223,19 @@ final class AddFirearmViewModel {
 
     func selectedMagazineValidationResult(
         magazines: [Magazine],
+        selectedPatterns: [FirearmMagazinePatternReference],
         firearmType: FirearmType,
         action: FirearmAction,
         caliber: Caliber?,
         owningFirearm: Firearm?
     ) -> MagazineCompatibilityValidationResult {
-        compatibilityValidator.firstFailure(
+        let selectedPatternIDs = Set(selectedPatterns.map(\.id))
+        if !selectedPatternIDs.isEmpty,
+           let magazine = magazines.first(where: { !selectedPatternIDs.contains($0.resolvedPattern.id) }) {
+            return .init(failure: .patternNotSelected(patternName: magazine.resolvedPattern.displayName))
+        }
+
+        return compatibilityValidator.firstFailure(
             magazines: magazines,
             firearmType: firearmType,
             action: action,
@@ -241,6 +306,27 @@ final class AddFirearmViewModel {
         return updatedSelection
     }
 
+    func toggledMagazinePatternSelection(
+        currentSelection: [FirearmMagazinePatternReference],
+        pattern: FirearmMagazinePatternReference,
+        isEditing: Bool
+    ) -> [FirearmMagazinePatternReference] {
+        guard isEditing else {
+            return currentSelection
+        }
+
+        var updatedSelection = currentSelection
+        if let index = updatedSelection.firstIndex(where: { $0.id == pattern.id }) {
+            updatedSelection.remove(at: index)
+        } else {
+            updatedSelection.append(pattern)
+        }
+
+        return updatedSelection.sorted {
+            $0.resolvedDisplayName.localizedCaseInsensitiveCompare($1.resolvedDisplayName) == .orderedAscending
+        }
+    }
+
     func isReadOnly(hasFirearm: Bool, isEditing: Bool) -> Bool {
         hasFirearm && !isEditing
     }
@@ -302,6 +388,7 @@ final class AddFirearmViewModel {
         barrelLengthText: String,
         duplicateExists: Bool,
         magazines: [Magazine],
+        selectedMagazinePatterns: [FirearmMagazinePatternReference],
         caliber: Caliber?,
         owningFirearm: Firearm?
     ) -> Bool {
@@ -322,6 +409,7 @@ final class AddFirearmViewModel {
 
         return selectedMagazineValidationResult(
             magazines: magazines,
+            selectedPatterns: selectedMagazinePatterns,
             firearmType: selectedType,
             action: selectedAction,
             caliber: caliber,
@@ -344,6 +432,7 @@ final class AddFirearmViewModel {
         colorDetail: String?,
         barrelLengthInches: Double?,
         notes: String?,
+        supportedMagazinePatterns: [FirearmMagazinePatternReference],
         caliber: Caliber?,
         optics: [Optic],
         magazines: [Magazine],
@@ -357,6 +446,7 @@ final class AddFirearmViewModel {
         }
         guard selectedMagazineValidationResult(
             magazines: magazines,
+            selectedPatterns: supportedMagazinePatterns,
             firearmType: type,
             action: action,
             caliber: caliber,
@@ -380,6 +470,7 @@ final class AddFirearmViewModel {
             colorDetail: colorDetail,
             barrelLengthInches: barrelLengthInches,
             notes: notes,
+            supportedMagazinePatterns: supportedMagazinePatterns,
             caliber: caliber,
             optics: optics,
             magazines: magazines,
@@ -415,6 +506,7 @@ final class AddFirearmViewModel {
         colorDetail: String?,
         barrelLengthInches: Double?,
         notes: String?,
+        supportedMagazinePatterns: [FirearmMagazinePatternReference],
         caliber: Caliber?,
         optics: [Optic],
         magazines: [Magazine],
@@ -428,6 +520,7 @@ final class AddFirearmViewModel {
         }
         guard selectedMagazineValidationResult(
             magazines: magazines,
+            selectedPatterns: supportedMagazinePatterns,
             firearmType: type,
             action: action,
             caliber: caliber,
@@ -450,6 +543,7 @@ final class AddFirearmViewModel {
         firearm.colorDetail = colorDetail
         firearm.barrelLengthInches = barrelLengthInches
         firearm.notes = notes
+        firearm.supportedMagazinePatterns = supportedMagazinePatterns
         firearm.caliber = caliber
         firearm.optics = optics
         firearm.magazines = magazines

--- a/ArmoryInventory/Firearms/FirearmModels.swift
+++ b/ArmoryInventory/Firearms/FirearmModels.swift
@@ -8,6 +8,36 @@
 import Foundation
 import SwiftData
 
+struct FirearmMagazinePatternReference: Codable, Hashable, Identifiable {
+    let id: String
+    let kind: MagazinePatternKind
+    let displayName: String?
+
+    init(id: String, kind: MagazinePatternKind, displayName: String?) {
+        self.id = id
+        self.kind = kind
+        self.displayName = displayName
+    }
+
+    init(pattern: MagazinePattern) {
+        self.id = pattern.id
+        self.kind = pattern.kind
+        self.displayName = pattern.kind == .catalog ? nil : pattern.displayName
+    }
+
+    var resolvedDisplayName: String {
+        if kind == .catalog, let pattern = MagazinePatternCatalog.pattern(id: id) {
+            return pattern.displayName
+        }
+
+        if let displayName, !displayName.isEmpty {
+            return displayName
+        }
+
+        return id
+    }
+}
+
 enum FirearmType: String, Codable, CaseIterable, Identifiable {
     case rifle
     case pistol
@@ -127,6 +157,7 @@ final class Firearm {
     var colorDetail: String?
     var barrelLengthInches: Double?
     var notes: String?
+    var supportedMagazinePatternsData: String?
     var sortOrder: Int
     var createdAt: Date
 
@@ -152,6 +183,7 @@ final class Firearm {
         colorDetail: String? = nil,
         barrelLengthInches: Double? = nil,
         notes: String? = nil,
+        supportedMagazinePatterns: [FirearmMagazinePatternReference] = [],
         caliber: Caliber? = nil,
         optics: [Optic] = [],
         magazines: [Magazine] = [],
@@ -175,6 +207,7 @@ final class Firearm {
         self.colorDetail = colorDetail
         self.barrelLengthInches = barrelLengthInches
         self.notes = notes
+        self.supportedMagazinePatternsData = Self.encodeMagazinePatterns(supportedMagazinePatterns)
         self.caliber = caliber
         self.optics = optics
         self.magazines = magazines
@@ -272,6 +305,15 @@ final class Firearm {
         notes?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
     }
 
+    var supportedMagazinePatterns: [FirearmMagazinePatternReference] {
+        get { Self.decodeMagazinePatterns(from: supportedMagazinePatternsData) }
+        set { supportedMagazinePatternsData = Self.encodeMagazinePatterns(newValue) }
+    }
+
+    var supportedMagazinePatternIDs: Set<String> {
+        Set(supportedMagazinePatterns.map(\.id))
+    }
+
     var totalCardValueCents: Int {
         let opticsValue = optics.reduce(0) { $0 + max(0, $1.purchasePriceCents) }
         let magazinesValue = magazines.reduce(0) { $0 + max(0, $1.purchasePriceCents) }
@@ -283,5 +325,25 @@ final class Firearm {
     var totalCardValueText: String {
         let amount = Decimal(totalCardValueCents) / 100
         return amount.formatted(.currency(code: Locale.current.currency?.identifier ?? "USD"))
+    }
+
+    private static func encodeMagazinePatterns(_ patterns: [FirearmMagazinePatternReference]) -> String? {
+        guard !patterns.isEmpty,
+              let data = try? JSONEncoder().encode(patterns),
+              let json = String(data: data, encoding: .utf8) else {
+            return nil
+        }
+
+        return json
+    }
+
+    private static func decodeMagazinePatterns(from value: String?) -> [FirearmMagazinePatternReference] {
+        guard let value,
+              let data = value.data(using: .utf8),
+              let patterns = try? JSONDecoder().decode([FirearmMagazinePatternReference].self, from: data) else {
+            return []
+        }
+
+        return patterns
     }
 }

--- a/ArmoryInventory/Firearms/FirearmModels.swift
+++ b/ArmoryInventory/Firearms/FirearmModels.swift
@@ -314,6 +314,23 @@ final class Firearm {
         Set(supportedMagazinePatterns.map(\.id))
     }
 
+    func totalLinkedMagazineCount(using magazines: [Magazine]) -> Int {
+        magazines.reduce(0) { $0 + max(0, $1.count) }
+    }
+
+    func totalLinkedMagazineCapacity(using magazines: [Magazine]) -> Int {
+        magazines.reduce(0) { $0 + $1.totalRoundCapacity }
+    }
+
+    func linkedMagazineCountText(using magazines: [Magazine]) -> String {
+        let totalCount = totalLinkedMagazineCount(using: magazines)
+        return totalCount == 1 ? "1 magazine" : "\(totalCount) magazines"
+    }
+
+    func linkedMagazineCapacityText(using magazines: [Magazine]) -> String {
+        AmmoType.roundsText(for: totalLinkedMagazineCapacity(using: magazines))
+    }
+
     var totalCardValueCents: Int {
         let opticsValue = optics.reduce(0) { $0 + max(0, $1.purchasePriceCents) }
         let magazinesValue = magazines.reduce(0) { $0 + max(0, $1.purchasePriceCents) }

--- a/ArmoryInventory/Localizable.xcstrings
+++ b/ArmoryInventory/Localizable.xcstrings
@@ -160,10 +160,10 @@
     "All Calibers (%lld)" : {
 
     },
-    "All saved attachments are linked to other firearms or none have been added yet." : {
+    "All compatible magazines are linked to other firearms or none have been added yet." : {
 
     },
-    "All saved magazines are linked to other firearms or none have been added yet." : {
+    "All saved attachments are linked to other firearms or none have been added yet." : {
 
     },
     "All saved optics are linked to other firearms or none have been added yet." : {
@@ -289,6 +289,9 @@
     "Custom Caliber" : {
 
     },
+    "Custom Name" : {
+
+    },
     "Custom percent" : {
 
     },
@@ -403,6 +406,9 @@
     "Last cleaned" : {
 
     },
+    "Legacy Name" : {
+
+    },
     "Legal" : {
 
     },
@@ -455,6 +461,9 @@
 
     },
     "Manage Parts" : {
+
+    },
+    "Manual Patterns" : {
 
     },
     "Max" : {
@@ -514,6 +523,9 @@
     "No common grain options are available for %@. Enter a custom weight below." : {
 
     },
+    "No compatible magazines are currently available." : {
+
+    },
     "No Firearms Yet" : {
 
     },
@@ -545,9 +557,6 @@
 
     },
     "No unlinked attachments available." : {
-
-    },
-    "No unlinked magazines available." : {
 
     },
     "No unlinked optics available." : {
@@ -592,6 +601,9 @@
     "Ordering" : {
 
     },
+    "Other Catalog Patterns" : {
+
+    },
     "Overview" : {
 
     },
@@ -605,6 +617,9 @@
 
     },
     "Parts Sorting" : {
+
+    },
+    "Pattern" : {
 
     },
     "Post-Tax Total" : {
@@ -683,6 +698,9 @@
 
     },
     "Starting Quantity" : {
+
+    },
+    "Suggested Catalog Patterns" : {
 
     },
     "Tax Rate" : {

--- a/ArmoryInventory/Localizable.xcstrings
+++ b/ArmoryInventory/Localizable.xcstrings
@@ -302,6 +302,9 @@
     "Custom Name" : {
 
     },
+    "Custom Patterns" : {
+
+    },
     "Custom percent" : {
 
     },
@@ -324,6 +327,9 @@
 
     },
     "Done" : {
+
+    },
+    "Edit Saved Pattern" : {
 
     },
     "Enter dollars and cents, for example 1299.99." : {
@@ -474,9 +480,6 @@
 
     },
     "Manage Parts" : {
-
-    },
-    "Manual Patterns" : {
 
     },
     "Max" : {
@@ -669,6 +672,9 @@
 
     },
     "Rounds" : {
+
+    },
+    "Saved Custom Patterns" : {
 
     },
     "Select" : {

--- a/ArmoryInventory/Localizable.xcstrings
+++ b/ArmoryInventory/Localizable.xcstrings
@@ -27,6 +27,16 @@
         }
       }
     },
+    "%@ • %@ • %@" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$@ • %2$@ • %3$@"
+          }
+        }
+      }
+    },
     "%@ currently on hand" : {
 
     },
@@ -109,10 +119,10 @@
     "Add Magazine" : {
 
     },
-    "Add Magazines" : {
+    "Add magazines first to link them to this firearm." : {
 
     },
-    "Add magazines first to link them to this firearm." : {
+    "Add magazines or select a caliber to surface compatible patterns." : {
 
     },
     "Add Optic" : {
@@ -142,7 +152,7 @@
     "Add your first firearm to start tracking your collection." : {
 
     },
-    "Add your first magazine to track capacity, caliber, and assigned firearm." : {
+    "Add your first magazine to track capacity, supported calibers, and linked firearms." : {
 
     },
     "Add your first optic to start tracking mounts, magnification, and purchase cost." : {
@@ -158,9 +168,6 @@
 
     },
     "All Calibers (%lld)" : {
-
-    },
-    "All compatible magazines are linked to other firearms or none have been added yet." : {
 
     },
     "All saved attachments are linked to other firearms or none have been added yet." : {
@@ -269,6 +276,9 @@
 
     },
     "Common Calibers" : {
+
+    },
+    "Compatible Calibers" : {
 
     },
     "Configuration" : {
@@ -415,9 +425,6 @@
     "Link Attachments" : {
 
     },
-    "Link Magazines" : {
-
-    },
     "Link Optics" : {
 
     },
@@ -428,6 +435,9 @@
 
     },
     "Linked Firearm" : {
+
+    },
+    "Linked Firearms" : {
 
     },
     "Linked Magazines" : {
@@ -442,6 +452,9 @@
     "Magazine Details" : {
 
     },
+    "Magazine Patterns" : {
+
+    },
     "Magazines" : {
 
     },
@@ -454,7 +467,7 @@
     "Manage Attachments" : {
 
     },
-    "Manage Magazines" : {
+    "Manage Magazine Patterns" : {
 
     },
     "Manage Optics" : {
@@ -523,16 +536,16 @@
     "No common grain options are available for %@. Enter a custom weight below." : {
 
     },
-    "No compatible magazines are currently available." : {
-
-    },
     "No Firearms Yet" : {
 
     },
-    "No Magazines Available" : {
+    "No Magazine Patterns Available" : {
 
     },
-    "No magazines linked." : {
+    "No magazine patterns selected." : {
+
+    },
+    "No magazines currently match the selected patterns." : {
 
     },
     "No Magazines Yet" : {
@@ -659,6 +672,12 @@
 
     },
     "Select" : {
+
+    },
+    "Select Magazine Patterns" : {
+
+    },
+    "Select one or more magazine patterns to see linked magazines." : {
 
     },
     "Send Feedback" : {

--- a/ArmoryInventory/Localizable.xcstrings
+++ b/ArmoryInventory/Localizable.xcstrings
@@ -443,9 +443,6 @@
     "Linked Firearm" : {
 
     },
-    "Linked Firearms" : {
-
-    },
     "Linked Magazines" : {
 
     },
@@ -785,6 +782,35 @@
     },
     "Use the slider to set a rate from 0% to 100%. Move it all the way to 100% to unlock a custom value above that range." : {
 
+    },
+    "usedByFirearm" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "variations" : {
+            "plural" : {
+              "one" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "Used by %lld firearm: "
+                }
+              },
+              "other" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "Used by %lld firearms: "
+                }
+              },
+              "zero" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "Used by %lld firearm."
+                }
+              }
+            }
+          }
+        }
+      }
     },
     "User Data" : {
 

--- a/ArmoryInventory/Localizable.xcstrings
+++ b/ArmoryInventory/Localizable.xcstrings
@@ -27,16 +27,6 @@
         }
       }
     },
-    "%@ • %@ • %@" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%1$@ • %2$@ • %3$@"
-          }
-        }
-      }
-    },
     "%@ currently on hand" : {
 
     },
@@ -119,7 +109,7 @@
     "Add Magazine" : {
 
     },
-    "Add magazines first to link them to this firearm." : {
+    "Add magazines first to see which ones are compatible with this firearm." : {
 
     },
     "Add magazines or select a caliber to surface compatible patterns." : {
@@ -279,6 +269,9 @@
 
     },
     "Compatible Calibers" : {
+
+    },
+    "Compatible Magazines" : {
 
     },
     "Configuration" : {
@@ -443,9 +436,6 @@
     "Linked Firearm" : {
 
     },
-    "Linked Magazines" : {
-
-    },
     "Linked Optics" : {
 
     },
@@ -457,6 +447,85 @@
     },
     "Magazine Patterns" : {
 
+    },
+    "magazineCapacityText" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "variations" : {
+            "plural" : {
+              "one" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "%lld round"
+                }
+              },
+              "other" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "%lld rounds"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "magazineCount" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "variations" : {
+            "plural" : {
+              "one" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "%lld magazine"
+                }
+              },
+              "other" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "%lld magazines"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "magazineCountAndCapacity" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%#@count@"
+          },
+          "substitutions" : {
+            "count" : {
+              "argNum" : 1,
+              "formatSpecifier" : "lld",
+              "variations" : {
+                "plural" : {
+                  "one" : {
+                    "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "%1$lld %2$lld-round magazine"
+                    }
+                  },
+                  "other" : {
+                    "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "%1$lld %2$lld-round magazines"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
     },
     "Magazines" : {
 
@@ -545,7 +614,7 @@
     "No magazine patterns selected." : {
 
     },
-    "No magazines currently match the selected patterns." : {
+    "No magazines are currently compatible with the selected patterns." : {
 
     },
     "No Magazines Yet" : {
@@ -680,7 +749,7 @@
     "Select Magazine Patterns" : {
 
     },
-    "Select one or more magazine patterns to see linked magazines." : {
+    "Select one or more magazine patterns to see compatible magazines." : {
 
     },
     "Send Feedback" : {

--- a/ArmoryInventory/Services/UserDataTransferService.swift
+++ b/ArmoryInventory/Services/UserDataTransferService.swift
@@ -177,6 +177,7 @@ final class UserDataTransferService: UserDataTransferServicing {
                     patternID: $0.patternID,
                     patternKind: $0.patternKind,
                     patternDisplayName: $0.patternDisplayName,
+                    patternSupportedCaliberNames: $0.storedPatternSupportedCaliberNames,
                     count: $0.count,
                     capacity: $0.capacity,
                     purchaseDate: $0.purchaseDate,
@@ -312,6 +313,7 @@ final class UserDataTransferService: UserDataTransferServicing {
                 patternID: snapshot.patternID,
                 patternKind: snapshot.patternKind.flatMap(MagazinePatternKind.init(rawValue:)),
                 patternDisplayName: snapshot.patternDisplayName,
+                patternSupportedCaliberNames: snapshot.patternSupportedCaliberNames ?? [],
                 count: snapshot.count,
                 capacity: snapshot.capacity,
                 purchaseDate: snapshot.purchaseDate,
@@ -685,6 +687,7 @@ private struct MagazineSnapshot: Codable {
     let patternID: String?
     let patternKind: String?
     let patternDisplayName: String?
+    let patternSupportedCaliberNames: [String]?
     let count: Int
     let capacity: Int
     let purchaseDate: Date

--- a/ArmoryInventory/Services/UserDataTransferService.swift
+++ b/ArmoryInventory/Services/UserDataTransferService.swift
@@ -138,6 +138,7 @@ final class UserDataTransferService: UserDataTransferServicing {
                     colorDetail: $0.colorDetail,
                     barrelLengthInches: $0.barrelLengthInches,
                     notes: $0.notes,
+                    supportedMagazinePatterns: $0.supportedMagazinePatterns,
                     sortOrder: $0.sortOrder,
                     createdAt: $0.createdAt,
                     caliberName: $0.caliber?.name
@@ -252,6 +253,7 @@ final class UserDataTransferService: UserDataTransferServicing {
                 colorDetail: snapshot.colorDetail,
                 barrelLengthInches: snapshot.barrelLengthInches,
                 notes: snapshot.notes,
+                supportedMagazinePatterns: snapshot.supportedMagazinePatterns,
                 caliber: snapshot.caliberName.flatMap { calibers[$0] },
                 sortOrder: snapshot.sortOrder,
                 createdAt: snapshot.createdAt
@@ -549,6 +551,27 @@ private struct AmmoAdjustmentRecordSnapshot: Codable {
 }
 
 private struct FirearmSnapshot: Codable {
+    private enum CodingKeys: String, CodingKey {
+        case id
+        case brand
+        case modelName
+        case nickname
+        case serialNumber
+        case purchaseDate
+        case purchasePriceCents
+        case type
+        case action
+        case actionDetail
+        case color
+        case colorDetail
+        case barrelLengthInches
+        case notes
+        case supportedMagazinePatterns
+        case sortOrder
+        case createdAt
+        case caliberName
+    }
+
     let id: UUID
     let brand: String
     let modelName: String
@@ -563,9 +586,72 @@ private struct FirearmSnapshot: Codable {
     let colorDetail: String?
     let barrelLengthInches: Double?
     let notes: String?
+    let supportedMagazinePatterns: [FirearmMagazinePatternReference]
     let sortOrder: Int
     let createdAt: Date
     let caliberName: String?
+
+    init(
+        id: UUID,
+        brand: String,
+        modelName: String,
+        nickname: String?,
+        serialNumber: String?,
+        purchaseDate: Date,
+        purchasePriceCents: Int,
+        type: String,
+        action: String,
+        actionDetail: String?,
+        color: String?,
+        colorDetail: String?,
+        barrelLengthInches: Double?,
+        notes: String?,
+        supportedMagazinePatterns: [FirearmMagazinePatternReference],
+        sortOrder: Int,
+        createdAt: Date,
+        caliberName: String?
+    ) {
+        self.id = id
+        self.brand = brand
+        self.modelName = modelName
+        self.nickname = nickname
+        self.serialNumber = serialNumber
+        self.purchaseDate = purchaseDate
+        self.purchasePriceCents = purchasePriceCents
+        self.type = type
+        self.action = action
+        self.actionDetail = actionDetail
+        self.color = color
+        self.colorDetail = colorDetail
+        self.barrelLengthInches = barrelLengthInches
+        self.notes = notes
+        self.supportedMagazinePatterns = supportedMagazinePatterns
+        self.sortOrder = sortOrder
+        self.createdAt = createdAt
+        self.caliberName = caliberName
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        id = try container.decode(UUID.self, forKey: .id)
+        brand = try container.decode(String.self, forKey: .brand)
+        modelName = try container.decode(String.self, forKey: .modelName)
+        nickname = try container.decodeIfPresent(String.self, forKey: .nickname)
+        serialNumber = try container.decodeIfPresent(String.self, forKey: .serialNumber)
+        purchaseDate = try container.decode(Date.self, forKey: .purchaseDate)
+        purchasePriceCents = try container.decode(Int.self, forKey: .purchasePriceCents)
+        type = try container.decode(String.self, forKey: .type)
+        action = try container.decode(String.self, forKey: .action)
+        actionDetail = try container.decodeIfPresent(String.self, forKey: .actionDetail)
+        color = try container.decodeIfPresent(String.self, forKey: .color)
+        colorDetail = try container.decodeIfPresent(String.self, forKey: .colorDetail)
+        barrelLengthInches = try container.decodeIfPresent(Double.self, forKey: .barrelLengthInches)
+        notes = try container.decodeIfPresent(String.self, forKey: .notes)
+        supportedMagazinePatterns = try container.decodeIfPresent([FirearmMagazinePatternReference].self, forKey: .supportedMagazinePatterns) ?? []
+        sortOrder = try container.decode(Int.self, forKey: .sortOrder)
+        createdAt = try container.decode(Date.self, forKey: .createdAt)
+        caliberName = try container.decodeIfPresent(String.self, forKey: .caliberName)
+    }
 }
 
 private struct OpticSnapshot: Codable {

--- a/ArmoryInventoryTests/AccessoriesTests/AddMagazineViewModelTests.swift
+++ b/ArmoryInventoryTests/AccessoriesTests/AddMagazineViewModelTests.swift
@@ -39,6 +39,8 @@ final class AddMagazineViewModelTests: XCTestCase {
                 selectedColor: nil,
                 colorDetail: nil,
                 purchasePriceText: "10",
+                patternSelection: .automatic,
+                manualPatternName: "",
                 selectedCaliber: nil,
                 firearm: nil
             )
@@ -52,6 +54,8 @@ final class AddMagazineViewModelTests: XCTestCase {
                 selectedColor: .other,
                 colorDetail: nil,
                 purchasePriceText: "10",
+                patternSelection: .automatic,
+                manualPatternName: "",
                 selectedCaliber: nil,
                 firearm: nil
             )
@@ -65,10 +69,14 @@ final class AddMagazineViewModelTests: XCTestCase {
                 selectedColor: .black,
                 colorDetail: nil,
                 purchasePriceText: "10",
+                patternSelection: .automatic,
+                manualPatternName: "",
                 selectedCaliber: nil,
                 firearm: nil
             )
         )
+        XCTAssertEqual(viewModel.initialPatternSelection(for: nil), .automatic)
+        XCTAssertEqual(viewModel.initialManualPatternName(for: nil), "")
     }
 
     func testCanAddReturnsFalseForMagazineCaliberMismatchAgainstLinkedFirearm() {
@@ -93,8 +101,30 @@ final class AddMagazineViewModelTests: XCTestCase {
                 selectedColor: .black,
                 colorDetail: nil,
                 purchasePriceText: "75",
+                patternSelection: .automatic,
+                manualPatternName: "",
                 selectedCaliber: magazineCaliber,
                 firearm: firearm
+            )
+        )
+    }
+
+    func testCanAddRequiresManualPatternNameForLegacySelection() {
+        let viewModel = AddMagazineViewModel()
+
+        XCTAssertFalse(
+            viewModel.canAdd(
+                brand: "Magpul",
+                modelName: "PMAG",
+                countText: "1",
+                capacityText: "30",
+                selectedColor: .black,
+                colorDetail: nil,
+                purchasePriceText: "20",
+                patternSelection: .legacy,
+                manualPatternName: "",
+                selectedCaliber: nil,
+                firearm: nil
             )
         )
     }
@@ -126,6 +156,8 @@ final class AddMagazineViewModelTests: XCTestCase {
             color: .black,
             colorDetail: nil,
             notes: "Range set",
+            patternSelection: .automatic,
+            manualPatternName: "",
             caliber: caliber,
             firearm: firearm,
             canAdd: true,
@@ -164,6 +196,8 @@ final class AddMagazineViewModelTests: XCTestCase {
             color: nil,
             colorDetail: nil,
             notes: nil,
+            patternSelection: .automatic,
+            manualPatternName: "",
             caliber: nil,
             firearm: nil,
             canAdd: false,
@@ -192,6 +226,8 @@ final class AddMagazineViewModelTests: XCTestCase {
             color: .black,
             colorDetail: nil,
             notes: nil,
+            patternSelection: .automatic,
+            manualPatternName: "",
             caliber: caliber,
             firearm: nil,
             canAdd: true,
@@ -205,6 +241,39 @@ final class AddMagazineViewModelTests: XCTestCase {
         XCTAssertNil(magazines.first?.firearm)
         XCTAssertEqual(magazines.first?.storedPatternKind, .catalog)
         XCTAssertEqual(magazines.first?.patternID, "catalog:ar15-stanag-223-556-300blk")
+    }
+
+    @MainActor
+    func testAddMagazinePersistsExplicitLegacyPattern() throws {
+        let container = try makeInMemoryContainer()
+        let context = container.mainContext
+        let caliber = Caliber(name: "9mm")
+        context.insert(caliber)
+
+        let viewModel = AddMagazineViewModel()
+        let didAdd = viewModel.addMagazine(
+            brand: "Atlas",
+            modelName: "Premium",
+            count: 2,
+            capacity: 20,
+            purchaseDate: .now,
+            purchasePriceCents: 12000,
+            color: .black,
+            colorDetail: nil,
+            notes: nil,
+            patternSelection: .legacy,
+            manualPatternName: "Old Match Tube",
+            caliber: caliber,
+            firearm: nil,
+            canAdd: true,
+            to: context
+        )
+
+        let magazines = try context.fetch(FetchDescriptor<Magazine>())
+
+        XCTAssertTrue(didAdd)
+        XCTAssertEqual(magazines.first?.storedPatternKind, .legacy)
+        XCTAssertEqual(magazines.first?.patternDisplayName, "Old Match Tube")
     }
 
     @MainActor
@@ -254,6 +323,8 @@ final class AddMagazineViewModelTests: XCTestCase {
             color: .other,
             colorDetail: "Nickel",
             notes: "Updated",
+            patternSelection: .automatic,
+            manualPatternName: "",
             caliber: updatedCaliber,
             firearm: updatedFirearm,
             canSave: true,
@@ -314,6 +385,8 @@ final class AddMagazineViewModelTests: XCTestCase {
             color: .black,
             colorDetail: nil,
             notes: "Updated",
+            patternSelection: .automatic,
+            manualPatternName: "",
             caliber: originalCaliber,
             firearm: firearm,
             canSave: true,
@@ -367,6 +440,8 @@ final class AddMagazineViewModelTests: XCTestCase {
             color: nil,
             colorDetail: nil,
             notes: nil,
+            patternSelection: .automatic,
+            manualPatternName: "",
             caliber: caliber,
             firearm: nil,
             canSave: true,
@@ -377,5 +452,21 @@ final class AddMagazineViewModelTests: XCTestCase {
         XCTAssertNil(magazine.firearm)
         XCTAssertEqual(magazine.storedPatternKind, .catalog)
         XCTAssertEqual(magazine.patternID, "catalog:ar15-stanag-223-556-300blk")
+    }
+
+    func testInitialPatternHelpersExposeLegacyValues() {
+        let magazine = Magazine(
+            brand: "CZ",
+            modelName: "OEM",
+            patternID: "legacy:cz-oem",
+            patternKind: .legacy,
+            patternDisplayName: "Legacy CZ Tube",
+            capacity: 17,
+            purchasePriceCents: 3200
+        )
+        let viewModel = AddMagazineViewModel()
+
+        XCTAssertEqual(viewModel.initialPatternSelection(for: magazine), .legacy)
+        XCTAssertEqual(viewModel.initialManualPatternName(for: magazine), "Legacy CZ Tube")
     }
 }

--- a/ArmoryInventoryTests/AccessoriesTests/AddMagazineViewModelTests.swift
+++ b/ArmoryInventoryTests/AccessoriesTests/AddMagazineViewModelTests.swift
@@ -39,7 +39,7 @@ final class AddMagazineViewModelTests: XCTestCase {
                 selectedColor: nil,
                 colorDetail: nil,
                 purchasePriceText: "10",
-                patternSelection: .automatic,
+                patternSelection: .catalog("catalog:ar15-stanag-223-556-300blk"),
                 manualPatternName: "",
                 compatibleCaliberNames: [],
                 firearm: nil
@@ -54,7 +54,7 @@ final class AddMagazineViewModelTests: XCTestCase {
                 selectedColor: .other,
                 colorDetail: nil,
                 purchasePriceText: "10",
-                patternSelection: .automatic,
+                patternSelection: .catalog("catalog:ar15-stanag-223-556-300blk"),
                 manualPatternName: "",
                 compatibleCaliberNames: [],
                 firearm: nil
@@ -69,13 +69,13 @@ final class AddMagazineViewModelTests: XCTestCase {
                 selectedColor: .black,
                 colorDetail: nil,
                 purchasePriceText: "10",
-                patternSelection: .automatic,
+                patternSelection: .catalog("catalog:ar15-stanag-223-556-300blk"),
                 manualPatternName: "",
                 compatibleCaliberNames: [],
                 firearm: nil
             )
         )
-        XCTAssertEqual(viewModel.initialPatternSelection(for: nil), .automatic)
+        XCTAssertEqual(viewModel.initialPatternSelection(for: nil), .custom)
         XCTAssertEqual(viewModel.initialManualPatternName(for: nil), "")
     }
 
@@ -108,7 +108,7 @@ final class AddMagazineViewModelTests: XCTestCase {
         )
     }
 
-    func testCanAddRequiresManualPatternNameForLegacySelection() {
+    func testCanAddRequiresManualPatternNameForCustomSelection() {
         let viewModel = AddMagazineViewModel()
 
         XCTAssertFalse(
@@ -120,7 +120,7 @@ final class AddMagazineViewModelTests: XCTestCase {
                 selectedColor: .black,
                 colorDetail: nil,
                 purchasePriceText: "20",
-                patternSelection: .legacy,
+                patternSelection: .custom,
                 manualPatternName: "",
                 compatibleCaliberNames: [],
                 firearm: nil
@@ -156,9 +156,9 @@ final class AddMagazineViewModelTests: XCTestCase {
             color: .black,
             colorDetail: nil,
             notes: "Range set",
-            patternSelection: .automatic,
-            manualPatternName: "",
-            compatibleCaliberNames: [],
+            patternSelection: .custom,
+            manualPatternName: "CZ OEM",
+            compatibleCaliberNames: ["9mm"],
             firearm: firearm,
             canAdd: true,
             to: context
@@ -176,7 +176,7 @@ final class AddMagazineViewModelTests: XCTestCase {
         XCTAssertEqual(magazines.first?.firearm?.displayName, "CZ P-10 C")
         XCTAssertEqual(magazines.first?.purchaseDate, purchaseDate)
         XCTAssertEqual(magazines.first?.sortOrder, 0)
-        XCTAssertEqual(magazines.first?.storedPatternKind, .legacy)
+        XCTAssertEqual(magazines.first?.storedPatternKind, .custom)
         XCTAssertEqual(magazines.first?.patternDisplayName, "CZ OEM")
     }
 
@@ -196,7 +196,7 @@ final class AddMagazineViewModelTests: XCTestCase {
             color: nil,
             colorDetail: nil,
             notes: nil,
-            patternSelection: .automatic,
+            patternSelection: .catalog("catalog:glock-double-stack-9mm-full-size-compact"),
             manualPatternName: "",
             compatibleCaliberNames: [],
             firearm: nil,
@@ -223,7 +223,7 @@ final class AddMagazineViewModelTests: XCTestCase {
             color: .black,
             colorDetail: nil,
             notes: nil,
-            patternSelection: .automatic,
+            patternSelection: .catalog("catalog:ar15-stanag-223-556-300blk"),
             manualPatternName: "",
             compatibleCaliberNames: [],
             firearm: nil,
@@ -241,7 +241,7 @@ final class AddMagazineViewModelTests: XCTestCase {
     }
 
     @MainActor
-    func testAddMagazinePersistsExplicitLegacyPattern() throws {
+    func testAddMagazinePersistsExplicitCustomPattern() throws {
         let container = try makeInMemoryContainer()
         let context = container.mainContext
         let viewModel = AddMagazineViewModel()
@@ -255,8 +255,8 @@ final class AddMagazineViewModelTests: XCTestCase {
             color: .black,
             colorDetail: nil,
             notes: nil,
-            patternSelection: .legacy,
-            manualPatternName: "Old Match Tube",
+            patternSelection: .custom,
+            manualPatternName: "Match Tube",
             compatibleCaliberNames: ["9mm", ".38 Super"],
             firearm: nil,
             canAdd: true,
@@ -266,8 +266,8 @@ final class AddMagazineViewModelTests: XCTestCase {
         let magazines = try context.fetch(FetchDescriptor<Magazine>())
 
         XCTAssertTrue(didAdd)
-        XCTAssertEqual(magazines.first?.storedPatternKind, .legacy)
-        XCTAssertEqual(magazines.first?.patternDisplayName, "Old Match Tube")
+        XCTAssertEqual(magazines.first?.storedPatternKind, .custom)
+        XCTAssertEqual(magazines.first?.patternDisplayName, "Match Tube")
         XCTAssertEqual(magazines.first?.supportedCaliberNames, [".38 Super", "9mm"])
     }
 
@@ -318,7 +318,7 @@ final class AddMagazineViewModelTests: XCTestCase {
             color: .other,
             colorDetail: "Nickel",
             notes: "Updated",
-            patternSelection: .automatic,
+            patternSelection: .catalog("catalog:2011-double-stack-9mm"),
             manualPatternName: "",
             compatibleCaliberNames: [],
             firearm: updatedFirearm,
@@ -435,7 +435,7 @@ final class AddMagazineViewModelTests: XCTestCase {
             color: nil,
             colorDetail: nil,
             notes: nil,
-            patternSelection: .automatic,
+            patternSelection: .catalog("catalog:ar15-stanag-223-556-300blk"),
             manualPatternName: "",
             compatibleCaliberNames: [],
             firearm: nil,

--- a/ArmoryInventoryTests/AccessoriesTests/AddMagazineViewModelTests.swift
+++ b/ArmoryInventoryTests/AccessoriesTests/AddMagazineViewModelTests.swift
@@ -464,4 +464,95 @@ final class AddMagazineViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.initialPatternSelection(for: magazine), .legacy)
         XCTAssertEqual(viewModel.initialManualPatternName(for: magazine), "Legacy CZ Tube")
     }
+
+    @MainActor
+    func testAvailableCustomPatternsReturnsPersistedCustomPatterns() throws {
+        let container = try makeInMemoryContainer()
+        let context = container.mainContext
+        let customPattern = MagazinePattern.custom(
+            id: UUID(uuidString: "12345678-1234-1234-1234-1234567890AB")!,
+            displayName: "P320 Legion 9mm",
+            familyLabel: "P320 Legion 9mm",
+            supportedCaliberNames: ["9mm"]
+        )
+        let duplicateMagazine = Magazine(
+            brand: "SIG",
+            modelName: "Legion Spare",
+            patternID: customPattern.id,
+            patternKind: .custom,
+            patternDisplayName: customPattern.displayName,
+            patternSupportedCaliberNames: customPattern.compatibility.supportedCaliberNames,
+            capacity: 21,
+            purchasePriceCents: 5000
+        )
+        let originalMagazine = Magazine(
+            brand: "SIG",
+            modelName: "Legion",
+            patternID: customPattern.id,
+            patternKind: .custom,
+            patternDisplayName: customPattern.displayName,
+            patternSupportedCaliberNames: customPattern.compatibility.supportedCaliberNames,
+            capacity: 21,
+            purchasePriceCents: 4500
+        )
+        let catalogMagazine = Magazine(
+            brand: "Magpul",
+            modelName: "PMAG",
+            patternID: "catalog:ar15-stanag-223-556-300blk",
+            patternKind: .catalog,
+            capacity: 30,
+            purchasePriceCents: 1500
+        )
+        context.insert(originalMagazine)
+        context.insert(duplicateMagazine)
+        context.insert(catalogMagazine)
+
+        let viewModel = AddMagazineViewModel()
+        let availablePatterns = viewModel.availableCustomPatterns(in: context)
+
+        XCTAssertEqual(availablePatterns.count, 1)
+        XCTAssertEqual(availablePatterns.first?.id, customPattern.id)
+        XCTAssertEqual(availablePatterns.first?.displayName, "P320 Legion 9mm")
+        XCTAssertEqual(availablePatterns.first?.compatibility.supportedCaliberNames, ["9mm"])
+    }
+
+    @MainActor
+    func testAddMagazineWithExistingCustomPatternReusesPatternIdentity() throws {
+        let container = try makeInMemoryContainer()
+        let context = container.mainContext
+        let viewModel = AddMagazineViewModel()
+        let customPattern = MagazinePattern.custom(
+            id: UUID(uuidString: "12345678-1234-1234-1234-1234567890AB")!,
+            displayName: "P320 Legion 9mm",
+            familyLabel: "P320 Legion 9mm",
+            supportedCaliberNames: ["9mm"]
+        )
+
+        let didAdd = viewModel.addMagazine(
+            brand: "SIG",
+            modelName: "OEM 17",
+            count: 2,
+            capacity: 17,
+            purchaseDate: .now,
+            purchasePriceCents: 4000,
+            color: .black,
+            colorDetail: nil,
+            notes: nil,
+            patternSelection: .existingCustom(customPattern),
+            manualPatternName: "",
+            compatibleCaliberNames: [],
+            firearm: nil,
+            canAdd: true,
+            to: context
+        )
+
+        let magazines = try context.fetch(FetchDescriptor<Magazine>())
+
+        XCTAssertTrue(didAdd)
+        XCTAssertEqual(magazines.count, 1)
+        XCTAssertEqual(magazines.first?.storedPatternKind, .custom)
+        XCTAssertEqual(magazines.first?.patternID, customPattern.id)
+        XCTAssertEqual(magazines.first?.patternDisplayName, customPattern.displayName)
+        XCTAssertEqual(magazines.first?.supportedCaliberNames, ["9mm"])
+    }
 }

--- a/ArmoryInventoryTests/AccessoriesTests/AddMagazineViewModelTests.swift
+++ b/ArmoryInventoryTests/AccessoriesTests/AddMagazineViewModelTests.swift
@@ -41,7 +41,7 @@ final class AddMagazineViewModelTests: XCTestCase {
                 purchasePriceText: "10",
                 patternSelection: .automatic,
                 manualPatternName: "",
-                selectedCaliber: nil,
+                compatibleCaliberNames: [],
                 firearm: nil
             )
         )
@@ -56,7 +56,7 @@ final class AddMagazineViewModelTests: XCTestCase {
                 purchasePriceText: "10",
                 patternSelection: .automatic,
                 manualPatternName: "",
-                selectedCaliber: nil,
+                compatibleCaliberNames: [],
                 firearm: nil
             )
         )
@@ -71,7 +71,7 @@ final class AddMagazineViewModelTests: XCTestCase {
                 purchasePriceText: "10",
                 patternSelection: .automatic,
                 manualPatternName: "",
-                selectedCaliber: nil,
+                compatibleCaliberNames: [],
                 firearm: nil
             )
         )
@@ -81,7 +81,6 @@ final class AddMagazineViewModelTests: XCTestCase {
 
     func testCanAddReturnsFalseForMagazineCaliberMismatchAgainstLinkedFirearm() {
         let viewModel = AddMagazineViewModel()
-        let magazineCaliber = Caliber(name: "9mm")
         let firearmCaliber = Caliber(name: ".45 ACP")
         let firearm = Firearm(
             brand: "Staccato",
@@ -101,9 +100,9 @@ final class AddMagazineViewModelTests: XCTestCase {
                 selectedColor: .black,
                 colorDetail: nil,
                 purchasePriceText: "75",
-                patternSelection: .automatic,
+                patternSelection: .catalog("catalog:2011-double-stack-9mm"),
                 manualPatternName: "",
-                selectedCaliber: magazineCaliber,
+                compatibleCaliberNames: [],
                 firearm: firearm
             )
         )
@@ -123,7 +122,7 @@ final class AddMagazineViewModelTests: XCTestCase {
                 purchasePriceText: "20",
                 patternSelection: .legacy,
                 manualPatternName: "",
-                selectedCaliber: nil,
+                compatibleCaliberNames: [],
                 firearm: nil
             )
         )
@@ -141,7 +140,8 @@ final class AddMagazineViewModelTests: XCTestCase {
             modelName: "P-10 C",
             purchasePriceCents: 50000,
             type: .pistol,
-            action: .semiAuto
+            action: .semiAuto,
+            caliber: caliber
         )
         context.insert(caliber)
         context.insert(firearm)
@@ -158,7 +158,7 @@ final class AddMagazineViewModelTests: XCTestCase {
             notes: "Range set",
             patternSelection: .automatic,
             manualPatternName: "",
-            caliber: caliber,
+            compatibleCaliberNames: [],
             firearm: firearm,
             canAdd: true,
             to: context
@@ -172,7 +172,7 @@ final class AddMagazineViewModelTests: XCTestCase {
         XCTAssertEqual(magazines.first?.modelName, "OEM")
         XCTAssertEqual(magazines.first?.count, 5)
         XCTAssertEqual(magazines.first?.capacity, 15)
-        XCTAssertEqual(magazines.first?.caliber?.name, "9mm")
+        XCTAssertEqual(magazines.first?.supportedCaliberNames, ["9mm"])
         XCTAssertEqual(magazines.first?.firearm?.displayName, "CZ P-10 C")
         XCTAssertEqual(magazines.first?.purchaseDate, purchaseDate)
         XCTAssertEqual(magazines.first?.sortOrder, 0)
@@ -198,7 +198,7 @@ final class AddMagazineViewModelTests: XCTestCase {
             notes: nil,
             patternSelection: .automatic,
             manualPatternName: "",
-            caliber: nil,
+            compatibleCaliberNames: [],
             firearm: nil,
             canAdd: false,
             to: context
@@ -212,9 +212,6 @@ final class AddMagazineViewModelTests: XCTestCase {
     func testAddMagazineAllowsUnlinkedCatalogPatternMagazine() throws {
         let container = try makeInMemoryContainer()
         let context = container.mainContext
-        let caliber = Caliber(name: "5.56 NATO")
-        context.insert(caliber)
-
         let viewModel = AddMagazineViewModel()
         let didAdd = viewModel.addMagazine(
             brand: "Magpul",
@@ -228,7 +225,7 @@ final class AddMagazineViewModelTests: XCTestCase {
             notes: nil,
             patternSelection: .automatic,
             manualPatternName: "",
-            caliber: caliber,
+            compatibleCaliberNames: [],
             firearm: nil,
             canAdd: true,
             to: context
@@ -247,9 +244,6 @@ final class AddMagazineViewModelTests: XCTestCase {
     func testAddMagazinePersistsExplicitLegacyPattern() throws {
         let container = try makeInMemoryContainer()
         let context = container.mainContext
-        let caliber = Caliber(name: "9mm")
-        context.insert(caliber)
-
         let viewModel = AddMagazineViewModel()
         let didAdd = viewModel.addMagazine(
             brand: "Atlas",
@@ -263,7 +257,7 @@ final class AddMagazineViewModelTests: XCTestCase {
             notes: nil,
             patternSelection: .legacy,
             manualPatternName: "Old Match Tube",
-            caliber: caliber,
+            compatibleCaliberNames: ["9mm", ".38 Super"],
             firearm: nil,
             canAdd: true,
             to: context
@@ -274,6 +268,7 @@ final class AddMagazineViewModelTests: XCTestCase {
         XCTAssertTrue(didAdd)
         XCTAssertEqual(magazines.first?.storedPatternKind, .legacy)
         XCTAssertEqual(magazines.first?.patternDisplayName, "Old Match Tube")
+        XCTAssertEqual(magazines.first?.supportedCaliberNames, [".38 Super", "9mm"])
     }
 
     @MainActor
@@ -325,7 +320,7 @@ final class AddMagazineViewModelTests: XCTestCase {
             notes: "Updated",
             patternSelection: .automatic,
             manualPatternName: "",
-            caliber: updatedCaliber,
+            compatibleCaliberNames: [],
             firearm: updatedFirearm,
             canSave: true,
             in: context
@@ -338,12 +333,12 @@ final class AddMagazineViewModelTests: XCTestCase {
         XCTAssertEqual(magazine.capacity, 20)
         XCTAssertEqual(magazine.magazineColor, .other)
         XCTAssertEqual(magazine.colorDetail, "Nickel")
-        XCTAssertEqual(magazine.caliber?.name, ".45 ACP")
+        XCTAssertEqual(magazine.supportedCaliberNames, ["9mm"])
         XCTAssertEqual(magazine.firearm?.displayName, "Staccato XC")
         XCTAssertEqual(magazine.notes, "Updated")
-        XCTAssertEqual(magazine.storedPatternKind, .legacy)
-        XCTAssertEqual(magazine.patternID, "legacy:atlas-premium")
-        XCTAssertEqual(magazine.patternDisplayName, "Atlas Premium")
+        XCTAssertEqual(magazine.storedPatternKind, .catalog)
+        XCTAssertEqual(magazine.patternID, "catalog:2011-double-stack-9mm")
+        XCTAssertNil(magazine.patternDisplayName)
     }
 
     @MainActor
@@ -385,9 +380,9 @@ final class AddMagazineViewModelTests: XCTestCase {
             color: .black,
             colorDetail: nil,
             notes: "Updated",
-            patternSelection: .automatic,
+            patternSelection: .catalog("catalog:2011-double-stack-9mm"),
             manualPatternName: "",
-            caliber: originalCaliber,
+            compatibleCaliberNames: [],
             firearm: firearm,
             canSave: true,
             in: context
@@ -442,7 +437,7 @@ final class AddMagazineViewModelTests: XCTestCase {
             notes: nil,
             patternSelection: .automatic,
             manualPatternName: "",
-            caliber: caliber,
+            compatibleCaliberNames: [],
             firearm: nil,
             canSave: true,
             in: context

--- a/ArmoryInventoryTests/AccessoriesTests/AddMagazineViewModelTests.swift
+++ b/ArmoryInventoryTests/AccessoriesTests/AddMagazineViewModelTests.swift
@@ -555,4 +555,77 @@ final class AddMagazineViewModelTests: XCTestCase {
         XCTAssertEqual(magazines.first?.patternDisplayName, customPattern.displayName)
         XCTAssertEqual(magazines.first?.supportedCaliberNames, ["9mm"])
     }
+
+    @MainActor
+    func testUpdateMagazineEditingSavedCustomPatternPropagatesToSharedRecords() throws {
+        let container = try makeInMemoryContainer()
+        let context = container.mainContext
+        let viewModel = AddMagazineViewModel()
+        let customPatternID = UUID(uuidString: "12345678-1234-1234-1234-1234567890AB")!
+        let originalPattern = MagazinePattern.custom(
+            id: customPatternID,
+            displayName: "P320 Legion 9mm",
+            familyLabel: "P320 Legion 9mm",
+            supportedCaliberNames: ["9mm"]
+        )
+        let editedMagazine = Magazine(
+            brand: "SIG",
+            modelName: "OEM 17",
+            patternID: originalPattern.id,
+            patternKind: .custom,
+            patternDisplayName: originalPattern.displayName,
+            patternSupportedCaliberNames: originalPattern.compatibility.supportedCaliberNames,
+            capacity: 17,
+            purchasePriceCents: 4000
+        )
+        let siblingMagazine = Magazine(
+            brand: "SIG",
+            modelName: "OEM 21",
+            patternID: originalPattern.id,
+            patternKind: .custom,
+            patternDisplayName: originalPattern.displayName,
+            patternSupportedCaliberNames: originalPattern.compatibility.supportedCaliberNames,
+            capacity: 21,
+            purchasePriceCents: 4500
+        )
+        let firearm = Firearm(
+            brand: "SIG",
+            modelName: "P320",
+            purchasePriceCents: 70000,
+            type: .pistol,
+            action: .semiAuto,
+            supportedMagazinePatterns: [FirearmMagazinePatternReference(pattern: originalPattern)]
+        )
+        context.insert(editedMagazine)
+        context.insert(siblingMagazine)
+        context.insert(firearm)
+
+        let didSave = viewModel.updateMagazine(
+            editedMagazine,
+            brand: "SIG",
+            modelName: "OEM 17",
+            count: 1,
+            capacity: 17,
+            purchaseDate: .now,
+            purchasePriceCents: 4000,
+            color: nil,
+            colorDetail: nil,
+            notes: nil,
+            patternSelection: .custom,
+            manualPatternName: "P320 Legion Multi-Cal",
+            compatibleCaliberNames: ["9mm", ".357 SIG"],
+            existingCustomPatternIDOverride: customPatternID,
+            firearm: nil,
+            canSave: true,
+            in: context
+        )
+
+        XCTAssertTrue(didSave)
+        XCTAssertEqual(editedMagazine.patternID, originalPattern.id)
+        XCTAssertEqual(editedMagazine.patternDisplayName, "P320 Legion Multi-Cal")
+        XCTAssertEqual(editedMagazine.supportedCaliberNames, [".357 SIG", "9mm"])
+        XCTAssertEqual(siblingMagazine.patternDisplayName, "P320 Legion Multi-Cal")
+        XCTAssertEqual(siblingMagazine.supportedCaliberNames, [".357 SIG", "9mm"])
+        XCTAssertEqual(firearm.supportedMagazinePatterns.first?.displayName, "P320 Legion Multi-Cal")
+    }
 }

--- a/ArmoryInventoryTests/AccessoriesTests/MagazineCompatibilityValidatorTests.swift
+++ b/ArmoryInventoryTests/AccessoriesTests/MagazineCompatibilityValidatorTests.swift
@@ -9,45 +9,6 @@ import XCTest
 @testable import ArmoryInventory
 
 final class MagazineCompatibilityValidatorTests: XCTestCase {
-    func testValidateReturnsLinkedToDifferentFirearmFailure() {
-        let validator = MagazineCompatibilityValidator()
-        let currentFirearm = Firearm(
-            brand: "Glock",
-            modelName: "19",
-            purchasePriceCents: 50000,
-            type: .pistol,
-            action: .semiAuto
-        )
-        let otherFirearm = Firearm(
-            brand: "SIG",
-            modelName: "P320",
-            purchasePriceCents: 65000,
-            type: .pistol,
-            action: .semiAuto
-        )
-        let magazine = Magazine(
-            brand: "SIG",
-            modelName: "OEM",
-            capacity: 17,
-            purchasePriceCents: 4500,
-            caliber: Caliber(name: "9mm"),
-            firearm: otherFirearm
-        )
-
-        let result = validator.validate(
-            magazine: magazine,
-            firearmType: .pistol,
-            action: .semiAuto,
-            caliber: currentFirearm.caliber,
-            owningFirearm: currentFirearm
-        )
-
-        XCTAssertEqual(
-            result.failure,
-            .linkedToDifferentFirearm(currentFirearmName: otherFirearm.displayName)
-        )
-    }
-
     func testValidateReturnsCaliberMismatchFailure() {
         let validator = MagazineCompatibilityValidator()
         let result = validator.validate(
@@ -65,7 +26,7 @@ final class MagazineCompatibilityValidatorTests: XCTestCase {
         )
     }
 
-    func testValidateReturnsIncompatiblePatternFailure() {
+    func testValidateUsesPatternSupportedCalibersWhenAvailable() {
         let validator = MagazineCompatibilityValidator()
         let arPattern = MagazinePattern(
             id: "catalog:test-ar-pattern",
@@ -82,30 +43,31 @@ final class MagazineCompatibilityValidatorTests: XCTestCase {
             aliases: [],
             notes: nil
         )
+
         let result = validator.validate(
             pattern: arPattern,
-            selectedMagazineCaliber: Caliber(name: "5.56 NATO"),
+            selectedMagazineCaliber: nil,
             firearmType: .pistol,
             action: .semiAuto,
-            caliber: Caliber(name: "5.56 NATO"),
-            firearmDescription: "Glock 19"
+            caliber: Caliber(name: ".300 Blackout"),
+            firearmDescription: "AR Pistol"
         )
 
         XCTAssertEqual(
             result.failure,
-            .incompatiblePattern(patternName: "Test AR Pattern", firearmDescription: "Glock 19")
+            .caliberMismatch(magazineCaliberName: "5.56 NATO", firearmCaliberName: ".300 Blackout")
         )
     }
 
     func testValidateReturnsCompatibleForMatchingPatternAndCaliber() {
         let validator = MagazineCompatibilityValidator()
         let result = validator.validate(
-            pattern: MagazinePatternCatalog.canonicalPatterns.first { $0.id == "catalog:glock-double-stack-9mm-full-size-compact" }!,
-            selectedMagazineCaliber: Caliber(name: "9mm"),
+            pattern: MagazinePatternCatalog.canonicalPatterns.first { $0.id == "catalog:ar15-stanag-223-556-300blk" }!,
+            selectedMagazineCaliber: nil,
             firearmType: .pistol,
             action: .semiAuto,
-            caliber: Caliber(name: "9mm"),
-            firearmDescription: "Glock 19"
+            caliber: Caliber(name: "5.56 NATO"),
+            firearmDescription: "AR Pistol"
         )
 
         XCTAssertTrue(result.isCompatible)

--- a/ArmoryInventoryTests/AccessoriesTests/MagazineModelsTests.swift
+++ b/ArmoryInventoryTests/AccessoriesTests/MagazineModelsTests.swift
@@ -33,6 +33,7 @@ final class MagazineModelsTests: XCTestCase {
         XCTAssertEqual(magazine.displayName, "Atlas Premium")
         XCTAssertEqual(magazine.capacityText, "20 rounds")
         XCTAssertEqual(magazine.countText, "3 magazines")
+        XCTAssertEqual(magazine.countCapacityText, "3 20-round magazines")
         XCTAssertEqual(magazine.totalRoundCapacity, 60)
         XCTAssertEqual(magazine.totalRoundCapacityText, "60 Rounds")
         XCTAssertEqual(magazine.supportedCaliberNames, ["9mm"])
@@ -59,6 +60,7 @@ final class MagazineModelsTests: XCTestCase {
 
         XCTAssertEqual(magazine.countText, "1 magazine")
         XCTAssertEqual(magazine.capacityText, "17 rounds")
+        XCTAssertEqual(magazine.countCapacityText, "1 17-round magazine")
         XCTAssertEqual(magazine.totalRoundCapacity, 17)
         XCTAssertEqual(magazine.totalRoundCapacityText, "17 Rounds")
         XCTAssertEqual(magazine.caliberDisplayText, "No Caliber")

--- a/ArmoryInventoryTests/AccessoriesTests/MagazineModelsTests.swift
+++ b/ArmoryInventoryTests/AccessoriesTests/MagazineModelsTests.swift
@@ -33,6 +33,8 @@ final class MagazineModelsTests: XCTestCase {
         XCTAssertEqual(magazine.displayName, "Atlas Premium")
         XCTAssertEqual(magazine.capacityText, "20 rounds")
         XCTAssertEqual(magazine.countText, "3 magazines")
+        XCTAssertEqual(magazine.totalRoundCapacity, 60)
+        XCTAssertEqual(magazine.totalRoundCapacityText, "60 Rounds")
         XCTAssertEqual(magazine.magazineColor, .other)
         XCTAssertEqual(magazine.colorDisplayName, "Nickel")
         XCTAssertTrue(magazine.purchasePriceText.contains("210"))
@@ -55,6 +57,8 @@ final class MagazineModelsTests: XCTestCase {
 
         XCTAssertEqual(magazine.countText, "1 magazine")
         XCTAssertEqual(magazine.capacityText, "17 rounds")
+        XCTAssertEqual(magazine.totalRoundCapacity, 17)
+        XCTAssertEqual(magazine.totalRoundCapacityText, "17 Rounds")
         XCTAssertEqual(magazine.magazineColor, .other)
         XCTAssertEqual(magazine.colorDisplayName, "Other")
 

--- a/ArmoryInventoryTests/AccessoriesTests/MagazineModelsTests.swift
+++ b/ArmoryInventoryTests/AccessoriesTests/MagazineModelsTests.swift
@@ -35,6 +35,8 @@ final class MagazineModelsTests: XCTestCase {
         XCTAssertEqual(magazine.countText, "3 magazines")
         XCTAssertEqual(magazine.totalRoundCapacity, 60)
         XCTAssertEqual(magazine.totalRoundCapacityText, "60 Rounds")
+        XCTAssertEqual(magazine.supportedCaliberNames, ["9mm"])
+        XCTAssertEqual(magazine.caliberDisplayText, "9mm")
         XCTAssertEqual(magazine.magazineColor, .other)
         XCTAssertEqual(magazine.colorDisplayName, "Nickel")
         XCTAssertTrue(magazine.purchasePriceText.contains("210"))
@@ -59,6 +61,7 @@ final class MagazineModelsTests: XCTestCase {
         XCTAssertEqual(magazine.capacityText, "17 rounds")
         XCTAssertEqual(magazine.totalRoundCapacity, 17)
         XCTAssertEqual(magazine.totalRoundCapacityText, "17 Rounds")
+        XCTAssertEqual(magazine.caliberDisplayText, "No Caliber")
         XCTAssertEqual(magazine.magazineColor, .other)
         XCTAssertEqual(magazine.colorDisplayName, "Other")
 
@@ -68,5 +71,42 @@ final class MagazineModelsTests: XCTestCase {
         XCTAssertNil(magazine.colorDisplayName)
         XCTAssertEqual(magazine.resolvedPattern.kind, .legacy)
         XCTAssertEqual(magazine.resolvedPattern.displayName, "Glock OEM")
+    }
+
+    func testLinkedFirearmsDeriveFromSupportedPatterns() {
+        let caliber = Caliber(name: "5.56 NATO")
+        let magazine = Magazine(
+            brand: "Magpul",
+            modelName: "PMAG",
+            patternID: "catalog:ar15-stanag-223-556-300blk",
+            patternKind: .catalog,
+            count: 2,
+            capacity: 30,
+            purchasePriceCents: 2500,
+            caliber: caliber
+        )
+        let directLegacyFirearm = Firearm(
+            brand: "Legacy",
+            modelName: "Host",
+            purchasePriceCents: 100000,
+            type: .rifle,
+            action: .semiAuto,
+            magazines: [magazine]
+        )
+        let supportedPatternFirearm = Firearm(
+            brand: "AR",
+            modelName: "Pistol",
+            purchasePriceCents: 120000,
+            type: .pistol,
+            action: .semiAuto,
+            supportedMagazinePatterns: [FirearmMagazinePatternReference(pattern: magazine.resolvedPattern)],
+            caliber: caliber
+        )
+
+        XCTAssertEqual(
+            magazine.linkedFirearms(from: [supportedPatternFirearm, directLegacyFirearm]).map(\.displayName),
+            ["AR Pistol", "Legacy Host"]
+        )
+        XCTAssertEqual(magazine.caliberDisplayText, ".223 Rem, 5.56 NATO, .300 Blackout")
     }
 }

--- a/ArmoryInventoryTests/AccessoriesTests/MagazinePatternModelsTests.swift
+++ b/ArmoryInventoryTests/AccessoriesTests/MagazinePatternModelsTests.swift
@@ -41,7 +41,7 @@ final class MagazinePatternModelsTests: XCTestCase {
         XCTAssertTrue(compact.compatibility.platformTags.contains("Glock 19"))
     }
 
-    func testSuggestedPatternsFilterByTypeActionAndCaliber() {
+    func testSuggestedPatternsFilterByCaliber() {
         let pistolPatterns = MagazinePatternCatalog.suggestedPatterns(
             firearmType: .pistol,
             action: .semiAuto,
@@ -51,6 +51,11 @@ final class MagazinePatternModelsTests: XCTestCase {
             firearmType: .rifle,
             action: .semiAuto,
             caliberName: KnownCaliber.blackout300.displayName
+        )
+        let arPistolPatterns = MagazinePatternCatalog.suggestedPatterns(
+            firearmType: .pistol,
+            action: .semiAuto,
+            caliberName: KnownCaliber.nato556.displayName
         )
 
         XCTAssertEqual(
@@ -63,6 +68,7 @@ final class MagazinePatternModelsTests: XCTestCase {
             ]
         )
         XCTAssertEqual(riflePatterns.map(\.id), ["catalog:ar15-stanag-223-556-300blk"])
+        XCTAssertEqual(arPistolPatterns.map(\.id), ["catalog:ar15-stanag-223-556-300blk"])
     }
 
     func testLegacyFallbackPreservesUserFacingDetails() {

--- a/ArmoryInventoryTests/AccessoriesTests/MagazinePatternModelsTests.swift
+++ b/ArmoryInventoryTests/AccessoriesTests/MagazinePatternModelsTests.swift
@@ -32,8 +32,8 @@ final class MagazinePatternModelsTests: XCTestCase {
 
         XCTAssertEqual(fullSize.compatibility.supportedCaliberNames, [KnownCaliber.mm9.displayName])
         XCTAssertEqual(compact.compatibility.supportedCaliberNames, [KnownCaliber.mm9.displayName])
-        XCTAssertEqual(fullSize.familyLabel, "Glock Double-Stack 9mm")
-        XCTAssertEqual(compact.familyLabel, "Glock Double-Stack 9mm")
+        XCTAssertEqual(fullSize.familyLabel, "Glock 17 Pattern")
+        XCTAssertEqual(compact.familyLabel, "Glock 19 Pattern")
         XCTAssertNotEqual(fullSize.id, compact.id)
         XCTAssertNotEqual(fullSize.compatibility.fitDescriptors, compact.compatibility.fitDescriptors)
         XCTAssertTrue(fullSize.compatibility.platformTags.contains("Glock 17"))
@@ -63,7 +63,6 @@ final class MagazinePatternModelsTests: XCTestCase {
             [
                 "catalog:glock-double-stack-9mm-full-size-compact",
                 "catalog:glock-double-stack-9mm-compact",
-                "catalog:sig-p320-double-stack-9mm",
                 "catalog:2011-double-stack-9mm"
             ]
         )

--- a/ArmoryInventoryTests/FirearmsTests/AddFirearmViewModelTests.swift
+++ b/ArmoryInventoryTests/FirearmsTests/AddFirearmViewModelTests.swift
@@ -50,6 +50,7 @@ final class AddFirearmViewModelTests: XCTestCase {
                 barrelLengthText: "bad",
                 duplicateExists: false,
                 magazines: [],
+                selectedMagazinePatterns: [],
                 caliber: nil,
                 owningFirearm: nil
             )
@@ -68,6 +69,7 @@ final class AddFirearmViewModelTests: XCTestCase {
                 barrelLengthText: "",
                 duplicateExists: false,
                 magazines: [],
+                selectedMagazinePatterns: [],
                 caliber: nil,
                 owningFirearm: nil
             )
@@ -86,6 +88,7 @@ final class AddFirearmViewModelTests: XCTestCase {
                 barrelLengthText: "",
                 duplicateExists: false,
                 magazines: [],
+                selectedMagazinePatterns: [],
                 caliber: nil,
                 owningFirearm: nil
             )
@@ -104,6 +107,7 @@ final class AddFirearmViewModelTests: XCTestCase {
                 barrelLengthText: "",
                 duplicateExists: false,
                 magazines: [],
+                selectedMagazinePatterns: [],
                 caliber: nil,
                 owningFirearm: nil
             )
@@ -250,11 +254,13 @@ final class AddFirearmViewModelTests: XCTestCase {
 
         let selectedOpticIDs = viewModel.selectedOpticIDs(for: currentFirearm)
         let selectedMagazineIDs = viewModel.selectedMagazineIDs(for: currentFirearm)
+        let selectedMagazinePatterns = viewModel.selectedMagazinePatterns(for: currentFirearm)
         let selectedAttachmentIDs = viewModel.selectedAttachmentIDs(for: currentFirearm)
         let selectedPartIDs = viewModel.selectedPartIDs(for: currentFirearm)
 
         XCTAssertEqual(selectedOpticIDs, [currentOptic.persistentModelID])
         XCTAssertEqual(selectedMagazineIDs, [currentMagazine.persistentModelID])
+        XCTAssertTrue(selectedMagazinePatterns.isEmpty)
         XCTAssertEqual(selectedAttachmentIDs, [currentAttachment.persistentModelID])
         XCTAssertEqual(selectedPartIDs, [currentPart.persistentModelID])
 
@@ -274,6 +280,7 @@ final class AddFirearmViewModelTests: XCTestCase {
                 viewModel.availableMagazines(
                     from: [freeMagazine, currentMagazine, otherMagazine],
                     selectedIDs: selectedMagazineIDs,
+                    selectedPatterns: [],
                     firearm: currentFirearm,
                     firearmType: .pistol,
                     action: .semiAuto,
@@ -473,6 +480,7 @@ final class AddFirearmViewModelTests: XCTestCase {
             colorDetail: nil,
             barrelLengthInches: 4.02,
             notes: "Optics ready",
+            supportedMagazinePatterns: [],
             caliber: caliber,
             optics: [optic],
             magazines: [magazine],
@@ -524,6 +532,7 @@ final class AddFirearmViewModelTests: XCTestCase {
             colorDetail: nil,
             barrelLengthInches: 18.5,
             notes: nil,
+            supportedMagazinePatterns: [],
             caliber: nil,
             optics: [],
             magazines: [],
@@ -576,6 +585,7 @@ final class AddFirearmViewModelTests: XCTestCase {
             colorDetail: "Two Tone",
             barrelLengthInches: 4.25,
             notes: "Updated",
+            supportedMagazinePatterns: [],
             caliber: caliber,
             optics: [],
             magazines: [],
@@ -625,10 +635,144 @@ final class AddFirearmViewModelTests: XCTestCase {
                 barrelLengthText: "",
                 duplicateExists: false,
                 magazines: [incompatibleMagazine],
+                selectedMagazinePatterns: [],
                 caliber: caliber,
                 owningFirearm: nil
             )
         )
+    }
+
+    func testCanAddReturnsFalseWhenSelectedMagazinePatternExcludesLinkedMagazine() {
+        let viewModel = AddFirearmViewModel()
+        let caliber = Caliber(name: "9mm")
+        let magazine = Magazine(
+            brand: "Staccato",
+            modelName: "2011",
+            patternID: "catalog:2011-double-stack-9mm",
+            patternKind: .catalog,
+            capacity: 20,
+            purchasePriceCents: 8000,
+            caliber: caliber
+        )
+        let selectedPatterns = [
+            FirearmMagazinePatternReference(
+                id: "catalog:glock-double-stack-9mm-full-size-compact",
+                kind: .catalog,
+                displayName: nil
+            )
+        ]
+
+        XCTAssertFalse(
+            viewModel.canAdd(
+                brand: "Staccato",
+                modelName: "P",
+                serialNumber: "",
+                selectedType: .pistol,
+                selectedAction: .semiAuto,
+                actionDetail: nil,
+                selectedColor: nil,
+                colorDetail: nil,
+                purchasePriceText: "500",
+                barrelLengthText: "",
+                duplicateExists: false,
+                magazines: [magazine],
+                selectedMagazinePatterns: selectedPatterns,
+                caliber: caliber,
+                owningFirearm: nil
+            )
+        )
+    }
+
+    func testAvailableMagazinesFiltersToSelectedPatterns() {
+        let viewModel = AddFirearmViewModel()
+        let caliber = Caliber(name: "9mm")
+        let glockMagazine = Magazine(
+            brand: "Glock",
+            modelName: "OEM",
+            patternID: "catalog:glock-double-stack-9mm-full-size-compact",
+            patternKind: .catalog,
+            capacity: 17,
+            purchasePriceCents: 2500,
+            caliber: caliber
+        )
+        let staccatoMagazine = Magazine(
+            brand: "Staccato",
+            modelName: "2011",
+            patternID: "catalog:2011-double-stack-9mm",
+            patternKind: .catalog,
+            capacity: 20,
+            purchasePriceCents: 8000,
+            caliber: caliber
+        )
+        let selectedPatterns = [
+            FirearmMagazinePatternReference(
+                id: "catalog:glock-double-stack-9mm-full-size-compact",
+                kind: .catalog,
+                displayName: nil
+            )
+        ]
+
+        XCTAssertEqual(
+            viewModel.availableMagazines(
+                from: [glockMagazine, staccatoMagazine],
+                selectedIDs: [],
+                selectedPatterns: selectedPatterns,
+                firearm: nil,
+                firearmType: .pistol,
+                action: .semiAuto,
+                caliber: caliber
+            ).map(\.displayName),
+            ["Glock OEM"]
+        )
+    }
+
+    @MainActor
+    func testAddFirearmPersistsSelectedMagazinePatterns() throws {
+        let container = try makeInMemoryContainer()
+        let context = container.mainContext
+        let viewModel = AddFirearmViewModel()
+        let selectedPatterns = [
+            FirearmMagazinePatternReference(
+                id: "catalog:glock-double-stack-9mm-full-size-compact",
+                kind: .catalog,
+                displayName: nil
+            ),
+            FirearmMagazinePatternReference(
+                id: "legacy:cz-shadow-pattern",
+                kind: .legacy,
+                displayName: "CZ Shadow Legacy"
+            )
+        ]
+
+        let didAdd = viewModel.addFirearm(
+            brand: "CZ",
+            modelName: "Shadow 2",
+            nickname: nil,
+            serialNumber: "",
+            purchaseDate: .now,
+            lastCleanedDate: nil,
+            purchasePriceCents: 150000,
+            type: .pistol,
+            action: .semiAuto,
+            actionDetail: nil,
+            color: nil,
+            colorDetail: nil,
+            barrelLengthInches: nil,
+            notes: nil,
+            supportedMagazinePatterns: selectedPatterns,
+            caliber: nil,
+            optics: [],
+            magazines: [],
+            attachments: [],
+            parts: [],
+            canAdd: true,
+            to: context
+        )
+
+        let firearms = try context.fetch(FetchDescriptor<Firearm>())
+
+        XCTAssertTrue(didAdd)
+        XCTAssertEqual(firearms.first?.supportedMagazinePatterns, selectedPatterns)
     }
 
     @MainActor
@@ -675,6 +819,7 @@ final class AddFirearmViewModelTests: XCTestCase {
             colorDetail: nil,
             barrelLengthInches: 4.4,
             notes: nil,
+            supportedMagazinePatterns: [],
             caliber: updatedCaliber,
             optics: [],
             magazines: [magazine],

--- a/ArmoryInventoryTests/FirearmsTests/AddFirearmViewModelTests.swift
+++ b/ArmoryInventoryTests/FirearmsTests/AddFirearmViewModelTests.swift
@@ -175,6 +175,8 @@ final class AddFirearmViewModelTests: XCTestCase {
         let currentMagazine = Magazine(
             brand: "Glock",
             modelName: "OEM",
+            patternID: "catalog:glock-double-stack-9mm-full-size-compact",
+            patternKind: .catalog,
             capacity: 17,
             purchasePriceCents: 2500,
             caliber: pistolCaliber,
@@ -253,14 +255,12 @@ final class AddFirearmViewModelTests: XCTestCase {
         currentFirearm.parts = [currentPart]
 
         let selectedOpticIDs = viewModel.selectedOpticIDs(for: currentFirearm)
-        let selectedMagazineIDs = viewModel.selectedMagazineIDs(for: currentFirearm)
         let selectedMagazinePatterns = viewModel.selectedMagazinePatterns(for: currentFirearm)
         let selectedAttachmentIDs = viewModel.selectedAttachmentIDs(for: currentFirearm)
         let selectedPartIDs = viewModel.selectedPartIDs(for: currentFirearm)
 
         XCTAssertEqual(selectedOpticIDs, [currentOptic.persistentModelID])
-        XCTAssertEqual(selectedMagazineIDs, [currentMagazine.persistentModelID])
-        XCTAssertTrue(selectedMagazinePatterns.isEmpty)
+        XCTAssertEqual(selectedMagazinePatterns, [FirearmMagazinePatternReference(pattern: currentMagazine.resolvedPattern)])
         XCTAssertEqual(selectedAttachmentIDs, [currentAttachment.persistentModelID])
         XCTAssertEqual(selectedPartIDs, [currentPart.persistentModelID])
 
@@ -277,11 +277,9 @@ final class AddFirearmViewModelTests: XCTestCase {
         )
         XCTAssertEqual(
             Set(
-                viewModel.availableMagazines(
+                viewModel.linkedMagazines(
                     from: [freeMagazine, currentMagazine, otherMagazine],
-                    selectedIDs: selectedMagazineIDs,
-                    selectedPatterns: [],
-                    firearm: currentFirearm,
+                    selectedPatterns: selectedMagazinePatterns,
                     firearmType: .pistol,
                     action: .semiAuto,
                     caliber: currentMagazine.caliber
@@ -320,14 +318,6 @@ final class AddFirearmViewModelTests: XCTestCase {
             )
             .map(\.persistentModelID),
             [freeOptic.persistentModelID, otherOptic.persistentModelID]
-        )
-        XCTAssertEqual(
-            viewModel.resolvedMagazines(
-                from: [freeMagazine, currentMagazine, otherMagazine],
-                selectedIDs: [otherMagazine.persistentModelID]
-            )
-            .map(\.persistentModelID),
-            [otherMagazine.persistentModelID]
         )
         XCTAssertEqual(
             viewModel.resolvedAttachments(
@@ -480,7 +470,7 @@ final class AddFirearmViewModelTests: XCTestCase {
             colorDetail: nil,
             barrelLengthInches: 4.02,
             notes: "Optics ready",
-            supportedMagazinePatterns: [],
+            supportedMagazinePatterns: [FirearmMagazinePatternReference(pattern: magazine.resolvedPattern)],
             caliber: caliber,
             optics: [optic],
             magazines: [magazine],
@@ -506,7 +496,10 @@ final class AddFirearmViewModelTests: XCTestCase {
         XCTAssertEqual(firearms.first?.purchaseDate, purchaseDate)
         XCTAssertEqual(firearms.first?.lastCleanedDate, Date(timeIntervalSince1970: 22_222))
         XCTAssertEqual(firearms.first?.optics.map(\.displayName), ["Holosun 507C"])
-        XCTAssertEqual(firearms.first?.magazines.map(\.displayName), ["CZ P-10"])
+        XCTAssertEqual(
+            firearms.first?.supportedMagazinePatterns,
+            [FirearmMagazinePatternReference(pattern: magazine.resolvedPattern)]
+        )
         XCTAssertEqual(firearms.first?.attachments.map(\.displayName), ["Streamlight TLR-7A"])
         XCTAssertEqual(firearms.first?.parts.map(\.displayName), ["Apex Action Enhancement"])
     }
@@ -713,11 +706,9 @@ final class AddFirearmViewModelTests: XCTestCase {
         ]
 
         XCTAssertEqual(
-            viewModel.availableMagazines(
+            viewModel.linkedMagazines(
                 from: [glockMagazine, staccatoMagazine],
-                selectedIDs: [],
                 selectedPatterns: selectedPatterns,
-                firearm: nil,
                 firearmType: .pistol,
                 action: .semiAuto,
                 caliber: caliber

--- a/ArmoryInventoryTests/FirearmsTests/FirearmModelsTests.swift
+++ b/ArmoryInventoryTests/FirearmsTests/FirearmModelsTests.swift
@@ -117,6 +117,10 @@ final class FirearmModelsTests: XCTestCase {
         XCTAssertEqual(firearm.barrelLengthText, "4.4 in")
         XCTAssertTrue(firearm.purchasePriceText.contains("2,500"))
         XCTAssertEqual(firearm.lastCleanedDateText, firearm.lastCleanedDate?.formatted(date: .abbreviated, time: .omitted))
+        XCTAssertEqual(firearm.totalLinkedMagazineCount(using: [magazine]), 3)
+        XCTAssertEqual(firearm.totalLinkedMagazineCapacity(using: [magazine]), 51)
+        XCTAssertEqual(firearm.linkedMagazineCountText(using: [magazine]), "3 magazines")
+        XCTAssertEqual(firearm.linkedMagazineCapacityText(using: [magazine]), "51 Rounds")
         XCTAssertEqual(firearm.totalCardValueCents, 378000)
         XCTAssertTrue(firearm.totalCardValueText.contains("3,780"))
     }
@@ -189,6 +193,10 @@ final class FirearmModelsTests: XCTestCase {
         XCTAssertEqual(firearm.subtitle, "Other")
         XCTAssertEqual(firearm.roundsText, "0 Rounds")
         XCTAssertNil(firearm.barrelLengthText)
+        XCTAssertEqual(firearm.totalLinkedMagazineCount(using: [magazine]), 1)
+        XCTAssertEqual(firearm.totalLinkedMagazineCapacity(using: [magazine]), 30)
+        XCTAssertEqual(firearm.linkedMagazineCountText(using: [magazine]), "1 magazine")
+        XCTAssertEqual(firearm.linkedMagazineCapacityText(using: [magazine]), "30 Rounds")
         XCTAssertEqual(firearm.totalCardValueCents, 0)
         XCTAssertTrue(firearm.totalCardValueText.contains("0.00"))
         XCTAssertNil(firearm.lastCleanedDateText)
@@ -199,5 +207,27 @@ final class FirearmModelsTests: XCTestCase {
         XCTAssertNil(firearm.firearmColor)
         XCTAssertNil(firearm.colorDisplayName)
         XCTAssertNil(firearm.roundsText)
+    }
+
+    func testLinkedMagazineSummariesClampNegativeMagazineCounts() {
+        let firearm = Firearm(
+            brand: "Test",
+            modelName: "Host",
+            purchasePriceCents: 100000,
+            type: .pistol,
+            action: .semiAuto
+        )
+        let malformedMagazine = Magazine(
+            brand: "Broken",
+            modelName: "Input",
+            count: -2,
+            capacity: 17,
+            purchasePriceCents: 1000
+        )
+
+        XCTAssertEqual(firearm.totalLinkedMagazineCount(using: [malformedMagazine]), 0)
+        XCTAssertEqual(firearm.totalLinkedMagazineCapacity(using: [malformedMagazine]), 0)
+        XCTAssertEqual(firearm.linkedMagazineCountText(using: [malformedMagazine]), "0 magazines")
+        XCTAssertEqual(firearm.linkedMagazineCapacityText(using: [malformedMagazine]), "0 Rounds")
     }
 }

--- a/ArmoryInventoryTests/ServicesTests/UserDataTransferServiceTests.swift
+++ b/ArmoryInventoryTests/ServicesTests/UserDataTransferServiceTests.swift
@@ -31,6 +31,18 @@ final class UserDataTransferServiceTests: XCTestCase {
             action: .semiAuto,
             color: .black,
             notes: "Primary",
+            supportedMagazinePatterns: [
+                FirearmMagazinePatternReference(
+                    id: "catalog:glock-double-stack-9mm-full-size-compact",
+                    kind: .catalog,
+                    displayName: nil
+                ),
+                FirearmMagazinePatternReference(
+                    id: "legacy:glock-legacy",
+                    kind: .legacy,
+                    displayName: "Legacy Glock Pattern"
+                )
+            ],
             caliber: caliber,
             sortOrder: 3,
             createdAt: Date(timeIntervalSince1970: 2_000)
@@ -145,6 +157,21 @@ final class UserDataTransferServiceTests: XCTestCase {
         XCTAssertEqual(importedRecords.count, 1)
         XCTAssertEqual(importedFirearms.first?.id, firearmID)
         XCTAssertEqual(importedFirearms.first?.caliber?.name, "9mm")
+        XCTAssertEqual(
+            importedFirearms.first?.supportedMagazinePatterns,
+            [
+                FirearmMagazinePatternReference(
+                    id: "catalog:glock-double-stack-9mm-full-size-compact",
+                    kind: .catalog,
+                    displayName: nil
+                ),
+                FirearmMagazinePatternReference(
+                    id: "legacy:glock-legacy",
+                    kind: .legacy,
+                    displayName: "Legacy Glock Pattern"
+                )
+            ]
+        )
         XCTAssertEqual(importedOptics.first?.firearm?.id, firearmID)
         XCTAssertEqual(importedMagazines.first?.caliber?.name, "9mm")
         XCTAssertEqual(importedMagazines.first?.storedPatternKind, .legacy)


### PR DESCRIPTION
## Summary
- add explicit magazine pattern selection to the add/edit magazine screen
- support automatic, catalog, legacy, and custom pattern choices while preserving legacy values
- cover the new selection and persistence paths in the add-magazine view model tests

## Testing
- DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test -scheme 'Armory Inventory' -destination 'platform=iOS Simulator,name=iPhone 17,OS=26.4.1' -only-testing:ArmoryInventoryTests/AddMagazineViewModelTests -only-testing:ArmoryInventoryTests/AddFirearmViewModelTests -only-testing:ArmoryInventoryTests/MagazineCompatibilityValidatorTests -only-testing:ArmoryInventoryTests/MagazinePatternModelsTests -only-testing:ArmoryInventoryTests/MagazinePatternMigrationTests

Closes #22