### PR TITLE
Add test coverage for extracted magazine pattern view logic

### DIFF
--- a/ArmoryInventory/Accessories/Magazines/MagazinesView.swift
+++ b/ArmoryInventory/Accessories/Magazines/MagazinesView.swift
@@ -18,6 +18,7 @@ struct MagazinesView: View {
     @State private var magazines: [Magazine] = []
 
     private let inventoryListService: InventoryListServicing = AppServices.shared.resolve(InventoryListServicing.self)
+    private let viewModel = MagazinesViewModel()
 
     var body: some View {
         Group {
@@ -65,11 +66,9 @@ struct MagazinesView: View {
                                 Text(group.summaryText)
                                     .font(.caption)
                                     .foregroundStyle(.secondary)
-                                if let linkedFirearmsText = group.linkedFirearmsText {
-                                    Text(linkedFirearmsText)
-                                        .font(.caption)
-                                        .foregroundStyle(.secondary)
-                                }
+                                Text(group.linkedFirearmsText)
+                                    .font(.caption)
+                                    .foregroundStyle(.secondary)
                             }
                         }
                     }
@@ -156,110 +155,7 @@ struct MagazinesView: View {
         return amount.formatted(.currency(code: Locale.current.currency?.identifier ?? "USD"))
     }
 
-    private func linkedFirearmNames(for magazines: [Magazine]) -> [String] {
-        var uniqueNames: Set<String> = []
-
-        for magazine in magazines {
-            for firearm in magazine.linkedFirearms(from: firearms) {
-                uniqueNames.insert(firearm.displayName)
-            }
-        }
-
-        return uniqueNames.sorted {
-            $0.localizedCaseInsensitiveCompare($1) == .orderedAscending
-        }
-    }
-
-    private var groupedMagazines: [MagazinePatternGroup] {
-        let grouped = Dictionary(grouping: magazines) { magazine in
-            magazine.resolvedPattern.id
-        }
-
-        return grouped
-            .compactMap { _, magazines in
-                guard let firstMagazine = magazines.first else {
-                    return nil
-                }
-
-                let pattern = firstMagazine.resolvedPattern
-                return MagazinePatternGroup(
-                    id: pattern.id,
-                    displayName: pattern.displayName,
-                    caliberText: pattern.compatibility.supportedCaliberNames.joined(separator: ", "),
-                    linkedFirearmNames: linkedFirearmNames(for: magazines),
-                    magazines: magazines
-                )
-            }
-            .sorted {
-                switch ($0.primaryCaliberName, $1.primaryCaliberName) {
-                case let (lhs?, rhs?):
-                    if lhs.caseInsensitiveCompare(rhs) != .orderedSame {
-                        return CaliberSort.areInAscendingOrder(lhs, rhs)
-                    }
-                case (.some, .none):
-                    return true
-                case (.none, .some):
-                    return false
-                case (.none, .none):
-                    break
-                }
-
-                let nameComparison = $0.displayName.localizedCaseInsensitiveCompare($1.displayName)
-                if nameComparison != .orderedSame {
-                    return nameComparison == .orderedAscending
-                }
-
-                return $0.id.localizedCaseInsensitiveCompare($1.id) == .orderedAscending
-            }
-    }
-}
-
-private struct MagazinePatternGroup: Identifiable {
-    let id: String
-    let displayName: String
-    let caliberText: String
-    let linkedFirearmNames: [String]
-    let magazines: [Magazine]
-
-    init(id: String, displayName: String, caliberText: String, linkedFirearmNames: [String] = [], magazines: [Magazine] = []) {
-        self.id = id
-        self.displayName = displayName
-        self.caliberText = caliberText
-        self.linkedFirearmNames = linkedFirearmNames
-        self.magazines = magazines
-    }
-
-    var summaryText: String {
-        let totalCount = magazines.reduce(0) { $0 + max(0, $1.count) }
-        let countText = String.localizedStringWithFormat(
-            String(localized: "magazineCount"),
-            Int64(totalCount)
-        )
-        guard !caliberText.isEmpty else {
-            return countText
-        }
-
-        return "\(caliberText) • \(countText)"
-    }
-
-    var primaryCaliberName: String? {
-        let caliberNames = caliberText
-            .split(separator: ",")
-            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
-            .filter { !$0.isEmpty }
-
-        return caliberNames.first
-    }
-
-    var linkedFirearmsText: String? {
-        let baseText = String.localizedStringWithFormat(
-            String(localized: "usedByFirearm"),
-            Int64(linkedFirearmNames.count)
-        )
-        guard !linkedFirearmNames.isEmpty else {
-            return baseText
-        }
-
-        return "\(baseText)\(linkedFirearmNames.joined(separator: ", "))"
+    private var groupedMagazines: [MagazinePatternGroupSummary] {
+        viewModel.groupedMagazines(magazines, firearms: firearms)
     }
 }

--- a/ArmoryInventory/Accessories/Magazines/MagazinesViewModel.swift
+++ b/ArmoryInventory/Accessories/Magazines/MagazinesViewModel.swift
@@ -1,0 +1,111 @@
+//
+//  MagazinesViewModel.swift
+//  Armory Inventory
+//
+//  Created by Codex on 4/24/26.
+//
+
+import Foundation
+
+struct MagazinePatternGroupSummary: Identifiable, Equatable {
+    let id: String
+    let displayName: String
+    let caliberText: String
+    let linkedFirearmNames: [String]
+    let magazines: [Magazine]
+
+    var summaryText: String {
+        let totalCount = magazines.reduce(0) { $0 + max(0, $1.count) }
+        let countText = String.localizedStringWithFormat(
+            String(localized: "magazineCount"),
+            Int64(totalCount)
+        )
+        guard !caliberText.isEmpty else {
+            return countText
+        }
+
+        return "\(caliberText) • \(countText)"
+    }
+
+    var primaryCaliberName: String? {
+        let caliberNames = caliberText
+            .split(separator: ",")
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+
+        return caliberNames.first
+    }
+
+    var linkedFirearmsText: String {
+        let baseText = String.localizedStringWithFormat(
+            String(localized: "usedByFirearm"),
+            Int64(linkedFirearmNames.count)
+        )
+        guard !linkedFirearmNames.isEmpty else {
+            return baseText
+        }
+
+        return "\(baseText)\(linkedFirearmNames.joined(separator: ", "))"
+    }
+}
+
+final class MagazinesViewModel {
+    func groupedMagazines(_ magazines: [Magazine], firearms: [Firearm]) -> [MagazinePatternGroupSummary] {
+        let grouped = Dictionary(grouping: magazines) { magazine in
+            magazine.resolvedPattern.id
+        }
+
+        return grouped
+            .compactMap { _, magazines in
+                guard let firstMagazine = magazines.first else {
+                    return nil
+                }
+
+                let pattern = firstMagazine.resolvedPattern
+                return MagazinePatternGroupSummary(
+                    id: pattern.id,
+                    displayName: pattern.displayName,
+                    caliberText: pattern.compatibility.supportedCaliberNames.joined(separator: ", "),
+                    linkedFirearmNames: linkedFirearmNames(for: magazines, firearms: firearms),
+                    magazines: magazines
+                )
+            }
+            .sorted(by: areInDisplayOrder)
+    }
+
+    func linkedFirearmNames(for magazines: [Magazine], firearms: [Firearm]) -> [String] {
+        var uniqueNames: Set<String> = []
+
+        for magazine in magazines {
+            for firearm in magazine.linkedFirearms(from: firearms) {
+                uniqueNames.insert(firearm.displayName)
+            }
+        }
+
+        return uniqueNames.sorted {
+            $0.localizedCaseInsensitiveCompare($1) == .orderedAscending
+        }
+    }
+
+    func areInDisplayOrder(_ lhs: MagazinePatternGroupSummary, _ rhs: MagazinePatternGroupSummary) -> Bool {
+        switch (lhs.primaryCaliberName, rhs.primaryCaliberName) {
+        case let (lhs?, rhs?):
+            if lhs.caseInsensitiveCompare(rhs) != .orderedSame {
+                return CaliberSort.areInAscendingOrder(lhs, rhs)
+            }
+        case (.some, .none):
+            return true
+        case (.none, .some):
+            return false
+        case (.none, .none):
+            break
+        }
+
+        let nameComparison = lhs.displayName.localizedCaseInsensitiveCompare(rhs.displayName)
+        if nameComparison != .orderedSame {
+            return nameComparison == .orderedAscending
+        }
+
+        return lhs.id.localizedCaseInsensitiveCompare(rhs.id) == .orderedAscending
+    }
+}

--- a/ArmoryInventory/Firearms/AddFirearmView.swift
+++ b/ArmoryInventory/Firearms/AddFirearmView.swift
@@ -828,12 +828,11 @@ struct AddFirearmView: View {
     }
 
     private func patternDetailText(for pattern: FirearmMagazinePatternReference) -> String {
-        let magazines = resolvedMagazines.filter { $0.resolvedPattern.id == pattern.id }
-        guard !magazines.isEmpty else {
-            return ""
-        }
-
-        return "\(currentFirearmForSummary.linkedMagazineCountText(using: magazines)) • \(currentFirearmForSummary.linkedMagazineCapacityText(using: magazines))"
+        viewModel.magazinePatternDetailText(
+            for: pattern,
+            magazines: resolvedMagazines,
+            summaryFirearm: currentFirearmForSummary
+        )
     }
 
     private func saveFirearm() {

--- a/ArmoryInventory/Firearms/AddFirearmViewModel.swift
+++ b/ArmoryInventory/Firearms/AddFirearmViewModel.swift
@@ -227,6 +227,19 @@ final class AddFirearmViewModel {
         }
     }
 
+    func magazinePatternDetailText(
+        for pattern: FirearmMagazinePatternReference,
+        magazines: [Magazine],
+        summaryFirearm: Firearm
+    ) -> String {
+        let matchingMagazines = magazines.filter { $0.resolvedPattern.id == pattern.id }
+        guard !matchingMagazines.isEmpty else {
+            return ""
+        }
+
+        return "\(summaryFirearm.linkedMagazineCountText(using: matchingMagazines)) • \(summaryFirearm.linkedMagazineCapacityText(using: matchingMagazines))"
+    }
+
     func selectedMagazineValidationResult(
         magazines: [Magazine],
         selectedPatterns: [FirearmMagazinePatternReference],

--- a/ArmoryInventoryTests/AccessoriesTests/MagazinePatternMigrationTests.swift
+++ b/ArmoryInventoryTests/AccessoriesTests/MagazinePatternMigrationTests.swift
@@ -164,4 +164,45 @@ final class MagazinePatternMigrationTests: XCTestCase {
         XCTAssertEqual(firstPattern.id, secondPattern.id)
         XCTAssertTrue(firstPattern.id.hasPrefix("custom:"))
     }
+
+    func testResolvedPatternPreservesStoredCustomSupportedCalibers() {
+        let magazine = Magazine(
+            brand: "Custom",
+            modelName: "Multi-Cal",
+            patternID: "custom:12345678-1234-1234-1234-1234567890ab",
+            patternKind: .custom,
+            patternDisplayName: "Competition PCC",
+            patternSupportedCaliberNames: ["9mm", ".357 SIG"],
+            count: 2,
+            capacity: 35,
+            purchasePriceCents: 4_000
+        )
+
+        let pattern = MagazinePatternMigration.resolvedPattern(for: magazine)
+
+        XCTAssertEqual(pattern.compatibility.supportedCaliberNames, ["9mm", ".357 SIG"])
+    }
+
+    @MainActor
+    func testBackfillRepairsCustomPatternMissingDisplayNameWithoutDiscardingStoredCalibers() throws {
+        let container = try makeInMemoryContainer()
+        let context = container.mainContext
+        let magazine = Magazine(
+            brand: "Custom",
+            modelName: "Multi-Cal",
+            patternID: "custom:12345678-1234-1234-1234-1234567890ab",
+            patternKind: .custom,
+            patternDisplayName: nil,
+            patternSupportedCaliberNames: ["9mm", ".357 SIG"],
+            count: 2,
+            capacity: 35,
+            purchasePriceCents: 4_000
+        )
+        context.insert(magazine)
+
+        XCTAssertTrue(MagazinePatternMigration.backfillMissingPatterns(in: context))
+        XCTAssertEqual(magazine.storedPatternKind, .custom)
+        XCTAssertEqual(magazine.patternDisplayName, "Custom Multi-Cal")
+        XCTAssertEqual(magazine.storedPatternSupportedCaliberNames, ["9mm", ".357 SIG"])
+    }
 }

--- a/ArmoryInventoryTests/AccessoriesTests/MagazinesViewModelTests.swift
+++ b/ArmoryInventoryTests/AccessoriesTests/MagazinesViewModelTests.swift
@@ -1,0 +1,128 @@
+//
+//  MagazinesViewModelTests.swift
+//  Armory InventoryTests
+//
+//  Created by Codex on 4/24/26.
+//
+
+import XCTest
+@testable import ArmoryInventory
+
+final class MagazinesViewModelTests: XCTestCase {
+    func testGroupedMagazinesUsesCaliberSortAndBuildsGroupSummaries() {
+        let viewModel = MagazinesViewModel()
+
+        let rifleMagazine = Magazine(
+            brand: "Magpul",
+            modelName: "PMAG",
+            patternID: "catalog:ar15-stanag-223-556-300blk",
+            patternKind: .catalog,
+            count: 2,
+            capacity: 30,
+            purchasePriceCents: 1500
+        )
+        let pistolMagazine = Magazine(
+            brand: "Glock",
+            modelName: "OEM 15",
+            patternID: "catalog:glock-double-stack-9mm-compact",
+            patternKind: .catalog,
+            count: 3,
+            capacity: 15,
+            purchasePriceCents: 1200
+        )
+        let customMagazine = Magazine(
+            brand: "Mystery",
+            modelName: "Tube",
+            patternID: "custom:12345678-1234-1234-1234-1234567890ab",
+            patternKind: .custom,
+            patternDisplayName: "Mystery Tube",
+            patternSupportedCaliberNames: [],
+            count: 1,
+            capacity: 20,
+            purchasePriceCents: 500
+        )
+
+        let arFirearm = Firearm(
+            brand: "Daniel Defense",
+            modelName: "DDM4",
+            purchasePriceCents: 180000,
+            type: .rifle,
+            action: .semiAuto,
+            supportedMagazinePatterns: [FirearmMagazinePatternReference(pattern: rifleMagazine.resolvedPattern)]
+        )
+        let glockFirearm = Firearm(
+            brand: "Glock",
+            modelName: "19",
+            purchasePriceCents: 50000,
+            type: .pistol,
+            action: .semiAuto,
+            supportedMagazinePatterns: [FirearmMagazinePatternReference(pattern: pistolMagazine.resolvedPattern)]
+        )
+        let secondGlockFirearm = Firearm(
+            brand: "Glock",
+            modelName: "26",
+            purchasePriceCents: 45000,
+            type: .pistol,
+            action: .semiAuto,
+            supportedMagazinePatterns: [FirearmMagazinePatternReference(pattern: pistolMagazine.resolvedPattern)]
+        )
+
+        let groups = viewModel.groupedMagazines(
+            [customMagazine, pistolMagazine, rifleMagazine],
+            firearms: [secondGlockFirearm, arFirearm, glockFirearm]
+        )
+
+        XCTAssertEqual(groups.map(\.id), [
+            "catalog:ar15-stanag-223-556-300blk",
+            "catalog:glock-double-stack-9mm-compact",
+            "custom:12345678-1234-1234-1234-1234567890ab",
+        ])
+        XCTAssertEqual(groups[0].summaryText, ".223 Rem, 5.56 NATO, .300 Blackout • 2 magazines")
+        XCTAssertEqual(groups[1].summaryText, "9mm • 3 magazines")
+        XCTAssertEqual(groups[1].linkedFirearmsText, "Used by 2 firearms: Glock 19, Glock 26")
+        XCTAssertEqual(groups[2].linkedFirearmsText, "Used by 0 firearm.")
+    }
+
+    func testLinkedFirearmNamesDeduplicatesAndSortsDisplayNames() {
+        let viewModel = MagazinesViewModel()
+        let magazine = Magazine(
+            brand: "Magpul",
+            modelName: "PMAG",
+            patternID: "catalog:ar15-stanag-223-556-300blk",
+            patternKind: .catalog,
+            count: 1,
+            capacity: 30,
+            purchasePriceCents: 1500
+        )
+
+        let zulu = Firearm(
+            brand: "Zulu",
+            modelName: "Host",
+            purchasePriceCents: 100000,
+            type: .rifle,
+            action: .semiAuto,
+            supportedMagazinePatterns: [FirearmMagazinePatternReference(pattern: magazine.resolvedPattern)]
+        )
+        let alpha = Firearm(
+            brand: "Alpha",
+            modelName: "Host",
+            purchasePriceCents: 100000,
+            type: .rifle,
+            action: .semiAuto,
+            supportedMagazinePatterns: [FirearmMagazinePatternReference(pattern: magazine.resolvedPattern)]
+        )
+        let duplicateAlpha = Firearm(
+            brand: "Alpha",
+            modelName: "Host",
+            purchasePriceCents: 100000,
+            type: .rifle,
+            action: .semiAuto,
+            supportedMagazinePatterns: [FirearmMagazinePatternReference(pattern: magazine.resolvedPattern)]
+        )
+
+        XCTAssertEqual(
+            viewModel.linkedFirearmNames(for: [magazine], firearms: [zulu, alpha, duplicateAlpha]),
+            ["Alpha Host", "Zulu Host"]
+        )
+    }
+}

--- a/ArmoryInventoryTests/FirearmsTests/AddFirearmViewModelTests.swift
+++ b/ArmoryInventoryTests/FirearmsTests/AddFirearmViewModelTests.swift
@@ -114,6 +114,57 @@ final class AddFirearmViewModelTests: XCTestCase {
         )
     }
 
+    func testMagazinePatternDetailTextReturnsSummaryForMatchingMagazines() {
+        let viewModel = AddFirearmViewModel()
+        let pattern = FirearmMagazinePatternReference(
+            id: "catalog:ar15-stanag-223-556-300blk",
+            kind: .catalog,
+            displayName: nil
+        )
+        let matchingMagazine = Magazine(
+            brand: "Magpul",
+            modelName: "PMAG",
+            patternID: pattern.id,
+            patternKind: .catalog,
+            count: 2,
+            capacity: 30,
+            purchasePriceCents: 1500
+        )
+        let nonMatchingMagazine = Magazine(
+            brand: "Glock",
+            modelName: "OEM",
+            patternID: "catalog:glock-double-stack-9mm-compact",
+            patternKind: .catalog,
+            count: 1,
+            capacity: 15,
+            purchasePriceCents: 1200
+        )
+        let summaryFirearm = Firearm(
+            brand: "Daniel Defense",
+            modelName: "DDM4",
+            purchasePriceCents: 180000,
+            type: .rifle,
+            action: .semiAuto
+        )
+
+        XCTAssertEqual(
+            viewModel.magazinePatternDetailText(
+                for: pattern,
+                magazines: [matchingMagazine, nonMatchingMagazine],
+                summaryFirearm: summaryFirearm
+            ),
+            "2 magazines • 60 Rounds"
+        )
+        XCTAssertEqual(
+            viewModel.magazinePatternDetailText(
+                for: pattern,
+                magazines: [nonMatchingMagazine],
+                summaryFirearm: summaryFirearm
+            ),
+            ""
+        )
+    }
+
     @MainActor
     func testRelationshipSelectionAndAvailabilityHelpersRespectAssignments() throws {
         let container = try makeInMemoryContainer()


### PR DESCRIPTION
## Summary
- extract magazine list grouping and summary formatting from `MagazinesView` into a testable `MagazinesViewModel`
- move firearm pattern detail summary formatting behind `AddFirearmViewModel`
- add focused tests for the extracted view-model logic and custom-pattern migration edge cases

## Testing
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test -scheme 'Armory Inventory' -destination 'id=00006000-001851500A62801E' -only-testing:ArmoryInventoryTests/MagazinesViewModelTests -only-testing:ArmoryInventoryTests/AddFirearmViewModelTests -only-testing:ArmoryInventoryTests/MagazinePatternMigrationTests`

Closes #23