### PR TITLE
[codex] Introduce general kits

### DIFF
--- a/ArmoryInventory/Accessories/AccessoriesView.swift
+++ b/ArmoryInventory/Accessories/AccessoriesView.swift
@@ -14,13 +14,13 @@ struct AccessoriesView: View {
     @Query private var attachments: [Attachment]
     @Query private var parts: [Part]
     @AppStorage(InventorySettingsKeys.showTotalValue) private var showTotalValue = true
-    private let topLevelCategories = AccessoryCategory.topLevelCategories
+    private let viewModel = AccessoriesViewModel()
 
     var body: some View {
         NavigationStack {
             List {
                 Section {
-                    ForEach(topLevelCategories) { category in
+                    ForEach(viewModel.topLevelCategories) { category in
                         NavigationLink {
                             destination(for: category)
                         } label: {
@@ -54,19 +54,15 @@ struct AccessoriesView: View {
             AttachmentsView()
         case "parts":
             PartsView()
+        case "kits":
+            KitsView()
         default:
             AccessoryCategoryDetailView(category: category)
         }
     }
 
     private var totalValueText: String {
-        let totalCents =
-            optics.reduce(0) { $0 + max(0, $1.purchasePriceCents) } +
-            magazines.reduce(0) { $0 + max(0, $1.purchasePriceCents) } +
-            attachments.reduce(0) { $0 + max(0, $1.purchasePriceCents) } +
-            parts.reduce(0) { $0 + max(0, $1.purchasePriceCents) }
-        let amount = Decimal(totalCents) / 100
-        return amount.formatted(.currency(code: Locale.current.currency?.identifier ?? "USD"))
+        viewModel.totalValueText(optics: optics, magazines: magazines, attachments: attachments, parts: parts)
     }
 }
 
@@ -116,74 +112,6 @@ private struct AccessoryCategoryDetailView: View {
         .navigationTitle(category.name)
         .navigationBarTitleDisplayMode(.inline)
     }
-}
-
-private struct AccessoryCategory: Identifiable {
-    let id: String
-    let name: String
-    let systemImage: String
-    let shortDescription: String
-    let detailDescription: String
-    let examples: [String]
-
-    static let topLevelCategories: [AccessoryCategory] = [
-        AccessoryCategory(
-            id: "optics",
-            name: String(localized: "Optics"),
-            systemImage: "scope",
-            shortDescription: String(localized: "Scopes, red dots, and magnifiers"),
-            detailDescription: String(localized: "Optics include sighting systems used to improve target acquisition and precision across different firearm setups."),
-            examples: [
-                String(localized: "LPVO"),
-                String(localized: "Red Dot"),
-                String(localized: "Holographic Sight"),
-                String(localized: "Magnifier"),
-            ]
-        ),
-        AccessoryCategory(
-            id: "magazines",
-            name: String(localized: "Magazines"),
-            systemImage: "rectangle.stack.fill.badge.plus",
-            shortDescription: String(localized: "Spare mags and loadout essentials"),
-            detailDescription: String(localized: "Magazine tracking helps you manage capacity, platform compatibility, and quantity on hand."),
-            examples: [
-                String(localized: "Pistol Magazine"),
-                String(localized: "AR-15 Magazine"),
-                String(localized: "AK Magazine"),
-                String(localized: "Drum Magazine"),
-            ]
-        ),
-        AccessoryCategory(
-            id: "attachments",
-            name: String(localized: "Attachments"),
-            systemImage: "hand.raised.fill",
-            shortDescription: String(localized: "Mounted accessories grouped by attachment type"),
-            detailDescription: String(localized: "Attachments include mounted accessories such as stocks, grips, lasers, lights, hand stops, and similar hardware. They can be categorized later using an Attachment Type field instead of separate screens."),
-            examples: [
-                String(localized: "Stock"),
-                String(localized: "Grip"),
-                String(localized: "Laser"),
-                String(localized: "Light"),
-                String(localized: "Hand Stop"),
-                String(localized: "Bipod"),
-            ]
-        ),
-        AccessoryCategory(
-            id: "parts",
-            name: String(localized: "Parts"),
-            systemImage: "gearshape.2.fill",
-            shortDescription: String(localized: "Core components and replacement assemblies"),
-            detailDescription: String(localized: "Parts cover major firearm components you install, swap, or keep on hand, such as barrels, triggers, receivers, recoil systems, and other internal assemblies."),
-            examples: [
-                String(localized: "Barrel"),
-                String(localized: "Trigger"),
-                String(localized: "Bolt Carrier Group"),
-                String(localized: "Charging Handle"),
-                String(localized: "Slide"),
-                String(localized: "Recoil System"),
-            ]
-        ),
-    ]
 }
 
 #Preview {

--- a/ArmoryInventory/Accessories/AccessoriesViewModel.swift
+++ b/ArmoryInventory/Accessories/AccessoriesViewModel.swift
@@ -1,0 +1,101 @@
+//
+//  AccessoriesViewModel.swift
+//  Armory Inventory
+//
+//  Created by Codex on 5/20/26.
+//
+
+import Foundation
+
+struct AccessoryCategory: Identifiable {
+    let id: String
+    let name: String
+    let systemImage: String
+    let shortDescription: String
+    let detailDescription: String
+    let examples: [String]
+}
+
+final class AccessoriesViewModel {
+    let topLevelCategories: [AccessoryCategory] = [
+        AccessoryCategory(
+            id: "optics",
+            name: String(localized: "Optics"),
+            systemImage: "scope",
+            shortDescription: String(localized: "Scopes, red dots, and magnifiers"),
+            detailDescription: String(localized: "Optics include sighting systems used to improve target acquisition and precision across different firearm setups."),
+            examples: [
+                String(localized: "LPVO"),
+                String(localized: "Red Dot"),
+                String(localized: "Holographic Sight"),
+                String(localized: "Magnifier"),
+            ]
+        ),
+        AccessoryCategory(
+            id: "magazines",
+            name: String(localized: "Magazines"),
+            systemImage: "rectangle.stack.fill.badge.plus",
+            shortDescription: String(localized: "Spare mags and loadout essentials"),
+            detailDescription: String(localized: "Magazine tracking helps you manage capacity, platform compatibility, and quantity on hand."),
+            examples: [
+                String(localized: "Pistol Magazine"),
+                String(localized: "AR-15 Magazine"),
+                String(localized: "AK Magazine"),
+                String(localized: "Drum Magazine"),
+            ]
+        ),
+        AccessoryCategory(
+            id: "attachments",
+            name: String(localized: "Attachments"),
+            systemImage: "hand.raised.fill",
+            shortDescription: String(localized: "Mounted accessories grouped by attachment type"),
+            detailDescription: String(localized: "Attachments include mounted accessories such as stocks, grips, lasers, lights, hand stops, and similar hardware. They can be categorized later using an Attachment Type field instead of separate screens."),
+            examples: [
+                String(localized: "Stock"),
+                String(localized: "Grip"),
+                String(localized: "Laser"),
+                String(localized: "Light"),
+                String(localized: "Hand Stop"),
+                String(localized: "Bipod"),
+            ]
+        ),
+        AccessoryCategory(
+            id: "parts",
+            name: String(localized: "Parts"),
+            systemImage: "gearshape.2.fill",
+            shortDescription: String(localized: "Core components and replacement assemblies"),
+            detailDescription: String(localized: "Parts cover major firearm components you install, swap, or keep on hand, such as barrels, triggers, receivers, recoil systems, and other internal assemblies."),
+            examples: [
+                String(localized: "Barrel"),
+                String(localized: "Trigger"),
+                String(localized: "Bolt Carrier Group"),
+                String(localized: "Charging Handle"),
+                String(localized: "Slide"),
+                String(localized: "Recoil System"),
+            ]
+        ),
+        AccessoryCategory(
+            id: "kits",
+            name: String(localized: "Kits"),
+            systemImage: "shippingbox.fill",
+            shortDescription: String(localized: "Grouped parts, optics, and attachments"),
+            detailDescription: String(localized: "Kits group unlinked parts, optics, and attachments so complete assemblies can be linked to firearms together while preserving direct item tracking."),
+            examples: [
+                String(localized: "Upper Receiver Kit"),
+                String(localized: "Lower Receiver Kit"),
+                String(localized: "Optics Kit"),
+                String(localized: "Custom Kit")
+            ]
+        ),
+    ]
+
+    func totalValueText(optics: [Optic], magazines: [Magazine], attachments: [Attachment], parts: [Part]) -> String {
+        let totalCents =
+            optics.reduce(0) { $0 + max(0, $1.purchasePriceCents) } +
+            magazines.reduce(0) { $0 + max(0, $1.purchasePriceCents) } +
+            attachments.reduce(0) { $0 + max(0, $1.purchasePriceCents) } +
+            parts.reduce(0) { $0 + max(0, $1.purchasePriceCents) }
+        let amount = Decimal(totalCents) / 100
+        return amount.formatted(.currency(code: Locale.current.currency?.identifier ?? "USD"))
+    }
+}

--- a/ArmoryInventory/Accessories/AccessoryInventoryListViewModel.swift
+++ b/ArmoryInventory/Accessories/AccessoryInventoryListViewModel.swift
@@ -1,0 +1,199 @@
+//
+//  AccessoryInventoryListViewModel.swift
+//  Armory Inventory
+//
+//  Created by Codex on 5/20/26.
+//
+
+import Foundation
+import SwiftData
+
+final class AccessoryInventoryListViewModel {
+    private let eligibilityService: KitEligibilityServicing
+
+    init(eligibilityService: KitEligibilityServicing = KitEligibilityService()) {
+        self.eligibilityService = eligibilityService
+    }
+
+    func groupedParts(_ parts: [Part], sortOrderRaw: String, sortDirectionRaw: String) -> [String: [Part]] {
+        Dictionary(grouping: parts, by: \.type).mapValues {
+            AccessoryItemSort.sorted(
+                $0,
+                by: selectedItemSortOrder(from: sortOrderRaw),
+                direction: selectedItemSortDirection(sortOrderRaw: sortOrderRaw, sortDirectionRaw: sortDirectionRaw)
+            )
+        }
+    }
+
+    func groupedPartTypes(from groupedParts: [String: [Part]]) -> [String] {
+        PartTypeSort.displayOrder(for: Array(groupedParts.keys))
+    }
+
+    func partTypeDisplayName(for typeID: String) -> String {
+        PartType(rawValue: typeID)?.displayName ?? typeID
+    }
+
+    func groupedOptics(_ optics: [Optic], sortOrderRaw: String, sortDirectionRaw: String) -> [String: [Optic]] {
+        Dictionary(grouping: optics, by: \.type).mapValues {
+            AccessoryItemSort.sorted(
+                $0,
+                by: selectedItemSortOrder(from: sortOrderRaw),
+                direction: selectedItemSortDirection(sortOrderRaw: sortOrderRaw, sortDirectionRaw: sortDirectionRaw)
+            )
+        }
+    }
+
+    func groupedOpticTypes(from groupedOptics: [String: [Optic]]) -> [String] {
+        OpticTypeSort.displayOrder(for: Array(groupedOptics.keys))
+    }
+
+    func opticTypeDisplayName(for typeID: String) -> String {
+        OpticType(rawValue: typeID)?.displayName ?? typeID
+    }
+
+    func groupedAttachments(_ attachments: [Attachment], sortOrderRaw: String, sortDirectionRaw: String) -> [String: [Attachment]] {
+        Dictionary(grouping: attachments, by: \.type).mapValues {
+            AccessoryItemSort.sorted(
+                $0,
+                by: selectedItemSortOrder(from: sortOrderRaw),
+                direction: selectedItemSortDirection(sortOrderRaw: sortOrderRaw, sortDirectionRaw: sortDirectionRaw)
+            )
+        }
+    }
+
+    func groupedAttachmentTypes(from groupedAttachments: [String: [Attachment]]) -> [String] {
+        AttachmentTypeSort.displayOrder(for: Array(groupedAttachments.keys))
+    }
+
+    func attachmentTypeDisplayName(for typeID: String) -> String {
+        AttachmentType(rawValue: typeID)?.displayName ?? typeID
+    }
+
+    func totalValueText<T: AccessoryInventoryValuable>(for items: [T]) -> String {
+        let totalCents = items.reduce(0) { $0 + max(0, $1.purchasePriceCents) }
+        let amount = Decimal(totalCents) / 100
+        return amount.formatted(.currency(code: Locale.current.currency?.identifier ?? "USD"))
+    }
+
+    func deleteParts(
+        at offsets: IndexSet,
+        in type: String,
+        groupedParts: [String: [Part]],
+        allParts: [Part],
+        kits: [Kit],
+        context: ModelContext
+    ) -> KitValidationResult {
+        guard let sectionParts = groupedParts[type] else {
+            return .valid
+        }
+
+        var blockedMessage: String?
+        for index in offsets {
+            let part = sectionParts[index]
+            if eligibilityService.isReserved(part, by: kits, excluding: nil) {
+                blockedMessage = deletionBlockedMessage(itemName: part.displayName)
+            } else {
+                context.delete(part)
+            }
+        }
+        resequence(allParts)
+        return save(context: context, blockedMessage: blockedMessage)
+    }
+
+    func deleteOptics(
+        at offsets: IndexSet,
+        in type: String,
+        groupedOptics: [String: [Optic]],
+        allOptics: [Optic],
+        kits: [Kit],
+        context: ModelContext
+    ) -> KitValidationResult {
+        guard let sectionOptics = groupedOptics[type] else {
+            return .valid
+        }
+
+        var blockedMessage: String?
+        for index in offsets {
+            let optic = sectionOptics[index]
+            if eligibilityService.isReserved(optic, by: kits, excluding: nil) {
+                blockedMessage = deletionBlockedMessage(itemName: optic.displayName)
+            } else {
+                context.delete(optic)
+            }
+        }
+        resequence(allOptics)
+        return save(context: context, blockedMessage: blockedMessage)
+    }
+
+    func deleteAttachments(
+        at offsets: IndexSet,
+        in type: String,
+        groupedAttachments: [String: [Attachment]],
+        allAttachments: [Attachment],
+        kits: [Kit],
+        context: ModelContext
+    ) -> KitValidationResult {
+        guard let sectionAttachments = groupedAttachments[type] else {
+            return .valid
+        }
+
+        var blockedMessage: String?
+        for index in offsets {
+            let attachment = sectionAttachments[index]
+            if eligibilityService.isReserved(attachment, by: kits, excluding: nil) {
+                blockedMessage = deletionBlockedMessage(itemName: attachment.displayName)
+            } else {
+                context.delete(attachment)
+            }
+        }
+        resequence(allAttachments)
+        return save(context: context, blockedMessage: blockedMessage)
+    }
+
+    private func selectedItemSortOrder(from rawValue: String) -> AccessoryItemSortOrder {
+        AccessoryItemSortOrder(rawValue: rawValue) ?? .manual
+    }
+
+    private func selectedItemSortDirection(sortOrderRaw: String, sortDirectionRaw: String) -> AccessoryItemSortDirection {
+        let sortOrder = selectedItemSortOrder(from: sortOrderRaw)
+        return AccessoryItemSortDirection(rawValue: sortDirectionRaw) ?? AccessoryItemSort.preferredDirection(for: sortOrder)
+    }
+
+    private func resequence<T: AccessoryInventorySortable>(_ items: [T]) {
+        for (index, item) in items.enumerated() {
+            item.sortOrder = index
+        }
+    }
+
+    private func save(context: ModelContext, blockedMessage: String?) -> KitValidationResult {
+        do {
+            try context.save()
+            UserDefaults.standard.set(Date(), forKey: "LastModelSaveDate")
+            if let blockedMessage {
+                return .invalid(blockedMessage)
+            }
+            return .valid
+        } catch {
+            return .invalid(error.localizedDescription)
+        }
+    }
+
+    private func deletionBlockedMessage(itemName: String) -> String {
+        String.localizedStringWithFormat(
+            String(localized: "Disassemble or edit the built/linked kit using %@ before deleting it."),
+            itemName
+        )
+    }
+}
+
+protocol AccessoryInventoryValuable {
+    var purchasePriceCents: Int { get }
+}
+
+protocol AccessoryInventorySortable: AnyObject {
+    var sortOrder: Int { get set }
+}
+
+extension Part: AccessoryInventoryValuable, AccessoryInventorySortable {}
+extension Optic: AccessoryInventoryValuable, AccessoryInventorySortable {}
+extension Attachment: AccessoryInventoryValuable, AccessoryInventorySortable {}

--- a/ArmoryInventory/Accessories/Attachments/AttachmentsView.swift
+++ b/ArmoryInventory/Accessories/Attachments/AttachmentsView.swift
@@ -18,7 +18,10 @@ struct AttachmentsView: View {
     @State private var showingAddAttachment = false
     @State private var selectedAttachment: Attachment?
     @State private var attachments: [Attachment] = []
+    @State private var kits: [Kit] = []
+    @State private var alertMessage: String?
 
+    private let viewModel = AccessoryInventoryListViewModel()
     private let inventoryListService: InventoryListServicing = AppServices.shared.resolve(InventoryListServicing.self)
 
     var body: some View {
@@ -105,66 +108,61 @@ struct AttachmentsView: View {
             AddAttachmentView(attachment: attachment, viewModel: AddAttachmentViewModel())
                 .presentationDetents([.large])
         }
+        .alert("Attachment Cannot Be Deleted", isPresented: alertBinding) {
+            Button("OK", role: .cancel) {
+                alertMessage = nil
+            }
+        } message: {
+            Text(alertMessage ?? "")
+        }
     }
 
     private var groupedAttachments: [String: [Attachment]] {
-        Dictionary(grouping: attachments, by: \.type).mapValues {
-            AccessoryItemSort.sorted($0, by: selectedItemSortOrder, direction: selectedItemSortDirection)
-        }
+        viewModel.groupedAttachments(attachments, sortOrderRaw: itemSortOrder, sortDirectionRaw: itemSortDirectionRaw)
     }
 
     private var groupedAttachmentTypes: [String] {
-        AttachmentTypeSort.displayOrder(for: Array(groupedAttachments.keys))
+        viewModel.groupedAttachmentTypes(from: groupedAttachments)
     }
 
     private func deleteAttachments(at offsets: IndexSet, in type: String) {
-        guard let sectionAttachments = groupedAttachments[type] else {
-            return
-        }
-
-        for index in offsets {
-            context.delete(sectionAttachments[index])
-        }
-        resequenceAttachments()
-
-        do {
-            try context.save()
-            UserDefaults.standard.set(Date(), forKey: "LastModelSaveDate")
+        let result = viewModel.deleteAttachments(
+            at: offsets,
+            in: type,
+            groupedAttachments: groupedAttachments,
+            allAttachments: attachments,
+            kits: kits,
+            context: context
+        )
+        if result.isValid {
             reloadAttachments()
-        } catch {
-            print("Delete error: \(error)")
+        } else {
+            alertMessage = result.message
+            reloadAttachments()
         }
     }
 
     private func reloadAttachments() {
         do {
             attachments = try inventoryListService.fetchAttachments(in: context)
+            kits = try inventoryListService.fetchKits(in: context)
         } catch {
             print("Attachments fetch error: \(error)")
         }
     }
 
-    private func resequenceAttachments() {
-        for (index, attachment) in attachments.enumerated() {
-            attachment.sortOrder = index
-        }
-    }
-
     private var totalValueText: String {
-        let totalCents = attachments.reduce(0) { $0 + max(0, $1.purchasePriceCents) }
-        let amount = Decimal(totalCents) / 100
-        return amount.formatted(.currency(code: Locale.current.currency?.identifier ?? "USD"))
+        viewModel.totalValueText(for: attachments)
     }
 
     private func attachmentTypeDisplayName(for typeID: String) -> String {
-        AttachmentType(rawValue: typeID)?.displayName ?? typeID
+        viewModel.attachmentTypeDisplayName(for: typeID)
     }
 
-    private var selectedItemSortOrder: AccessoryItemSortOrder {
-        AccessoryItemSortOrder(rawValue: itemSortOrder) ?? .manual
-    }
-
-    private var selectedItemSortDirection: AccessoryItemSortDirection {
-        AccessoryItemSortDirection(rawValue: itemSortDirectionRaw) ?? AccessoryItemSort.preferredDirection(for: selectedItemSortOrder)
+    private var alertBinding: Binding<Bool> {
+        Binding(
+            get: { alertMessage != nil },
+            set: { if !$0 { alertMessage = nil } }
+        )
     }
 }

--- a/ArmoryInventory/Accessories/Kits/AddKitView.swift
+++ b/ArmoryInventory/Accessories/Kits/AddKitView.swift
@@ -123,6 +123,9 @@ struct AddKitView: View {
                         Button("Disassemble Kit", role: .destructive) {
                             disassembleKit()
                         }
+                        Button("Discard Kit", role: .destructive) {
+                            discardKit()
+                        }
                     }
                 }
             }
@@ -242,6 +245,13 @@ struct AddKitView: View {
             return
         }
         handle(viewModel.disassembleKit(kit, in: context))
+    }
+
+    private func discardKit() {
+        guard let kit else {
+            return
+        }
+        handle(viewModel.discardKit(kit, in: context))
     }
 
     private func handle(_ result: KitValidationResult) {

--- a/ArmoryInventory/Accessories/Kits/AddKitView.swift
+++ b/ArmoryInventory/Accessories/Kits/AddKitView.swift
@@ -1,0 +1,361 @@
+//
+//  AddKitView.swift
+//  Armory Inventory
+//
+//  Created by Codex on 5/14/26.
+//
+
+import SwiftUI
+import SwiftData
+
+struct AddKitView: View {
+    @Environment(\.dismiss) private var dismiss
+    @Environment(\.modelContext) private var context
+    @AppStorage(InventorySettingsKeys.showValueInDetails) private var showValueInDetails = true
+
+    let kit: Kit?
+    let viewModel: AddKitViewModel
+    private let inventoryListService: InventoryListServicing
+
+    @State private var name = ""
+    @State private var kind: KitKind = .upperReceiver
+    @State private var notes = ""
+    @State private var componentSelections: [KitComponentSelection] = []
+    @State private var parts: [Part] = []
+    @State private var optics: [Optic] = []
+    @State private var attachments: [Attachment] = []
+    @State private var kits: [Kit] = []
+    @State private var showingPartsPicker = false
+    @State private var showingOpticsPicker = false
+    @State private var showingAttachmentsPicker = false
+    @State private var alertMessage: String?
+
+    init(
+        kit: Kit? = nil,
+        viewModel: AddKitViewModel,
+        inventoryListService: InventoryListServicing = AppServices.shared.resolve(InventoryListServicing.self)
+    ) {
+        self.kit = kit
+        self.viewModel = viewModel
+        self.inventoryListService = inventoryListService
+        _name = State(initialValue: viewModel.initialName(for: kit))
+        _kind = State(initialValue: viewModel.initialKind(for: kit))
+        _notes = State(initialValue: viewModel.initialNotes(for: kit))
+        _componentSelections = State(initialValue: viewModel.initialSelections(for: kit))
+    }
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section("Kit") {
+                    LabeledContent("Name") {
+                        TextField(kind.displayName, text: $name)
+                            .textInputAutocapitalization(.words)
+                            .multilineTextAlignment(.trailing)
+                    }
+
+                    Picker("Kind", selection: $kind) {
+                        ForEach(KitKind.allCases) { kitKind in
+                            Text(kitKind.displayName).tag(kitKind)
+                        }
+                    }
+
+                    if let kit {
+                        if let firearm = kit.firearm {
+                            LabeledContent("Linked Firearm", value: firearm.displayName)
+                        }
+                    }
+                }
+
+                Section("Parts") {
+                    Button {
+                        showingPartsPicker = true
+                    } label: {
+                        Label("Manage Parts", systemImage: "gearshape.2.fill")
+                    }
+
+                    selectedComponentRows(for: .part)
+                }
+
+                Section("Optics") {
+                    Button {
+                        showingOpticsPicker = true
+                    } label: {
+                        Label("Manage Optics", systemImage: "scope")
+                    }
+
+                    selectedComponentRows(for: .optic)
+                }
+
+                Section("Attachments") {
+                    Button {
+                        showingAttachmentsPicker = true
+                    } label: {
+                        Label("Manage Attachments", systemImage: "paperclip")
+                    }
+
+                    selectedComponentRows(for: .attachment)
+                }
+
+                Section("Notes") {
+                    TextField("Notes (optional)", text: $notes, axis: .vertical)
+                        .lineLimit(3...6)
+                }
+
+                if showValueInDetails {
+                    Section("Total Value") {
+                        LabeledContent(
+                            "Components",
+                            value: KitValueService.currencyText(
+                                for: viewModel.componentValueCents(
+                                    from: componentSelections,
+                                    parts: parts,
+                                    optics: optics,
+                                    attachments: attachments
+                                )
+                            )
+                        )
+                    }
+                }
+
+                if viewModel.shouldShowDisassembleButton(for: kit) {
+                    Section {
+                        Button("Disassemble Kit", role: .destructive) {
+                            disassembleKit()
+                        }
+                    }
+                }
+            }
+            .navigationTitle(viewModel.navigationTitle(for: kit))
+            .navigationBarTitleDisplayMode(.inline)
+            .task {
+                reloadData()
+            }
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") {
+                        dismiss()
+                    }
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button(viewModel.primarySaveTitle(for: kit)) {
+                        saveCurrentStatus()
+                    }
+                }
+            }
+            .sheet(isPresented: $showingPartsPicker) {
+                componentPicker(
+                    title: viewModel.pickerTitle(for: .part),
+                    emptyTitle: viewModel.pickerEmptyTitle(for: .part),
+                    systemImage: "gearshape.2.fill",
+                    items: viewModel.partPickerItems(
+                        parts: parts,
+                        selections: componentSelections,
+                        kits: kits,
+                        editing: kit
+                    ),
+                    onToggle: togglePart
+                )
+            }
+            .sheet(isPresented: $showingOpticsPicker) {
+                componentPicker(
+                    title: viewModel.pickerTitle(for: .optic),
+                    emptyTitle: viewModel.pickerEmptyTitle(for: .optic),
+                    systemImage: "scope",
+                    items: viewModel.opticPickerItems(
+                        optics: optics,
+                        selections: componentSelections,
+                        kits: kits,
+                        editing: kit
+                    ),
+                    onToggle: toggleOptic
+                )
+            }
+            .sheet(isPresented: $showingAttachmentsPicker) {
+                componentPicker(
+                    title: viewModel.pickerTitle(for: .attachment),
+                    emptyTitle: viewModel.pickerEmptyTitle(for: .attachment),
+                    systemImage: "paperclip",
+                    items: viewModel.attachmentPickerItems(
+                        attachments: attachments,
+                        selections: componentSelections,
+                        kits: kits,
+                        editing: kit
+                    ),
+                    onToggle: toggleAttachment
+                )
+            }
+            .alert("Kit Save Failed", isPresented: alertBinding) {
+                Button("OK", role: .cancel) {
+                    alertMessage = nil
+                }
+            } message: {
+                Text(alertMessage ?? "")
+            }
+        }
+    }
+
+    private var selectedComponents: [KitComponent] {
+        viewModel.components(
+            from: componentSelections,
+            parts: parts,
+            optics: optics,
+            attachments: attachments
+        )
+    }
+
+    private var alertBinding: Binding<Bool> {
+        Binding(
+            get: { alertMessage != nil },
+            set: { if !$0 { alertMessage = nil } }
+        )
+    }
+
+    private func reloadData() {
+        do {
+            parts = try inventoryListService.fetchParts(in: context)
+            optics = try inventoryListService.fetchOptics(in: context)
+            attachments = try inventoryListService.fetchAttachments(in: context)
+            kits = try inventoryListService.fetchKits(in: context)
+        } catch {
+            alertMessage = error.localizedDescription
+        }
+    }
+
+    private func saveCurrentStatus() {
+        let status = kit?.kitStatus ?? .built
+        let result = viewModel.saveKit(
+            kit,
+            name: name,
+            kind: kind,
+            notes: viewModel.optionalValue(notes),
+            components: selectedComponents,
+            targetStatus: status,
+            kits: kits,
+            in: context
+        )
+        handle(result)
+    }
+
+    private func disassembleKit() {
+        guard let kit else {
+            return
+        }
+        handle(viewModel.disassembleKit(kit, in: context))
+    }
+
+    private func handle(_ result: KitValidationResult) {
+        if result.isValid {
+            dismiss()
+        } else {
+            alertMessage = result.message
+        }
+    }
+
+    private func togglePart(_ id: PersistentIdentifier) {
+        componentSelections = viewModel.toggledSelection(
+            componentSelections,
+            category: .part,
+            itemID: id
+        )
+    }
+
+    private func toggleOptic(_ id: PersistentIdentifier) {
+        componentSelections = viewModel.toggledSelection(
+            componentSelections,
+            category: .optic,
+            itemID: id
+        )
+    }
+
+    private func toggleAttachment(_ id: PersistentIdentifier) {
+        componentSelections = viewModel.toggledSelection(
+            componentSelections,
+            category: .attachment,
+            itemID: id
+        )
+    }
+
+    @ViewBuilder
+    private func selectedComponentRows(for category: KitComponentCategory) -> some View {
+        let rows = viewModel.selectedComponentRows(
+            for: category,
+            selections: componentSelections,
+            parts: parts,
+            optics: optics,
+            attachments: attachments
+        )
+        if rows.isEmpty {
+            Text(viewModel.emptySelectionText(for: category))
+                .font(.footnote)
+                .foregroundStyle(.secondary)
+        } else {
+            ForEach(rows) { row in
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(row.title)
+                        .font(.headline)
+                    Text(row.subtitle)
+                        .font(.footnote)
+                        .foregroundStyle(.secondary)
+                }
+                .padding(.vertical, 4)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func componentPicker(
+        title: String,
+        emptyTitle: String,
+        systemImage: String,
+        items: [AddKitComponentPickerItem],
+        onToggle: @escaping (PersistentIdentifier) -> Void
+    ) -> some View {
+        NavigationStack {
+            Group {
+                if items.isEmpty {
+                    ContentUnavailableView(
+                        emptyTitle,
+                        systemImage: systemImage,
+                        description: Text("Only unlinked items outside built or linked kits can be selected.")
+                    )
+                } else {
+                    List {
+                        ForEach(items) { item in
+                            Button {
+                                onToggle(item.id)
+                            } label: {
+                                HStack {
+                                    VStack(alignment: .leading, spacing: 2) {
+                                        Text(item.title)
+                                            .foregroundStyle(.primary)
+                                        Text(item.subtitle)
+                                            .font(.footnote)
+                                            .foregroundStyle(.secondary)
+                                    }
+                                    Spacer()
+                                    Image(systemName: item.isSelected ? "checkmark.circle.fill" : "circle")
+                                        .foregroundStyle(item.isSelected ? Color.accentColor : Color.secondary)
+                                }
+                                .contentShape(Rectangle())
+                            }
+                            .buttonStyle(.plain)
+                        }
+                    }
+                }
+            }
+            .navigationTitle(title)
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Done") {
+                        showingPartsPicker = false
+                        showingOpticsPicker = false
+                        showingAttachmentsPicker = false
+                    }
+                }
+            }
+        }
+        .presentationDetents([.medium, .large])
+    }
+}

--- a/ArmoryInventory/Accessories/Kits/AddKitViewModel.swift
+++ b/ArmoryInventory/Accessories/Kits/AddKitViewModel.swift
@@ -1,0 +1,432 @@
+//
+//  AddKitViewModel.swift
+//  Armory Inventory
+//
+//  Created by Codex on 5/14/26.
+//
+
+import Foundation
+import SwiftData
+
+struct KitComponentSelection: Identifiable, Hashable {
+    let category: KitComponentCategory
+    let itemID: PersistentIdentifier
+
+    var id: String {
+        "\(category.rawValue)-\(itemID)"
+    }
+}
+
+struct AddKitComponentRow: Identifiable, Hashable {
+    let id: String
+    let title: String
+    let subtitle: String
+
+    init(selection: KitComponentSelection, title: String, subtitle: String) {
+        self.id = selection.id
+        self.title = title
+        self.subtitle = subtitle
+    }
+}
+
+struct AddKitComponentPickerItem: Identifiable, Hashable {
+    let id: PersistentIdentifier
+    let title: String
+    let subtitle: String
+    let isSelected: Bool
+}
+
+final class AddKitViewModel {
+    private let eligibilityService: KitEligibilityServicing
+
+    init(eligibilityService: KitEligibilityServicing = AppServices.shared.resolve(KitEligibilityServicing.self)) {
+        self.eligibilityService = eligibilityService
+    }
+
+    func initialName(for kit: Kit?) -> String {
+        kit?.name ?? ""
+    }
+
+    func initialNotes(for kit: Kit?) -> String {
+        kit?.notes ?? ""
+    }
+
+    func initialKind(for kit: Kit?) -> KitKind {
+        kit?.kitKind ?? .upperReceiver
+    }
+
+    func navigationTitle(for kit: Kit?) -> String {
+        kit == nil ? String(localized: "New Kit") : String(localized: "Kit Details")
+    }
+
+    func primarySaveTitle(for kit: Kit?) -> String {
+        kit == nil ? String(localized: "Build Kit") : String(localized: "Save")
+    }
+
+    func shouldShowDisassembleButton(for kit: Kit?) -> Bool {
+        guard let kit else {
+            return false
+        }
+        return kit.kitStatus == .built || kit.kitStatus == .linked
+    }
+
+    func initialSelections(for kit: Kit?) -> [KitComponentSelection] {
+        kit?.sortedComponents.compactMap { component in
+            guard let identity = component.stableIdentity else {
+                return nil
+            }
+
+            switch identity {
+            case let .part(id):
+                return KitComponentSelection(category: .part, itemID: id)
+            case let .optic(id):
+                return KitComponentSelection(category: .optic, itemID: id)
+            case let .attachment(id):
+                return KitComponentSelection(category: .attachment, itemID: id)
+            }
+        } ?? []
+    }
+
+    func trimmedValue(_ value: String) -> String {
+        value.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    func optionalValue(_ value: String) -> String? {
+        let trimmed = trimmedValue(value)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+
+    func emptySelectionText(for category: KitComponentCategory) -> String {
+        switch category {
+        case .part:
+            return String(localized: "No parts selected.")
+        case .optic:
+            return String(localized: "No optics selected.")
+        case .attachment:
+            return String(localized: "No attachments selected.")
+        }
+    }
+
+    func pickerTitle(for category: KitComponentCategory) -> String {
+        switch category {
+        case .part:
+            return String(localized: "Select Parts")
+        case .optic:
+            return String(localized: "Select Optics")
+        case .attachment:
+            return String(localized: "Select Attachments")
+        }
+    }
+
+    func pickerEmptyTitle(for category: KitComponentCategory) -> String {
+        switch category {
+        case .part:
+            return String(localized: "No Parts Available")
+        case .optic:
+            return String(localized: "No Optics Available")
+        case .attachment:
+            return String(localized: "No Attachments Available")
+        }
+    }
+
+    func displayName(name: String, kind: KitKind) -> String {
+        let trimmed = trimmedValue(name)
+        return trimmed.isEmpty ? kind.displayName : trimmed
+    }
+
+    func selectedIDs(from selections: [KitComponentSelection], category: KitComponentCategory) -> Set<PersistentIdentifier> {
+        Set(selections.filter { $0.category == category }.map(\.itemID))
+    }
+
+    func availableParts(from parts: [Part], selectedIDs: Set<PersistentIdentifier>, kits: [Kit], editing kit: Kit?) -> [Part] {
+        parts.filter { part in
+            selectedIDs.contains(part.persistentModelID) ||
+            eligibilityService.canSelectForKit(part, kits: kits, excluding: kit)
+        }
+    }
+
+    func availableOptics(from optics: [Optic], selectedIDs: Set<PersistentIdentifier>, kits: [Kit], editing kit: Kit?) -> [Optic] {
+        optics.filter { optic in
+            selectedIDs.contains(optic.persistentModelID) ||
+            eligibilityService.canSelectForKit(optic, kits: kits, excluding: kit)
+        }
+    }
+
+    func availableAttachments(
+        from attachments: [Attachment],
+        selectedIDs: Set<PersistentIdentifier>,
+        kits: [Kit],
+        editing kit: Kit?
+    ) -> [Attachment] {
+        attachments.filter { attachment in
+            selectedIDs.contains(attachment.persistentModelID) ||
+            eligibilityService.canSelectForKit(attachment, kits: kits, excluding: kit)
+        }
+    }
+
+    func toggledSelection(
+        _ selections: [KitComponentSelection],
+        category: KitComponentCategory,
+        itemID: PersistentIdentifier
+    ) -> [KitComponentSelection] {
+        var updated = selections
+        if let index = updated.firstIndex(where: { $0.category == category && $0.itemID == itemID }) {
+            updated.remove(at: index)
+        } else {
+            updated.append(KitComponentSelection(category: category, itemID: itemID))
+        }
+        return updated
+    }
+
+    func components(
+        from selections: [KitComponentSelection],
+        parts: [Part],
+        optics: [Optic],
+        attachments: [Attachment]
+    ) -> [KitComponent] {
+        selections.enumerated().compactMap { index, selection in
+            switch selection.category {
+            case .part:
+                guard let part = parts.first(where: { $0.persistentModelID == selection.itemID }) else {
+                    return nil
+                }
+                return KitComponent(category: .part, part: part, sortOrder: index)
+            case .optic:
+                guard let optic = optics.first(where: { $0.persistentModelID == selection.itemID }) else {
+                    return nil
+                }
+                return KitComponent(category: .optic, optic: optic, sortOrder: index)
+            case .attachment:
+                guard let attachment = attachments.first(where: { $0.persistentModelID == selection.itemID }) else {
+                    return nil
+                }
+                return KitComponent(category: .attachment, attachment: attachment, sortOrder: index)
+            }
+        }
+    }
+
+    func componentValueCents(
+        from selections: [KitComponentSelection],
+        parts: [Part],
+        optics: [Optic],
+        attachments: [Attachment]
+    ) -> Int {
+        KitValueService.totalValueCents(
+            for: components(
+                from: selections,
+                parts: parts,
+                optics: optics,
+                attachments: attachments
+            )
+        )
+    }
+
+    func selectedComponentRows(
+        for category: KitComponentCategory,
+        selections: [KitComponentSelection],
+        parts: [Part],
+        optics: [Optic],
+        attachments: [Attachment]
+    ) -> [AddKitComponentRow] {
+        selections
+            .filter { $0.category == category }
+            .map { selection in
+                AddKitComponentRow(
+                    selection: selection,
+                    title: componentTitle(for: selection, parts: parts, optics: optics, attachments: attachments),
+                    subtitle: componentSubtitle(for: selection, parts: parts, optics: optics, attachments: attachments)
+                )
+            }
+    }
+
+    func partPickerItems(
+        parts: [Part],
+        selections: [KitComponentSelection],
+        kits: [Kit],
+        editing kit: Kit?
+    ) -> [AddKitComponentPickerItem] {
+        let selectedIDs = selectedIDs(from: selections, category: .part)
+        return availableParts(from: parts, selectedIDs: selectedIDs, kits: kits, editing: kit).map { part in
+            AddKitComponentPickerItem(
+                id: part.persistentModelID,
+                title: part.displayName,
+                subtitle: part.typeDisplayName,
+                isSelected: selectedIDs.contains(part.persistentModelID)
+            )
+        }
+    }
+
+    func opticPickerItems(
+        optics: [Optic],
+        selections: [KitComponentSelection],
+        kits: [Kit],
+        editing kit: Kit?
+    ) -> [AddKitComponentPickerItem] {
+        let selectedIDs = selectedIDs(from: selections, category: .optic)
+        return availableOptics(from: optics, selectedIDs: selectedIDs, kits: kits, editing: kit).map { optic in
+            AddKitComponentPickerItem(
+                id: optic.persistentModelID,
+                title: optic.displayName,
+                subtitle: opticSubtitle(for: optic),
+                isSelected: selectedIDs.contains(optic.persistentModelID)
+            )
+        }
+    }
+
+    func attachmentPickerItems(
+        attachments: [Attachment],
+        selections: [KitComponentSelection],
+        kits: [Kit],
+        editing kit: Kit?
+    ) -> [AddKitComponentPickerItem] {
+        let selectedIDs = selectedIDs(from: selections, category: .attachment)
+        return availableAttachments(from: attachments, selectedIDs: selectedIDs, kits: kits, editing: kit).map { attachment in
+            AddKitComponentPickerItem(
+                id: attachment.persistentModelID,
+                title: attachment.displayName,
+                subtitle: attachment.typeDisplayName,
+                isSelected: selectedIDs.contains(attachment.persistentModelID)
+            )
+        }
+    }
+
+    func componentTitle(
+        for selection: KitComponentSelection,
+        parts: [Part],
+        optics: [Optic],
+        attachments: [Attachment]
+    ) -> String {
+        switch selection.category {
+        case .part:
+            return parts.first { $0.persistentModelID == selection.itemID }?.displayName ?? String(localized: "Missing Part")
+        case .optic:
+            return optics.first { $0.persistentModelID == selection.itemID }?.displayName ?? String(localized: "Missing Optic")
+        case .attachment:
+            return attachments.first { $0.persistentModelID == selection.itemID }?.displayName ?? String(localized: "Missing Attachment")
+        }
+    }
+
+    func componentSubtitle(
+        for selection: KitComponentSelection,
+        parts: [Part],
+        optics: [Optic],
+        attachments: [Attachment]
+    ) -> String {
+        switch selection.category {
+        case .part:
+            return parts.first { $0.persistentModelID == selection.itemID }?.typeDisplayName ?? selection.category.displayName
+        case .optic:
+            guard let optic = optics.first(where: { $0.persistentModelID == selection.itemID }) else {
+                return selection.category.displayName
+            }
+            return opticSubtitle(for: optic)
+        case .attachment:
+            return attachments.first { $0.persistentModelID == selection.itemID }?.typeDisplayName ?? selection.category.displayName
+        }
+    }
+
+    func opticSubtitle(for optic: Optic) -> String {
+        String.localizedStringWithFormat(
+            String(localized: "%@ • %@"),
+            optic.typeDisplayName,
+            optic.magnificationText
+        )
+    }
+
+    func validationResultForBuild(components: [KitComponent], kits: [Kit], editing kit: Kit?) -> KitValidationResult {
+        guard !components.isEmpty else {
+            return .invalid(String(localized: "Add at least one component before building this kit."))
+        }
+        return eligibilityService.validationResultForBuild(components: components, kits: kits, excluding: kit)
+    }
+
+    func nextSortOrder(in context: ModelContext) -> Int {
+        var descriptor = FetchDescriptor<Kit>(
+            sortBy: [SortDescriptor(\.sortOrder, order: .reverse)]
+        )
+        descriptor.fetchLimit = 1
+        let highestSortOrder = (try? context.fetch(descriptor).first?.sortOrder) ?? -1
+        return highestSortOrder + 1
+    }
+
+    @discardableResult
+    func saveKit(
+        _ kit: Kit?,
+        name: String,
+        kind: KitKind,
+        notes: String?,
+        components: [KitComponent],
+        targetStatus: KitStatus,
+        kits: [Kit],
+        in context: ModelContext
+    ) -> KitValidationResult {
+        if targetStatus.reservesComponents {
+            let validation = validationResultForBuild(components: components, kits: kits, editing: kit)
+            guard validation.isValid else {
+                return validation
+            }
+        }
+
+        let now = Date()
+        let targetKit: Kit
+        if let kit {
+            targetKit = kit
+            for component in kit.components {
+                context.delete(component)
+            }
+            kit.components.removeAll()
+        } else {
+            targetKit = Kit(
+                name: displayName(name: name, kind: kind),
+                kind: kind,
+                status: targetStatus,
+                notes: notes,
+                sortOrder: nextSortOrder(in: context),
+                createdAt: now,
+                updatedAt: now
+            )
+            context.insert(targetKit)
+        }
+
+        targetKit.name = displayName(name: name, kind: kind)
+        targetKit.kind = kind.rawValue
+        targetKit.status = targetStatus.rawValue
+        targetKit.notes = notes
+        targetKit.updatedAt = now
+        if targetStatus != .linked {
+            targetKit.firearm = nil
+        }
+
+        for component in components {
+            component.kit = targetKit
+            context.insert(component)
+        }
+        targetKit.components = components
+
+        do {
+            try context.save()
+            UserDefaults.standard.set(Date(), forKey: "LastModelSaveDate")
+            return .valid
+        } catch {
+            return .invalid(
+                String.localizedStringWithFormat(
+                    String(localized: "Failed to save kit: %@"),
+                    error.localizedDescription
+                )
+            )
+        }
+    }
+
+    func disassembleKit(_ kit: Kit, in context: ModelContext) -> KitValidationResult {
+        kit.firearm = nil
+        context.delete(kit)
+
+        do {
+            try context.save()
+            UserDefaults.standard.set(Date(), forKey: "LastModelSaveDate")
+            return .valid
+        } catch {
+            return .invalid(error.localizedDescription)
+        }
+    }
+}

--- a/ArmoryInventory/Accessories/Kits/AddKitViewModel.swift
+++ b/ArmoryInventory/Accessories/Kits/AddKitViewModel.swift
@@ -429,4 +429,31 @@ final class AddKitViewModel {
             return .invalid(error.localizedDescription)
         }
     }
+
+    func discardKit(_ kit: Kit, in context: ModelContext) -> KitValidationResult {
+        let parts = uniqueModels(kit.components.compactMap(\.part))
+        let optics = uniqueModels(kit.components.compactMap(\.optic))
+        let attachments = uniqueModels(kit.components.compactMap(\.attachment))
+
+        kit.firearm = nil
+        context.delete(kit)
+        parts.forEach(context.delete)
+        optics.forEach(context.delete)
+        attachments.forEach(context.delete)
+
+        do {
+            try context.save()
+            UserDefaults.standard.set(Date(), forKey: "LastModelSaveDate")
+            return .valid
+        } catch {
+            return .invalid(error.localizedDescription)
+        }
+    }
+
+    private func uniqueModels<T: PersistentModel>(_ models: [T]) -> [T] {
+        var seenIDs = Set<PersistentIdentifier>()
+        return models.filter { model in
+            seenIDs.insert(model.persistentModelID).inserted
+        }
+    }
 }

--- a/ArmoryInventory/Accessories/Kits/KitModels.swift
+++ b/ArmoryInventory/Accessories/Kits/KitModels.swift
@@ -1,0 +1,370 @@
+//
+//  KitModels.swift
+//  Armory Inventory
+//
+//  Created by Codex on 5/14/26.
+//
+
+import Foundation
+import SwiftData
+
+enum KitKind: String, Codable, CaseIterable, Hashable, Identifiable {
+    case upperReceiver
+    case lowerReceiver
+    case optics
+    case custom
+
+    var id: String { rawValue }
+
+    var displayName: String {
+        switch self {
+        case .upperReceiver:
+            return String(localized: "Upper Receiver Kit")
+        case .lowerReceiver:
+            return String(localized: "Lower Receiver Kit")
+        case .optics:
+            return String(localized: "Optics Kit")
+        case .custom:
+            return String(localized: "Custom Kit")
+        }
+    }
+}
+
+enum KitStatus: String, Codable, CaseIterable, Hashable, Identifiable {
+    case built
+    case linked
+
+    var id: String { rawValue }
+
+    var displayName: String {
+        switch self {
+        case .built:
+            return String(localized: "Built")
+        case .linked:
+            return String(localized: "Linked")
+        }
+    }
+
+    var reservesComponents: Bool {
+        self == .built || self == .linked
+    }
+}
+
+enum KitComponentCategory: String, Codable, CaseIterable, Hashable, Identifiable {
+    case part
+    case optic
+    case attachment
+
+    var id: String { rawValue }
+
+    var displayName: String {
+        switch self {
+        case .part:
+            return String(localized: "Part")
+        case .optic:
+            return String(localized: "Optic")
+        case .attachment:
+            return String(localized: "Attachment")
+        }
+    }
+}
+
+enum KitComponentSlot: String, Codable, CaseIterable, Hashable, Identifiable {
+    case receiver
+    case boltCarrierGroup
+    case handguard
+    case muzzleDevice
+    case foregrip
+    case optic
+    case lowerReceiver
+    case trigger
+    case recoilSystem
+    case internals
+    case stock
+    case grip
+    case mount
+    case magnifier
+    case support
+    case other
+
+    var id: String { rawValue }
+
+    var displayName: String {
+        switch self {
+        case .receiver:
+            return String(localized: "Receiver")
+        case .boltCarrierGroup:
+            return String(localized: "Bolt Carrier Group")
+        case .handguard:
+            return String(localized: "Handguard")
+        case .muzzleDevice:
+            return String(localized: "Muzzle Device")
+        case .foregrip:
+            return String(localized: "Foregrip")
+        case .optic:
+            return String(localized: "Optic")
+        case .lowerReceiver:
+            return String(localized: "Lower Receiver")
+        case .trigger:
+            return String(localized: "Trigger")
+        case .recoilSystem:
+            return String(localized: "Recoil System")
+        case .internals:
+            return String(localized: "Internals")
+        case .stock:
+            return String(localized: "Stock")
+        case .grip:
+            return String(localized: "Grip")
+        case .mount:
+            return String(localized: "Mount")
+        case .magnifier:
+            return String(localized: "Magnifier")
+        case .support:
+            return String(localized: "Support")
+        case .other:
+            return String(localized: "Other")
+        }
+    }
+}
+
+enum KitHistoryEvent: String, Codable, CaseIterable, Hashable, Identifiable {
+    case created
+    case updated
+    case built
+    case linked
+    case unlinked
+
+    var id: String { rawValue }
+
+    var displayName: String {
+        switch self {
+        case .created:
+            return String(localized: "Created")
+        case .updated:
+            return String(localized: "Updated")
+        case .built:
+            return String(localized: "Built")
+        case .linked:
+            return String(localized: "Linked")
+        case .unlinked:
+            return String(localized: "Unlinked")
+        }
+    }
+}
+
+@Model
+final class Kit {
+    var id: UUID?
+    var name: String
+    var kind: KitKind.RawValue
+    var status: KitStatus.RawValue
+    var notes: String?
+    var sortOrder: Int
+    var createdAt: Date
+    var updatedAt: Date
+
+    @Relationship var firearm: Firearm?
+    @Relationship(deleteRule: .cascade, inverse: \KitComponent.kit) var components: [KitComponent]
+    @Relationship(deleteRule: .cascade, inverse: \KitHistoryRecord.kit) var historyRecords: [KitHistoryRecord]
+
+    init(
+        id: UUID? = UUID(),
+        name: String,
+        kind: KitKind,
+        status: KitStatus = .built,
+        notes: String? = nil,
+        firearm: Firearm? = nil,
+        components: [KitComponent] = [],
+        historyRecords: [KitHistoryRecord] = [],
+        sortOrder: Int = 0,
+        createdAt: Date = .now,
+        updatedAt: Date = .now
+    ) {
+        self.id = id
+        self.name = name
+        self.kind = kind.rawValue
+        self.status = status.rawValue
+        self.notes = notes
+        self.firearm = firearm
+        self.components = components
+        self.historyRecords = historyRecords
+        self.sortOrder = sortOrder
+        self.createdAt = createdAt
+        self.updatedAt = updatedAt
+    }
+
+    var kitKind: KitKind {
+        KitKind(rawValue: kind) ?? .custom
+    }
+
+    var kitStatus: KitStatus {
+        KitStatus(rawValue: status) ?? .built
+    }
+
+    var isActiveReservation: Bool {
+        kitStatus.reservesComponents
+    }
+
+    var displayName: String {
+        name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? kitKind.displayName : name
+    }
+
+    var sortedComponents: [KitComponent] {
+        components.sorted {
+            if $0.sortOrder != $1.sortOrder {
+                return $0.sortOrder < $1.sortOrder
+            }
+            return $0.displayName.localizedCaseInsensitiveCompare($1.displayName) == .orderedAscending
+        }
+    }
+
+    var sortedHistoryRecords: [KitHistoryRecord] {
+        historyRecords.sorted { $0.occurredAt > $1.occurredAt }
+    }
+
+    var componentCountText: String {
+        String.localizedStringWithFormat(
+            String(localized: "componentCount"),
+            components.count,
+            components.count.localizedCountString
+        )
+    }
+
+    var totalValueCents: Int {
+        KitValueService.totalValueCents(for: components)
+    }
+
+    var totalValueText: String {
+        KitValueService.currencyText(for: totalValueCents)
+    }
+}
+
+@Model
+final class KitComponent {
+    var id: UUID?
+    var category: KitComponentCategory.RawValue
+    var slot: KitComponentSlot.RawValue?
+    var sortOrder: Int
+
+    @Relationship var kit: Kit?
+    @Relationship var part: Part?
+    @Relationship var optic: Optic?
+    @Relationship var attachment: Attachment?
+
+    init(
+        id: UUID? = UUID(),
+        category: KitComponentCategory,
+        slot: KitComponentSlot? = nil,
+        part: Part? = nil,
+        optic: Optic? = nil,
+        attachment: Attachment? = nil,
+        sortOrder: Int = 0
+    ) {
+        self.id = id
+        self.category = category.rawValue
+        self.slot = slot?.rawValue
+        self.part = part
+        self.optic = optic
+        self.attachment = attachment
+        self.sortOrder = sortOrder
+    }
+
+    var componentCategory: KitComponentCategory {
+        KitComponentCategory(rawValue: category) ?? .part
+    }
+
+    var componentSlot: KitComponentSlot? {
+        guard let slot else {
+            return nil
+        }
+        return KitComponentSlot(rawValue: slot)
+    }
+
+    var displayName: String {
+        switch componentCategory {
+        case .part:
+            return part?.displayName ?? String(localized: "Missing Part")
+        case .optic:
+            return optic?.displayName ?? String(localized: "Missing Optic")
+        case .attachment:
+            return attachment?.displayName ?? String(localized: "Missing Attachment")
+        }
+    }
+
+    var detailText: String {
+        let slotText = componentSlot?.displayName
+        let typeText: String?
+        switch componentCategory {
+        case .part:
+            typeText = part?.typeDisplayName
+        case .optic:
+            typeText = optic.map {
+                String.localizedStringWithFormat(
+                    String(localized: "%@ • %@"),
+                    $0.typeDisplayName,
+                    $0.magnificationText
+                )
+            }
+        case .attachment:
+            typeText = attachment?.typeDisplayName
+        }
+
+        return [slotText, typeText]
+            .compactMap { $0 }
+            .filter { !$0.isEmpty }
+            .joined(separator: " • ")
+    }
+
+    var purchasePriceCents: Int {
+        switch componentCategory {
+        case .part:
+            return max(0, part?.purchasePriceCents ?? 0)
+        case .optic:
+            return max(0, optic?.purchasePriceCents ?? 0)
+        case .attachment:
+            return max(0, attachment?.purchasePriceCents ?? 0)
+        }
+    }
+
+    var stableIdentity: KitComponentIdentity? {
+        if let part {
+            return .part(part.persistentModelID)
+        }
+        if let optic {
+            return .optic(optic.persistentModelID)
+        }
+        if let attachment {
+            return .attachment(attachment.persistentModelID)
+        }
+        return nil
+    }
+}
+
+@Model
+final class KitHistoryRecord {
+    var occurredAt: Date
+    var event: KitHistoryEvent.RawValue
+    var note: String?
+
+    @Relationship var kit: Kit?
+
+    init(
+        occurredAt: Date = .now,
+        event: KitHistoryEvent,
+        note: String? = nil
+    ) {
+        self.occurredAt = occurredAt
+        self.event = event.rawValue
+        self.note = note
+    }
+
+    var historyEvent: KitHistoryEvent {
+        KitHistoryEvent(rawValue: event) ?? .updated
+    }
+}
+
+enum KitComponentIdentity: Hashable {
+    case part(PersistentIdentifier)
+    case optic(PersistentIdentifier)
+    case attachment(PersistentIdentifier)
+}

--- a/ArmoryInventory/Accessories/Kits/KitServices.swift
+++ b/ArmoryInventory/Accessories/Kits/KitServices.swift
@@ -1,0 +1,186 @@
+//
+//  KitServices.swift
+//  Armory Inventory
+//
+//  Created by Codex on 5/14/26.
+//
+
+import Foundation
+import SwiftData
+
+struct KitValidationResult {
+    let isValid: Bool
+    let message: String?
+
+    static let valid = KitValidationResult(isValid: true, message: nil)
+
+    static func invalid(_ message: String) -> KitValidationResult {
+        KitValidationResult(isValid: false, message: message)
+    }
+}
+
+protocol KitEligibilityServicing {
+    func isReserved(_ part: Part, by kits: [Kit], excluding kit: Kit?) -> Bool
+    func isReserved(_ optic: Optic, by kits: [Kit], excluding kit: Kit?) -> Bool
+    func isReserved(_ attachment: Attachment, by kits: [Kit], excluding kit: Kit?) -> Bool
+    func canSelectForKit(_ part: Part, kits: [Kit], excluding kit: Kit?) -> Bool
+    func canSelectForKit(_ optic: Optic, kits: [Kit], excluding kit: Kit?) -> Bool
+    func canSelectForKit(_ attachment: Attachment, kits: [Kit], excluding kit: Kit?) -> Bool
+    func canSelectForDirectFirearm(_ part: Part, kits: [Kit]) -> Bool
+    func canSelectForDirectFirearm(_ optic: Optic, kits: [Kit]) -> Bool
+    func canSelectForDirectFirearm(_ attachment: Attachment, kits: [Kit]) -> Bool
+    func validationResultForBuild(components: [KitComponent], kits: [Kit], excluding kit: Kit?) -> KitValidationResult
+}
+
+struct KitEligibilityService: KitEligibilityServicing {
+    func isReserved(_ part: Part, by kits: [Kit], excluding kit: Kit? = nil) -> Bool {
+        reservedComponents(in: kits, excluding: kit).contains { $0.part?.persistentModelID == part.persistentModelID }
+    }
+
+    func isReserved(_ optic: Optic, by kits: [Kit], excluding kit: Kit? = nil) -> Bool {
+        reservedComponents(in: kits, excluding: kit).contains { $0.optic?.persistentModelID == optic.persistentModelID }
+    }
+
+    func isReserved(_ attachment: Attachment, by kits: [Kit], excluding kit: Kit? = nil) -> Bool {
+        reservedComponents(in: kits, excluding: kit).contains { $0.attachment?.persistentModelID == attachment.persistentModelID }
+    }
+
+    func canSelectForKit(_ part: Part, kits: [Kit], excluding kit: Kit? = nil) -> Bool {
+        part.firearm == nil && !isReserved(part, by: kits, excluding: kit)
+    }
+
+    func canSelectForKit(_ optic: Optic, kits: [Kit], excluding kit: Kit? = nil) -> Bool {
+        optic.firearm == nil && !isReserved(optic, by: kits, excluding: kit)
+    }
+
+    func canSelectForKit(_ attachment: Attachment, kits: [Kit], excluding kit: Kit? = nil) -> Bool {
+        attachment.firearm == nil && !isReserved(attachment, by: kits, excluding: kit)
+    }
+
+    func canSelectForDirectFirearm(_ part: Part, kits: [Kit]) -> Bool {
+        part.firearm == nil && !isReserved(part, by: kits, excluding: nil)
+    }
+
+    func canSelectForDirectFirearm(_ optic: Optic, kits: [Kit]) -> Bool {
+        optic.firearm == nil && !isReserved(optic, by: kits, excluding: nil)
+    }
+
+    func canSelectForDirectFirearm(_ attachment: Attachment, kits: [Kit]) -> Bool {
+        attachment.firearm == nil && !isReserved(attachment, by: kits, excluding: nil)
+    }
+
+    func validationResultForBuild(components: [KitComponent], kits: [Kit], excluding kit: Kit? = nil) -> KitValidationResult {
+        for component in components {
+            switch component.componentCategory {
+            case .part:
+                guard let part = component.part else {
+                    return .invalid(String(localized: "A selected part is missing."))
+                }
+                if part.firearm != nil {
+                    return .invalid(alreadyLinkedToFirearmMessage(itemName: part.displayName))
+                }
+                if isReserved(part, by: kits, excluding: kit) {
+                    return .invalid(alreadyReservedByKitMessage(itemName: part.displayName))
+                }
+            case .optic:
+                guard let optic = component.optic else {
+                    return .invalid(String(localized: "A selected optic is missing."))
+                }
+                if optic.firearm != nil {
+                    return .invalid(alreadyLinkedToFirearmMessage(itemName: optic.displayName))
+                }
+                if isReserved(optic, by: kits, excluding: kit) {
+                    return .invalid(alreadyReservedByKitMessage(itemName: optic.displayName))
+                }
+            case .attachment:
+                guard let attachment = component.attachment else {
+                    return .invalid(String(localized: "A selected attachment is missing."))
+                }
+                if attachment.firearm != nil {
+                    return .invalid(alreadyLinkedToFirearmMessage(itemName: attachment.displayName))
+                }
+                if isReserved(attachment, by: kits, excluding: kit) {
+                    return .invalid(alreadyReservedByKitMessage(itemName: attachment.displayName))
+                }
+            }
+        }
+
+        return .valid
+    }
+
+    private func reservedComponents(in kits: [Kit], excluding kit: Kit?) -> [KitComponent] {
+        kits.filter { candidate in
+            candidate.isActiveReservation && candidate.persistentModelID != kit?.persistentModelID
+        }
+        .flatMap(\.components)
+    }
+
+    private func alreadyLinkedToFirearmMessage(itemName: String) -> String {
+        String.localizedStringWithFormat(
+            String(localized: "%@ is already linked to a firearm."),
+            itemName
+        )
+    }
+
+    private func alreadyReservedByKitMessage(itemName: String) -> String {
+        String.localizedStringWithFormat(
+            String(localized: "%@ is already reserved by another built or linked kit."),
+            itemName
+        )
+    }
+}
+
+struct KitValueService {
+    static func totalValueCents(for components: [KitComponent]) -> Int {
+        var seen: Set<KitComponentIdentity> = []
+        return components.reduce(0) { total, component in
+            guard let identity = component.stableIdentity else {
+                return total
+            }
+            guard seen.insert(identity).inserted else {
+                return total
+            }
+            return total + component.purchasePriceCents
+        }
+    }
+
+    static func effectiveTotalValueCents(
+        for firearm: Firearm,
+        linkedKits: [Kit],
+        compatibleMagazines: [Magazine]
+    ) -> Int {
+        var seen: Set<KitComponentIdentity> = []
+        var total = max(0, firearm.purchasePriceCents)
+
+        for optic in firearm.optics where seen.insert(.optic(optic.persistentModelID)).inserted {
+            total += max(0, optic.purchasePriceCents)
+        }
+
+        for attachment in firearm.attachments where seen.insert(.attachment(attachment.persistentModelID)).inserted {
+            total += max(0, attachment.purchasePriceCents)
+        }
+
+        for part in firearm.parts where seen.insert(.part(part.persistentModelID)).inserted {
+            total += max(0, part.purchasePriceCents)
+        }
+
+        total += compatibleMagazines.reduce(0) { $0 + max(0, $1.purchasePriceCents) }
+
+        for component in linkedKits.flatMap(\.components) {
+            guard let identity = component.stableIdentity else {
+                continue
+            }
+            guard seen.insert(identity).inserted else {
+                continue
+            }
+            total += component.purchasePriceCents
+        }
+
+        return total
+    }
+
+    static func currencyText(for amountCents: Int) -> String {
+        let amount = Decimal(amountCents) / 100
+        return amount.formatted(.currency(code: Locale.current.currency?.identifier ?? "USD"))
+    }
+}

--- a/ArmoryInventory/Accessories/Kits/KitsView.swift
+++ b/ArmoryInventory/Accessories/Kits/KitsView.swift
@@ -1,0 +1,386 @@
+//
+//  KitsView.swift
+//  Armory Inventory
+//
+//  Created by Codex on 5/14/26.
+//
+
+import SwiftUI
+import SwiftData
+import UniformTypeIdentifiers
+
+struct KitsView: View {
+    @Environment(\.modelContext) private var context
+    @AppStorage(InventorySettingsKeys.showValueInCard) private var showValueInCard = true
+    @AppStorage(InventorySettingsKeys.showTotalValue) private var showTotalValue = true
+    @State private var showingAddKit = false
+    @State private var selectedKit: Kit?
+    @State private var showingFilters = false
+    @State private var selectedKind: KitKind?
+    @State private var searchText = ""
+    @State private var kits: [Kit] = []
+    @State private var alertMessage: String?
+    @State private var showsExpandedCards = false
+    @State private var draggedKit: Kit?
+
+    private let viewModel = KitsViewModel()
+    private let inventoryListService: InventoryListServicing = AppServices.shared.resolve(InventoryListServicing.self)
+
+    var body: some View {
+        Group {
+            if kits.isEmpty {
+                ContentUnavailableView(
+                    "No Kits Yet",
+                    systemImage: "shippingbox.fill",
+                    description: Text("Build kits from unlinked parts, optics, and attachments.")
+                )
+            } else {
+                ScrollView {
+                    LazyVStack(alignment: .leading, spacing: 16) {
+                        filtersCard
+
+                        ForEach(filteredKits) { kit in
+                            Button {
+                                selectedKit = kit
+                            } label: {
+                                KitCardView(
+                                    kit: kit,
+                                    componentSummaries: viewModel.componentSummaries(for: kit),
+                                    showsExpandedCards: showsExpandedCards,
+                                    showValueInCard: showValueInCard
+                                )
+                            }
+                            .buttonStyle(.plain)
+                            .onDrag {
+                                draggedKit = kit
+                                return NSItemProvider(object: kit.displayName as NSString)
+                            }
+                            .onDrop(
+                                of: [UTType.text],
+                                delegate: KitDropDelegate(
+                                    targetKit: kit,
+                                    kits: filteredKits,
+                                    draggedKit: $draggedKit,
+                                    onMove: moveKits
+                                )
+                            )
+                        }
+
+                        if showTotalValue {
+                            LabeledContent("Total Value", value: totalValueText)
+                                .padding(16)
+                                .background(Color(.secondarySystemBackground), in: RoundedRectangle(cornerRadius: 18, style: .continuous))
+                        }
+                    }
+                    .padding()
+                }
+                .searchable(text: $searchText)
+            }
+        }
+        .navigationTitle("Kits")
+        .task {
+            reloadKits()
+        }
+        .onAppear {
+            reloadKits()
+        }
+        .onChange(of: showingAddKit) {
+            if !showingAddKit {
+                reloadKits()
+            }
+        }
+        .onChange(of: selectedKit) {
+            if selectedKit == nil {
+                reloadKits()
+            }
+        }
+        .toolbar {
+            ToolbarItemGroup(placement: .topBarTrailing) {
+                Button {
+                    withAnimation(.snappy(duration: 0.24, extraBounce: 0)) {
+                        showsExpandedCards.toggle()
+                    }
+                } label: {
+                    Image(systemName: showsExpandedCards ? "rectangle.compress.vertical" : "rectangle.expand.vertical")
+                }
+
+                Button {
+                    showingAddKit = true
+                } label: {
+                    Label("Add Kit", systemImage: "plus")
+                }
+            }
+        }
+        .sheet(isPresented: $showingAddKit) {
+            AddKitView(viewModel: AddKitViewModel())
+                .presentationDetents([.large])
+        }
+        .sheet(item: $selectedKit) { kit in
+            AddKitView(kit: kit, viewModel: AddKitViewModel())
+                .presentationDetents([.large])
+        }
+        .alert("Kit Action Failed", isPresented: alertBinding) {
+            Button("OK", role: .cancel) {
+                alertMessage = nil
+            }
+        } message: {
+            Text(alertMessage ?? "")
+        }
+    }
+
+    @ViewBuilder
+    private var filtersCard: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Button {
+                withAnimation(.easeInOut(duration: 0.2)) {
+                    showingFilters.toggle()
+                }
+            } label: {
+                HStack {
+                    Text("Filters")
+                    Spacer()
+                    Image(systemName: "chevron.down")
+                        .rotationEffect(.degrees(showingFilters ? 180 : 0))
+                        .animation(.easeInOut(duration: 0.2), value: showingFilters)
+                        .foregroundStyle(.secondary)
+                }
+            }
+            .buttonStyle(.plain)
+
+            if showingFilters {
+                filterControls
+                    .transition(.modifier(
+                        active: TopAnchoredStretchModifier(progress: 0.01),
+                        identity: TopAnchoredStretchModifier(progress: 1)
+                    ))
+            }
+        }
+        .padding(16)
+        .frame(maxWidth: .infinity)
+        .background(Color(.secondarySystemBackground), in: RoundedRectangle(cornerRadius: 18, style: .continuous))
+        .animation(.easeInOut(duration: 0.2), value: showingFilters)
+    }
+
+    private var filterControls: some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(spacing: 10) {
+                filterMenu(
+                    selectionTitle: selectedKind?.displayName ?? String(localized: "All Kinds"),
+                    isActive: selectedKind != nil
+                ) {
+                    Button(allKindsCountText) {
+                        selectedKind = nil
+                    }
+
+                    ForEach(KitKind.allCases) { kind in
+                        Button(viewModel.filterCountText(title: kind.displayName, count: viewModel.countForKind(kind, in: kits))) {
+                            selectedKind = kind
+                        }
+                    }
+                }
+
+                if selectedKind != nil {
+                    Button("Clear Filters") {
+                        selectedKind = nil
+                    }
+                    .font(.subheadline.weight(.semibold))
+                    .padding(.horizontal, 14)
+                    .padding(.vertical, 10)
+                    .background(Color(.tertiarySystemFill), in: Capsule())
+                }
+            }
+        }
+    }
+
+    private var filteredKits: [Kit] {
+        viewModel.filteredKits(kits, selectedKind: selectedKind, searchText: searchText)
+    }
+
+    private var totalValueText: String {
+        viewModel.totalValueText(for: filteredKits)
+    }
+
+    private var allKindsCountText: String {
+        viewModel.allKindsCountText(for: kits)
+    }
+
+    @ViewBuilder
+    private func filterMenu<Content: View>(
+        selectionTitle: String,
+        isActive: Bool,
+        @ViewBuilder content: () -> Content
+    ) -> some View {
+        Menu {
+            content()
+        } label: {
+            HStack(spacing: 8) {
+                Text(selectionTitle)
+                    .font(.subheadline)
+                Image(systemName: "chevron.down")
+                    .font(.caption.weight(.semibold))
+            }
+            .foregroundStyle(isActive ? .primary : .secondary)
+            .padding(.horizontal, 14)
+            .padding(.vertical, 10)
+            .background(isActive ? Color(.tertiarySystemFill) : Color(.secondarySystemFill), in: Capsule())
+        }
+        .buttonStyle(.plain)
+    }
+
+    private var alertBinding: Binding<Bool> {
+        Binding(
+            get: { alertMessage != nil },
+            set: { if !$0 { alertMessage = nil } }
+        )
+    }
+
+    private func moveKits(from source: IndexSet, to destination: Int) {
+        let result = viewModel.moveKits(
+            allKits: kits,
+            filteredKits: filteredKits,
+            selectedKind: selectedKind,
+            searchText: searchText,
+            source: source,
+            destination: destination,
+            in: context
+        )
+        if result.isValid {
+            reloadKits()
+        } else {
+            alertMessage = result.message
+        }
+    }
+
+    private func reloadKits() {
+        do {
+            kits = try inventoryListService.fetchKits(in: context)
+        } catch {
+            print("Kits fetch error: \(error)")
+        }
+    }
+}
+
+private struct TopAnchoredStretchModifier: ViewModifier {
+    let progress: CGFloat
+
+    func body(content: Content) -> some View {
+        content
+            .scaleEffect(x: 1, y: progress, anchor: .top)
+            .opacity(progress)
+            .clipped()
+    }
+}
+
+private struct KitCardView: View {
+    let kit: Kit
+    let componentSummaries: [KitComponentSummary]
+    let showsExpandedCards: Bool
+    let showValueInCard: Bool
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack(alignment: .firstTextBaseline) {
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(kit.displayName)
+                        .font(.headline)
+                    Text(kit.kitKind.displayName)
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                }
+                Spacer()
+            }
+
+            LabeledContent("Components", value: kit.componentCountText)
+
+            if let firearm = kit.firearm {
+                LabeledContent("Linked Firearm", value: firearm.displayName)
+            }
+
+            AnimatedExpandableSection(isExpanded: showsExpandedCards) {
+                VStack(alignment: .leading, spacing: 6) {
+                    ForEach(componentSummaries) { summary in
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text(summary.title)
+                                .font(.caption.weight(.semibold))
+                                .foregroundStyle(.secondary)
+                            Text(summary.itemNames)
+                                .font(.footnote)
+                                .foregroundStyle(.secondary)
+                                .lineLimit(2)
+                        }
+                    }
+
+                    if showValueInCard, kit.totalValueCents > 0 {
+                        LabeledContent("Value", value: kit.totalValueText)
+                    }
+                }
+            }
+        }
+        .padding(16)
+        .background(Color(.secondarySystemBackground), in: RoundedRectangle(cornerRadius: 18, style: .continuous))
+        .contentShape(Rectangle())
+    }
+
+}
+
+private struct KitDropDelegate: DropDelegate {
+    let targetKit: Kit
+    let kits: [Kit]
+    @Binding var draggedKit: Kit?
+    let onMove: (IndexSet, Int) -> Void
+
+    func dropEntered(info: DropInfo) {
+        guard let draggedKit else {
+            return
+        }
+        guard draggedKit.persistentModelID != targetKit.persistentModelID else {
+            return
+        }
+        guard
+            let fromIndex = kits.firstIndex(where: { $0.persistentModelID == draggedKit.persistentModelID }),
+            let toIndex = kits.firstIndex(where: { $0.persistentModelID == targetKit.persistentModelID })
+        else {
+            return
+        }
+
+        withAnimation(.snappy(duration: 0.2, extraBounce: 0)) {
+            onMove(IndexSet(integer: fromIndex), toIndex > fromIndex ? toIndex + 1 : toIndex)
+        }
+    }
+
+    func dropUpdated(info: DropInfo) -> DropProposal? {
+        DropProposal(operation: .move)
+    }
+
+    func performDrop(info: DropInfo) -> Bool {
+        draggedKit = nil
+        return true
+    }
+}
+
+private struct AnimatedExpandableSection<Content: View>: View {
+    let isExpanded: Bool
+    @ViewBuilder let content: () -> Content
+
+    @State private var contentHeight: CGFloat = .zero
+
+    var body: some View {
+        content()
+            .fixedSize(horizontal: false, vertical: true)
+            .background(
+                GeometryReader { proxy in
+                    Color.clear
+                        .onAppear {
+                            contentHeight = proxy.size.height
+                        }
+                        .onChange(of: proxy.size.height) {
+                            contentHeight = proxy.size.height
+                        }
+                }
+            )
+            .frame(maxHeight: isExpanded ? max(contentHeight, 1) : 0, alignment: .top)
+            .clipped()
+            .opacity(isExpanded ? 1 : 0)
+            .accessibilityHidden(!isExpanded)
+    }
+}

--- a/ArmoryInventory/Accessories/Kits/KitsViewModel.swift
+++ b/ArmoryInventory/Accessories/Kits/KitsViewModel.swift
@@ -1,0 +1,144 @@
+//
+//  KitsViewModel.swift
+//  Armory Inventory
+//
+//  Created by Codex on 5/20/26.
+//
+
+import Foundation
+import SwiftData
+
+struct KitComponentSummary: Identifiable, Hashable {
+    let title: String
+    let itemNames: String
+
+    var id: String { title }
+}
+
+final class KitsViewModel {
+    func filteredKits(_ kits: [Kit], selectedKind: KitKind?, searchText: String) -> [Kit] {
+        kits.filter { matchesFilters($0, selectedKind: selectedKind, searchText: searchText) }
+    }
+
+    func matchesFilters(_ kit: Kit, selectedKind: KitKind?, searchText: String) -> Bool {
+        let matchesKind = selectedKind == nil || kit.kitKind == selectedKind
+        let query = searchText.trimmingCharacters(in: .whitespacesAndNewlines)
+        let matchesSearch = query.isEmpty ||
+            kit.displayName.localizedCaseInsensitiveContains(query) ||
+            kit.kitKind.displayName.localizedCaseInsensitiveContains(query) ||
+            (kit.firearm?.displayName.localizedCaseInsensitiveContains(query) ?? false) ||
+            kit.components.contains { $0.displayName.localizedCaseInsensitiveContains(query) }
+        return matchesKind && matchesSearch
+    }
+
+    func totalValueText(for kits: [Kit]) -> String {
+        KitValueService.currencyText(for: kits.reduce(0) { $0 + $1.totalValueCents })
+    }
+
+    func countForKind(_ kind: KitKind, in kits: [Kit]) -> Int {
+        kits.count { $0.kitKind == kind }
+    }
+
+    func allKindsCountText(for kits: [Kit]) -> String {
+        String.localizedStringWithFormat(
+            String(localized: "All Kinds (%@)"),
+            kits.count.localizedCountString
+        )
+    }
+
+    func filterCountText(title: String, count: Int) -> String {
+        String.localizedStringWithFormat(
+            String(localized: "%@ (%@)"),
+            title,
+            count.localizedCountString
+        )
+    }
+
+    func componentSummaries(for kit: Kit) -> [KitComponentSummary] {
+        [
+            KitComponentSummary(title: String(localized: "Parts"), itemNames: itemNames(for: .part, in: kit)),
+            KitComponentSummary(title: String(localized: "Optics"), itemNames: itemNames(for: .optic, in: kit)),
+            KitComponentSummary(title: String(localized: "Attachments"), itemNames: itemNames(for: .attachment, in: kit))
+        ]
+        .filter { !$0.itemNames.isEmpty }
+    }
+
+    func reorderedKits(
+        allKits kits: [Kit],
+        filteredKits: [Kit],
+        selectedKind: KitKind?,
+        searchText: String,
+        source: IndexSet,
+        destination: Int
+    ) -> [Kit] {
+        let reorderedFilteredKits = movingItems(in: filteredKits, from: source, to: destination)
+
+        var reorderedFilteredIterator = reorderedFilteredKits.makeIterator()
+        return kits.map { kit in
+            guard matchesFilters(kit, selectedKind: selectedKind, searchText: searchText) else {
+                return kit
+            }
+
+            return reorderedFilteredIterator.next() ?? kit
+        }
+    }
+
+    func applySortOrder(to kits: [Kit]) {
+        for (index, kit) in kits.enumerated() {
+            kit.sortOrder = index
+        }
+    }
+
+    func moveKits(
+        allKits kits: [Kit],
+        filteredKits: [Kit],
+        selectedKind: KitKind?,
+        searchText: String,
+        source: IndexSet,
+        destination: Int,
+        in context: ModelContext
+    ) -> KitValidationResult {
+        let reorderedKits = reorderedKits(
+            allKits: kits,
+            filteredKits: filteredKits,
+            selectedKind: selectedKind,
+            searchText: searchText,
+            source: source,
+            destination: destination
+        )
+        applySortOrder(to: reorderedKits)
+
+        do {
+            try context.save()
+            UserDefaults.standard.set(Date(), forKey: "LastModelSaveDate")
+            return .valid
+        } catch {
+            return .invalid(error.localizedDescription)
+        }
+    }
+
+    private func itemNames(for category: KitComponentCategory, in kit: Kit) -> String {
+        kit.sortedComponents
+            .filter { $0.componentCategory == category }
+            .map(\.displayName)
+            .joined(separator: ", ")
+    }
+
+    private func movingItems(in kits: [Kit], from source: IndexSet, to destination: Int) -> [Kit] {
+        guard !source.isEmpty else {
+            return kits
+        }
+
+        var reorderedKits = kits
+        let sourceIndexes = source.sorted()
+        let movingKits = sourceIndexes.map { reorderedKits[$0] }
+
+        for index in sourceIndexes.reversed() {
+            reorderedKits.remove(at: index)
+        }
+
+        let insertionIndex = destination - sourceIndexes.count { $0 < destination }
+        reorderedKits.insert(contentsOf: movingKits, at: max(0, min(insertionIndex, reorderedKits.count)))
+        return reorderedKits
+    }
+}

--- a/ArmoryInventory/Accessories/Optics/OpticsView.swift
+++ b/ArmoryInventory/Accessories/Optics/OpticsView.swift
@@ -18,7 +18,10 @@ struct OpticsView: View {
     @State private var showingAddOptic = false
     @State private var selectedOptic: Optic?
     @State private var optics: [Optic] = []
+    @State private var kits: [Kit] = []
+    @State private var alertMessage: String?
 
+    private let viewModel = AccessoryInventoryListViewModel()
     private let inventoryListService: InventoryListServicing = AppServices.shared.resolve(InventoryListServicing.self)
 
     var body: some View {
@@ -125,66 +128,61 @@ struct OpticsView: View {
             AddOpticView(optic: optic, viewModel: AddOpticViewModel())
                 .presentationDetents([.large])
         }
+        .alert("Optic Cannot Be Deleted", isPresented: alertBinding) {
+            Button("OK", role: .cancel) {
+                alertMessage = nil
+            }
+        } message: {
+            Text(alertMessage ?? "")
+        }
     }
 
     private var groupedOptics: [String: [Optic]] {
-        Dictionary(grouping: optics, by: \.type).mapValues {
-            AccessoryItemSort.sorted($0, by: selectedItemSortOrder, direction: selectedItemSortDirection)
-        }
+        viewModel.groupedOptics(optics, sortOrderRaw: itemSortOrder, sortDirectionRaw: itemSortDirectionRaw)
     }
 
     private var groupedOpticTypes: [String] {
-        OpticTypeSort.displayOrder(for: Array(groupedOptics.keys))
+        viewModel.groupedOpticTypes(from: groupedOptics)
     }
 
     private func deleteOptics(at offsets: IndexSet, in type: String) {
-        guard let sectionOptics = groupedOptics[type] else {
-            return
-        }
-
-        for index in offsets {
-            context.delete(sectionOptics[index])
-        }
-        resequenceOptics()
-
-        do {
-            try context.save()
-            UserDefaults.standard.set(Date(), forKey: "LastModelSaveDate")
+        let result = viewModel.deleteOptics(
+            at: offsets,
+            in: type,
+            groupedOptics: groupedOptics,
+            allOptics: optics,
+            kits: kits,
+            context: context
+        )
+        if result.isValid {
             reloadOptics()
-        } catch {
-            print("Delete error: \(error)")
+        } else {
+            alertMessage = result.message
+            reloadOptics()
         }
     }
 
     private func reloadOptics() {
         do {
             optics = try inventoryListService.fetchOptics(in: context)
+            kits = try inventoryListService.fetchKits(in: context)
         } catch {
             print("Optics fetch error: \(error)")
         }
     }
 
-    private func resequenceOptics() {
-        for (index, optic) in optics.enumerated() {
-            optic.sortOrder = index
-        }
-    }
-
     private var totalValueText: String {
-        let totalCents = optics.reduce(0) { $0 + max(0, $1.purchasePriceCents) }
-        let amount = Decimal(totalCents) / 100
-        return amount.formatted(.currency(code: Locale.current.currency?.identifier ?? "USD"))
+        viewModel.totalValueText(for: optics)
     }
 
     private func opticTypeDisplayName(for typeID: String) -> String {
-        OpticType(rawValue: typeID)?.displayName ?? typeID
+        viewModel.opticTypeDisplayName(for: typeID)
     }
 
-    private var selectedItemSortOrder: AccessoryItemSortOrder {
-        AccessoryItemSortOrder(rawValue: itemSortOrder) ?? .manual
-    }
-
-    private var selectedItemSortDirection: AccessoryItemSortDirection {
-        AccessoryItemSortDirection(rawValue: itemSortDirectionRaw) ?? AccessoryItemSort.preferredDirection(for: selectedItemSortOrder)
+    private var alertBinding: Binding<Bool> {
+        Binding(
+            get: { alertMessage != nil },
+            set: { if !$0 { alertMessage = nil } }
+        )
     }
 }

--- a/ArmoryInventory/Accessories/Parts/PartsView.swift
+++ b/ArmoryInventory/Accessories/Parts/PartsView.swift
@@ -18,7 +18,10 @@ struct PartsView: View {
     @State private var showingAddPart = false
     @State private var selectedPart: Part?
     @State private var parts: [Part] = []
+    @State private var kits: [Kit] = []
+    @State private var alertMessage: String?
 
+    private let viewModel = AccessoryInventoryListViewModel()
     private let inventoryListService: InventoryListServicing = AppServices.shared.resolve(InventoryListServicing.self)
 
     var body: some View {
@@ -108,66 +111,61 @@ struct PartsView: View {
             AddPartView(part: part, viewModel: AddPartViewModel())
                 .presentationDetents([.large])
         }
+        .alert("Part Cannot Be Deleted", isPresented: alertBinding) {
+            Button("OK", role: .cancel) {
+                alertMessage = nil
+            }
+        } message: {
+            Text(alertMessage ?? "")
+        }
     }
 
     private var groupedParts: [String: [Part]] {
-        Dictionary(grouping: parts, by: \.type).mapValues {
-            AccessoryItemSort.sorted($0, by: selectedItemSortOrder, direction: selectedItemSortDirection)
-        }
+        viewModel.groupedParts(parts, sortOrderRaw: itemSortOrder, sortDirectionRaw: itemSortDirectionRaw)
     }
 
     private var groupedPartTypes: [String] {
-        PartTypeSort.displayOrder(for: Array(groupedParts.keys))
+        viewModel.groupedPartTypes(from: groupedParts)
     }
 
     private func deleteParts(at offsets: IndexSet, in type: String) {
-        guard let sectionParts = groupedParts[type] else {
-            return
-        }
-
-        for index in offsets {
-            context.delete(sectionParts[index])
-        }
-        resequenceParts()
-
-        do {
-            try context.save()
-            UserDefaults.standard.set(Date(), forKey: "LastModelSaveDate")
+        let result = viewModel.deleteParts(
+            at: offsets,
+            in: type,
+            groupedParts: groupedParts,
+            allParts: parts,
+            kits: kits,
+            context: context
+        )
+        if result.isValid {
             reloadParts()
-        } catch {
-            print("Delete error: \(error)")
+        } else {
+            alertMessage = result.message
+            reloadParts()
         }
     }
 
     private func reloadParts() {
         do {
             parts = try inventoryListService.fetchParts(in: context)
+            kits = try inventoryListService.fetchKits(in: context)
         } catch {
             print("Parts fetch error: \(error)")
         }
     }
 
-    private func resequenceParts() {
-        for (index, part) in parts.enumerated() {
-            part.sortOrder = index
-        }
-    }
-
     private var totalValueText: String {
-        let totalCents = parts.reduce(0) { $0 + max(0, $1.purchasePriceCents) }
-        let amount = Decimal(totalCents) / 100
-        return amount.formatted(.currency(code: Locale.current.currency?.identifier ?? "USD"))
+        viewModel.totalValueText(for: parts)
     }
 
     private func partTypeDisplayName(for typeID: String) -> String {
-        PartType(rawValue: typeID)?.displayName ?? typeID
+        viewModel.partTypeDisplayName(for: typeID)
     }
 
-    private var selectedItemSortOrder: AccessoryItemSortOrder {
-        AccessoryItemSortOrder(rawValue: itemSortOrder) ?? .manual
-    }
-
-    private var selectedItemSortDirection: AccessoryItemSortDirection {
-        AccessoryItemSortDirection(rawValue: itemSortDirectionRaw) ?? AccessoryItemSort.preferredDirection(for: selectedItemSortOrder)
+    private var alertBinding: Binding<Bool> {
+        Binding(
+            get: { alertMessage != nil },
+            set: { if !$0 { alertMessage = nil } }
+        )
     }
 }

--- a/ArmoryInventory/ArmoryInventory.swift
+++ b/ArmoryInventory/ArmoryInventory.swift
@@ -58,6 +58,9 @@ struct ArmoryInventory: App {
             Magazine.self,
             Attachment.self,
             Part.self,
+            Kit.self,
+            KitComponent.self,
+            KitHistoryRecord.self,
         ])
         let storeURL = URL.applicationSupportDirectory
             .appending(path: "ArmoryInventory.store")
@@ -121,6 +124,20 @@ struct ArmoryInventory: App {
         if let parts = try? context.fetch(FetchDescriptor<Part>()) {
             for part in parts where part.id == nil {
                 part.id = UUID()
+                didChange = true
+            }
+        }
+
+        if let kits = try? context.fetch(FetchDescriptor<Kit>()) {
+            for kit in kits where kit.id == nil {
+                kit.id = UUID()
+                didChange = true
+            }
+        }
+
+        if let components = try? context.fetch(FetchDescriptor<KitComponent>()) {
+            for component in components where component.id == nil {
+                component.id = UUID()
                 didChange = true
             }
         }

--- a/ArmoryInventory/Firearms/AddFirearmView.swift
+++ b/ArmoryInventory/Firearms/AddFirearmView.swift
@@ -290,12 +290,8 @@ struct AddFirearmView: View {
                         Text("Add optics first to link them to this firearm.")
                             .font(.footnote)
                             .foregroundStyle(.secondary)
-                    } else if availableOptics.isEmpty {
-                        Text("No unlinked optics available.")
-                            .font(.footnote)
-                            .foregroundStyle(.secondary)
                     } else if effectiveOptics.isEmpty {
-                        Text("No optics linked.")
+                        Text(availableOptics.isEmpty ? "No unlinked optics available." : "No optics linked.")
                             .font(.footnote)
                             .foregroundStyle(.secondary)
                     } else {
@@ -389,12 +385,8 @@ struct AddFirearmView: View {
                         Text("Add attachments first to link them to this firearm.")
                             .font(.footnote)
                             .foregroundStyle(.secondary)
-                    } else if availableAttachments.isEmpty {
-                        Text("No unlinked attachments available.")
-                            .font(.footnote)
-                            .foregroundStyle(.secondary)
                     } else if effectiveAttachments.isEmpty {
-                        Text("No attachments linked.")
+                        Text(availableAttachments.isEmpty ? "No unlinked attachments available." : "No attachments linked.")
                             .font(.footnote)
                             .foregroundStyle(.secondary)
                     } else {
@@ -429,12 +421,8 @@ struct AddFirearmView: View {
                         Text("Add parts first to link them to this firearm.")
                             .font(.footnote)
                             .foregroundStyle(.secondary)
-                    } else if availableParts.isEmpty {
-                        Text("No unlinked parts available.")
-                            .font(.footnote)
-                            .foregroundStyle(.secondary)
                     } else if effectiveParts.isEmpty {
-                        Text("No parts linked.")
+                        Text(availableParts.isEmpty ? "No unlinked parts available." : "No parts linked.")
                             .font(.footnote)
                             .foregroundStyle(.secondary)
                     } else {

--- a/ArmoryInventory/Firearms/AddFirearmView.swift
+++ b/ArmoryInventory/Firearms/AddFirearmView.swift
@@ -35,13 +35,16 @@ struct AddFirearmView: View {
     @State private var selectedMagazinePatterns: [FirearmMagazinePatternReference] = []
     @State private var selectedAttachmentIDs: Set<PersistentIdentifier> = []
     @State private var selectedPartIDs: Set<PersistentIdentifier> = []
+    @State private var selectedKitIDs: Set<PersistentIdentifier> = []
     @State private var showingOpticsPicker = false
     @State private var showingMagazinePatternsPicker = false
     @State private var showingAttachmentsPicker = false
     @State private var showingPartsPicker = false
+    @State private var showingKitsPicker = false
     @State private var showingAddCaliber = false
     @State private var isEditing = false
     @State private var lookupData = AddFirearmLookupData()
+    @State private var hasLoadedInitialKits = false
     @State private var snapshotErrorMessage: String?
 
     let viewModel: AddFirearmViewModel
@@ -236,6 +239,44 @@ struct AddFirearmView: View {
                 }
                 .disabled(isReadOnly)
 
+                if firearm != nil {
+                    Section("Linked Kits") {
+                        if isEditing {
+                            Button {
+                                showingKitsPicker = true
+                            } label: {
+                                Label(
+                                    selectedKitIDs.isEmpty ? String(localized: "Add Kits") : String(localized: "Manage Kits"),
+                                    systemImage: "shippingbox.fill"
+                                )
+                            }
+                        }
+
+                        if lookupData.kits.isEmpty {
+                            Text("Build kits first to link them to this firearm.")
+                                .font(.footnote)
+                                .foregroundStyle(.secondary)
+                        } else if availableKits.isEmpty {
+                            Text("No built kits available.")
+                                .font(.footnote)
+                                .foregroundStyle(.secondary)
+                        } else if resolvedKits.isEmpty {
+                            Text("No kits linked.")
+                                .font(.footnote)
+                                .foregroundStyle(.secondary)
+                        } else {
+                            ForEach(resolvedKits) { kit in
+                                VStack(alignment: .leading, spacing: 2) {
+                                    Text(kit.displayName)
+                                    Text("\(kit.kitKind.displayName) • \(kit.componentCountText)")
+                                        .font(.footnote)
+                                        .foregroundStyle(.secondary)
+                                }
+                            }
+                        }
+                    }
+                }
+
                 Section("Linked Optics") {
                     if isEditing {
                         Button {
@@ -253,7 +294,7 @@ struct AddFirearmView: View {
                         Text("No unlinked optics available.")
                             .font(.footnote)
                             .foregroundStyle(.secondary)
-                    } else if resolvedOptics.isEmpty {
+                    } else if effectiveOptics.isEmpty {
                         Text("No optics linked.")
                             .font(.footnote)
                             .foregroundStyle(.secondary)
@@ -265,6 +306,13 @@ struct AddFirearmView: View {
                                     .font(.footnote)
                                     .foregroundStyle(.secondary)
                             }
+                        }
+                        ForEach(managedOptics) { optic in
+                            ManagedItemRow(
+                                title: optic.displayName,
+                                subtitle: "\(optic.opticType.displayName) • \(optic.magnificationText)",
+                                kitName: managingKitName(for: optic)
+                            )
                         }
                     }
                 }
@@ -345,7 +393,7 @@ struct AddFirearmView: View {
                         Text("No unlinked attachments available.")
                             .font(.footnote)
                             .foregroundStyle(.secondary)
-                    } else if resolvedAttachments.isEmpty {
+                    } else if effectiveAttachments.isEmpty {
                         Text("No attachments linked.")
                             .font(.footnote)
                             .foregroundStyle(.secondary)
@@ -357,6 +405,13 @@ struct AddFirearmView: View {
                                     .font(.footnote)
                                     .foregroundStyle(.secondary)
                             }
+                        }
+                        ForEach(managedAttachments) { attachment in
+                            ManagedItemRow(
+                                title: attachment.displayName,
+                                subtitle: attachment.typeDisplayName,
+                                kitName: managingKitName(for: attachment)
+                            )
                         }
                     }
                 }
@@ -378,7 +433,7 @@ struct AddFirearmView: View {
                         Text("No unlinked parts available.")
                             .font(.footnote)
                             .foregroundStyle(.secondary)
-                    } else if resolvedParts.isEmpty {
+                    } else if effectiveParts.isEmpty {
                         Text("No parts linked.")
                             .font(.footnote)
                             .foregroundStyle(.secondary)
@@ -390,6 +445,13 @@ struct AddFirearmView: View {
                                     .font(.footnote)
                                     .foregroundStyle(.secondary)
                             }
+                        }
+                        ForEach(managedParts) { part in
+                            ManagedItemRow(
+                                title: part.displayName,
+                                subtitle: part.typeDisplayName,
+                                kitName: managingKitName(for: part)
+                            )
                         }
                     }
                 }
@@ -492,6 +554,57 @@ struct AddFirearmView: View {
                         ToolbarItem(placement: .cancellationAction) {
                             Button("Done") {
                                 showingOpticsPicker = false
+                            }
+                        }
+                    }
+                }
+                .presentationDetents([.medium, .large])
+            }
+            .sheet(isPresented: $showingKitsPicker) {
+                NavigationStack {
+                    Group {
+                        if availableKits.isEmpty {
+                            ContentUnavailableView(
+                                "No Kits Available",
+                                systemImage: "shippingbox.fill",
+                                description: Text("Only built kits not linked to another firearm can be selected.")
+                            )
+                        } else {
+                            List {
+                                ForEach(availableKits) { kit in
+                                    Button {
+                                        toggleKitSelection(for: kit)
+                                    } label: {
+                                        HStack {
+                                            VStack(alignment: .leading, spacing: 2) {
+                                                Text(kit.displayName)
+                                                    .foregroundStyle(.primary)
+                                                Text("\(kit.kitKind.displayName) • \(kit.componentCountText)")
+                                                    .font(.footnote)
+                                                    .foregroundStyle(.secondary)
+                                            }
+                                            Spacer()
+                                            if selectedKitIDs.contains(kit.persistentModelID) {
+                                                Image(systemName: "checkmark.circle.fill")
+                                                    .foregroundStyle(.tint)
+                                            } else {
+                                                Image(systemName: "circle")
+                                                    .foregroundStyle(.tertiary)
+                                            }
+                                        }
+                                        .contentShape(Rectangle())
+                                    }
+                                    .buttonStyle(.plain)
+                                }
+                            }
+                        }
+                    }
+                    .navigationTitle("Link Kits")
+                    .navigationBarTitleDisplayMode(.inline)
+                    .toolbar {
+                        ToolbarItem(placement: .cancellationAction) {
+                            Button("Done") {
+                                showingKitsPicker = false
                             }
                         }
                     }
@@ -711,8 +824,36 @@ struct AddFirearmView: View {
         viewModel.resolvedParts(from: lookupData.parts, selectedIDs: selectedPartIDs)
     }
 
+    private var resolvedKits: [Kit] {
+        viewModel.linkedKits(from: lookupData.kits, selectedIDs: selectedKitIDs)
+    }
+
+    private var managedOptics: [Optic] {
+        viewModel.managedOptics(from: resolvedKits)
+    }
+
+    private var managedAttachments: [Attachment] {
+        viewModel.managedAttachments(from: resolvedKits)
+    }
+
+    private var managedParts: [Part] {
+        viewModel.managedParts(from: resolvedKits)
+    }
+
+    private var effectiveOptics: [Optic] {
+        viewModel.effectiveOptics(resolvedOptics: resolvedOptics, managedOptics: managedOptics)
+    }
+
+    private var effectiveAttachments: [Attachment] {
+        viewModel.effectiveAttachments(resolvedAttachments: resolvedAttachments, managedAttachments: managedAttachments)
+    }
+
+    private var effectiveParts: [Part] {
+        viewModel.effectiveParts(resolvedParts: resolvedParts, managedParts: managedParts)
+    }
+
     private var availableOptics: [Optic] {
-        viewModel.availableOptics(from: lookupData.optics, selectedIDs: selectedOpticIDs, firearm: firearm)
+        viewModel.availableOptics(from: lookupData.optics, selectedIDs: selectedOpticIDs, firearm: firearm, kits: lookupData.kits)
     }
 
     private var selectedMagazineCompatibilityMessage: String? {
@@ -737,11 +878,15 @@ struct AddFirearmView: View {
     }
 
     private var availableAttachments: [Attachment] {
-        viewModel.availableAttachments(from: lookupData.attachments, selectedIDs: selectedAttachmentIDs, firearm: firearm)
+        viewModel.availableAttachments(from: lookupData.attachments, selectedIDs: selectedAttachmentIDs, firearm: firearm, kits: lookupData.kits)
     }
 
     private var availableParts: [Part] {
-        viewModel.availableParts(from: lookupData.parts, selectedIDs: selectedPartIDs, firearm: firearm)
+        viewModel.availableParts(from: lookupData.parts, selectedIDs: selectedPartIDs, firearm: firearm, kits: lookupData.kits)
+    }
+
+    private var availableKits: [Kit] {
+        viewModel.availableKits(from: lookupData.kits, selectedIDs: selectedKitIDs, firearm: firearm)
     }
 
     private var duplicateExists: Bool {
@@ -757,32 +902,30 @@ struct AddFirearmView: View {
     }
 
     private var showsPostTaxTotalSection: Bool {
-        firearm != nil && showValueInDetails
+        viewModel.showsPostTaxTotalSection(hasFirearm: firearm != nil, showValueInDetails: showValueInDetails)
     }
 
     private var totalValueWithTaxText: String {
-        let firearmTotalCents = taxedAmountCents(
-            baseAmountCents: max(0, resolvedPurchasePriceCents ?? 0),
-            taxRate: taxRateProvider.firearmsTaxRate
+        viewModel.totalValueWithTaxText(
+            firearmPriceCents: resolvedPurchasePriceCents ?? 0,
+            accessoriesSubtotalCents: accessoriesSubtotalCents,
+            firearmsTaxRate: taxRateProvider.firearmsTaxRate,
+            accessoriesTaxRate: taxRateProvider.accessoriesTaxRate
         )
-        let accessoriesTotalCents = taxedAmountCents(
-            baseAmountCents: accessoriesSubtotalCents,
-            taxRate: taxRateProvider.accessoriesTaxRate
-        )
-        let amount = Decimal(firearmTotalCents + accessoriesTotalCents) / 100
-        return amount.formatted(.currency(code: Locale.current.currency?.identifier ?? "USD"))
     }
 
     private var accessoriesSubtotalCents: Int {
-        let opticsTotal = resolvedOptics.reduce(0) { $0 + max(0, $1.purchasePriceCents) }
-        let magazinesTotal = resolvedMagazines.reduce(0) { $0 + max(0, $1.purchasePriceCents) }
-        let attachmentsTotal = resolvedAttachments.reduce(0) { $0 + max(0, $1.purchasePriceCents) }
-        let partsTotal = resolvedParts.reduce(0) { $0 + max(0, $1.purchasePriceCents) }
-        return opticsTotal + magazinesTotal + attachmentsTotal + partsTotal
+        viewModel.accessoriesSubtotalCents(
+            optics: effectiveOptics,
+            magazines: resolvedMagazines,
+            attachments: effectiveAttachments,
+            parts: effectiveParts
+        )
     }
 
     private var currentFirearmForSummary: Firearm {
-        firearm ?? Firearm(
+        viewModel.currentFirearmForSummary(
+            firearm: firearm,
             brand: brand,
             modelName: modelName,
             purchasePriceCents: resolvedPurchasePriceCents ?? 0,
@@ -818,13 +961,13 @@ struct AddFirearmView: View {
     private func reloadLookupData() {
         do {
             lookupData = try lookupService.fetchLookupData(in: context)
+            if !hasLoadedInitialKits {
+                selectedKitIDs = viewModel.selectedKitIDs(for: firearm, kits: lookupData.kits)
+                hasLoadedInitialKits = true
+            }
         } catch {
             print("Lookup fetch error: \(error)")
         }
-    }
-
-    private func taxedAmountCents(baseAmountCents: Int, taxRate: Double) -> Int {
-        Int((Double(baseAmountCents) * (1 + max(0, taxRate) / 100)).rounded())
     }
 
     private func patternDetailText(for pattern: FirearmMagazinePatternReference) -> String {
@@ -893,6 +1036,7 @@ struct AddFirearmView: View {
         guard didSave else {
             return
         }
+        saveKitLinks()
         if firearm == nil {
             dismiss()
         } else {
@@ -905,14 +1049,11 @@ struct AddFirearmView: View {
             return
         }
 
-        context.delete(firearm)
-
-        do {
-            try context.save()
-            UserDefaults.standard.set(Date(), forKey: "LastModelSaveDate")
+        let result = viewModel.deleteFirearm(firearm, in: context)
+        if result.isValid {
             dismiss()
-        } catch {
-            print("Delete error: \(error)")
+        } else {
+            print("Delete error: \(result.message ?? "")")
         }
     }
 
@@ -956,6 +1097,44 @@ struct AddFirearmView: View {
         )
     }
 
+    private func toggleKitSelection(for kit: Kit) {
+        selectedKitIDs = viewModel.toggledSelection(
+            currentSelection: selectedKitIDs,
+            itemID: kit.persistentModelID,
+            isEditing: isEditing
+        )
+    }
+
+    private func saveKitLinks() {
+        guard let firearm else {
+            return
+        }
+
+        let result = viewModel.saveKitLinks(
+            firearm: firearm,
+            selectedKitIDs: selectedKitIDs,
+            kits: lookupData.kits,
+            in: context
+        )
+        if result.isValid {
+            reloadLookupData()
+        } else {
+            print("Kit link save error: \(result.message ?? "")")
+        }
+    }
+
+    private func managingKitName(for optic: Optic) -> String {
+        viewModel.managingKitName(for: optic, kits: resolvedKits)
+    }
+
+    private func managingKitName(for attachment: Attachment) -> String {
+        viewModel.managingKitName(for: attachment, kits: resolvedKits)
+    }
+
+    private func managingKitName(for part: Part) -> String {
+        viewModel.managingKitName(for: part, kits: resolvedKits)
+    }
+
     private var snapshotErrorBinding: Binding<Bool> {
         Binding(
             get: { snapshotErrorMessage != nil },
@@ -986,10 +1165,10 @@ struct AddFirearmView: View {
             hidesSerialNumber: true,
             showsValue: showValueInDetails,
             totalValueText: totalValueWithTaxText,
-            optics: resolvedOptics,
+            optics: effectiveOptics,
             magazines: resolvedMagazines,
-            attachments: resolvedAttachments,
-            parts: resolvedParts
+            attachments: effectiveAttachments,
+            parts: effectiveParts
         )
         .frame(width: 1080)
         .background(Color.white)
@@ -1038,6 +1217,31 @@ private enum FirearmSnapshotError: LocalizedError {
         case .presentationFailed:
             return String(localized: "The share sheet could not be presented.")
         }
+    }
+}
+
+private struct ManagedItemRow: View {
+    let title: String
+    let subtitle: String
+    let kitName: String
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 2) {
+            Text(title)
+                .foregroundStyle(.secondary)
+            Text(managedSubtitle)
+                .font(.footnote)
+                .foregroundStyle(.secondary)
+        }
+        .disabled(true)
+    }
+
+    private var managedSubtitle: String {
+        String.localizedStringWithFormat(
+            String(localized: "%@ • Managed by %@"),
+            subtitle,
+            kitName
+        )
     }
 }
 

--- a/ArmoryInventory/Firearms/AddFirearmViewModel.swift
+++ b/ArmoryInventory/Firearms/AddFirearmViewModel.swift
@@ -389,11 +389,8 @@ final class AddFirearmViewModel {
             if selectedIDs.contains(kit.persistentModelID) {
                 return true
             }
-            guard kit.kitStatus == .built else {
-                return false
-            }
             guard let linkedFirearm = kit.firearm else {
-                return true
+                return kit.kitStatus == .built
             }
             guard let firearm else {
                 return false

--- a/ArmoryInventory/Firearms/AddFirearmViewModel.swift
+++ b/ArmoryInventory/Firearms/AddFirearmViewModel.swift
@@ -723,9 +723,18 @@ final class AddFirearmViewModel {
     }
 
     func deleteFirearm(_ firearm: Firearm, in context: ModelContext) -> KitValidationResult {
-        context.delete(firearm)
-
         do {
+            let linkedKits = try context.fetch(FetchDescriptor<Kit>()).filter {
+                $0.firearm?.persistentModelID == firearm.persistentModelID
+            }
+
+            for kit in linkedKits {
+                kit.firearm = nil
+                kit.status = KitStatus.built.rawValue
+                kit.updatedAt = .now
+            }
+
+            context.delete(firearm)
             try context.save()
             UserDefaults.standard.set(Date(), forKey: "LastModelSaveDate")
             return .valid

--- a/ArmoryInventory/Firearms/AddFirearmViewModel.swift
+++ b/ArmoryInventory/Firearms/AddFirearmViewModel.swift
@@ -56,6 +56,13 @@ final class AddFirearmViewModel {
         Set(firearm?.parts.map(\.persistentModelID) ?? [])
     }
 
+    func selectedKitIDs(for firearm: Firearm?, kits: [Kit]) -> Set<PersistentIdentifier> {
+        guard let firearm else {
+            return []
+        }
+        return Set(kits.filter { $0.firearm?.persistentModelID == firearm.persistentModelID }.map(\.persistentModelID))
+    }
+
     func trimmedValue(_ value: String) -> String {
         value.trimmingCharacters(in: .whitespacesAndNewlines)
     }
@@ -176,11 +183,17 @@ final class AddFirearmViewModel {
     func availableOptics(
         from optics: [Optic],
         selectedIDs: Set<PersistentIdentifier>,
-        firearm: Firearm?
+        firearm: Firearm?,
+        kits: [Kit]
     ) -> [Optic] {
-        optics.filter { optic in
+        let eligibilityService = KitEligibilityService()
+        return optics.filter { optic in
             if selectedIDs.contains(optic.persistentModelID) {
                 return true
+            }
+
+            guard !eligibilityService.isReserved(optic, by: kits, excluding: nil) else {
+                return false
             }
 
             guard let linkedFirearm = optic.firearm else {
@@ -271,11 +284,17 @@ final class AddFirearmViewModel {
     func availableAttachments(
         from attachments: [Attachment],
         selectedIDs: Set<PersistentIdentifier>,
-        firearm: Firearm?
+        firearm: Firearm?,
+        kits: [Kit]
     ) -> [Attachment] {
-        attachments.filter { attachment in
+        let eligibilityService = KitEligibilityService()
+        return attachments.filter { attachment in
             if selectedIDs.contains(attachment.persistentModelID) {
                 return true
+            }
+
+            guard !eligibilityService.isReserved(attachment, by: kits, excluding: nil) else {
+                return false
             }
 
             guard let linkedFirearm = attachment.firearm else {
@@ -293,11 +312,17 @@ final class AddFirearmViewModel {
     func availableParts(
         from parts: [Part],
         selectedIDs: Set<PersistentIdentifier>,
-        firearm: Firearm?
+        firearm: Firearm?,
+        kits: [Kit]
     ) -> [Part] {
-        parts.filter { part in
+        let eligibilityService = KitEligibilityService()
+        return parts.filter { part in
             if selectedIDs.contains(part.persistentModelID) {
                 return true
+            }
+
+            guard !eligibilityService.isReserved(part, by: kits, excluding: nil) else {
+                return false
             }
 
             guard let linkedFirearm = part.firearm else {
@@ -351,12 +376,118 @@ final class AddFirearmViewModel {
         }
     }
 
+    func linkedKits(from kits: [Kit], selectedIDs: Set<PersistentIdentifier>) -> [Kit] {
+        kits.filter { selectedIDs.contains($0.persistentModelID) }
+    }
+
+    func availableKits(
+        from kits: [Kit],
+        selectedIDs: Set<PersistentIdentifier>,
+        firearm: Firearm?
+    ) -> [Kit] {
+        kits.filter { kit in
+            if selectedIDs.contains(kit.persistentModelID) {
+                return true
+            }
+            guard kit.kitStatus == .built else {
+                return false
+            }
+            guard let linkedFirearm = kit.firearm else {
+                return true
+            }
+            guard let firearm else {
+                return false
+            }
+            return linkedFirearm.persistentModelID == firearm.persistentModelID
+        }
+    }
+
+    func managedOptics(from kits: [Kit]) -> [Optic] {
+        kits.flatMap(\.components).compactMap(\.optic)
+    }
+
+    func managedAttachments(from kits: [Kit]) -> [Attachment] {
+        kits.flatMap(\.components).compactMap(\.attachment)
+    }
+
+    func managedParts(from kits: [Kit]) -> [Part] {
+        kits.flatMap(\.components).compactMap(\.part)
+    }
+
+    func effectiveOptics(resolvedOptics: [Optic], managedOptics: [Optic]) -> [Optic] {
+        resolvedOptics + managedOptics.filter { managed in
+            !resolvedOptics.contains { $0.persistentModelID == managed.persistentModelID }
+        }
+    }
+
+    func effectiveAttachments(resolvedAttachments: [Attachment], managedAttachments: [Attachment]) -> [Attachment] {
+        resolvedAttachments + managedAttachments.filter { managed in
+            !resolvedAttachments.contains { $0.persistentModelID == managed.persistentModelID }
+        }
+    }
+
+    func effectiveParts(resolvedParts: [Part], managedParts: [Part]) -> [Part] {
+        resolvedParts + managedParts.filter { managed in
+            !resolvedParts.contains { $0.persistentModelID == managed.persistentModelID }
+        }
+    }
+
+    func accessoriesSubtotalCents(
+        optics: [Optic],
+        magazines: [Magazine],
+        attachments: [Attachment],
+        parts: [Part]
+    ) -> Int {
+        let opticsTotal = optics.reduce(0) { $0 + max(0, $1.purchasePriceCents) }
+        let magazinesTotal = magazines.reduce(0) { $0 + max(0, $1.purchasePriceCents) }
+        let attachmentsTotal = attachments.reduce(0) { $0 + max(0, $1.purchasePriceCents) }
+        let partsTotal = parts.reduce(0) { $0 + max(0, $1.purchasePriceCents) }
+        return opticsTotal + magazinesTotal + attachmentsTotal + partsTotal
+    }
+
     func isReadOnly(hasFirearm: Bool, isEditing: Bool) -> Bool {
         hasFirearm && !isEditing
     }
 
     func showsPurchaseSection(showValueInDetails: Bool, isReadOnly: Bool) -> Bool {
         showValueInDetails || !isReadOnly
+    }
+
+    func showsPostTaxTotalSection(hasFirearm: Bool, showValueInDetails: Bool) -> Bool {
+        hasFirearm && showValueInDetails
+    }
+
+    func totalValueWithTaxText(
+        firearmPriceCents: Int,
+        accessoriesSubtotalCents: Int,
+        firearmsTaxRate: Double,
+        accessoriesTaxRate: Double
+    ) -> String {
+        let firearmTotalCents = taxedAmountCents(baseAmountCents: max(0, firearmPriceCents), taxRate: firearmsTaxRate)
+        let accessoriesTotalCents = taxedAmountCents(baseAmountCents: accessoriesSubtotalCents, taxRate: accessoriesTaxRate)
+        let amount = Decimal(firearmTotalCents + accessoriesTotalCents) / 100
+        return amount.formatted(.currency(code: Locale.current.currency?.identifier ?? "USD"))
+    }
+
+    func taxedAmountCents(baseAmountCents: Int, taxRate: Double) -> Int {
+        Int((Double(baseAmountCents) * (1 + max(0, taxRate) / 100)).rounded())
+    }
+
+    func currentFirearmForSummary(
+        firearm: Firearm?,
+        brand: String,
+        modelName: String,
+        purchasePriceCents: Int,
+        type: FirearmType,
+        action: FirearmAction
+    ) -> Firearm {
+        firearm ?? Firearm(
+            brand: brand,
+            modelName: modelName,
+            purchasePriceCents: purchasePriceCents,
+            type: type,
+            action: action
+        )
     }
 
     func primaryButtonTitle(hasFirearm: Bool, isEditing: Bool) -> String {
@@ -589,6 +720,61 @@ final class AddFirearmViewModel {
             print("Save error: \(error)")
             return false
         }
+    }
+
+    func deleteFirearm(_ firearm: Firearm, in context: ModelContext) -> KitValidationResult {
+        context.delete(firearm)
+
+        do {
+            try context.save()
+            UserDefaults.standard.set(Date(), forKey: "LastModelSaveDate")
+            return .valid
+        } catch {
+            return .invalid(error.localizedDescription)
+        }
+    }
+
+    func saveKitLinks(firearm: Firearm, selectedKitIDs: Set<PersistentIdentifier>, kits: [Kit], in context: ModelContext) -> KitValidationResult {
+        for kit in kits {
+            let isSelected = selectedKitIDs.contains(kit.persistentModelID)
+            let isLinkedHere = kit.firearm?.persistentModelID == firearm.persistentModelID
+
+            if isSelected {
+                kit.firearm = firearm
+                kit.status = KitStatus.linked.rawValue
+                kit.updatedAt = .now
+            } else if isLinkedHere {
+                kit.firearm = nil
+                kit.status = KitStatus.built.rawValue
+                kit.updatedAt = .now
+            }
+        }
+
+        do {
+            try context.save()
+            UserDefaults.standard.set(Date(), forKey: "LastModelSaveDate")
+            return .valid
+        } catch {
+            return .invalid(error.localizedDescription)
+        }
+    }
+
+    func managingKitName(for optic: Optic, kits: [Kit]) -> String {
+        kits.first { kit in
+            kit.components.contains { $0.optic?.persistentModelID == optic.persistentModelID }
+        }?.displayName ?? String(localized: "Kit")
+    }
+
+    func managingKitName(for attachment: Attachment, kits: [Kit]) -> String {
+        kits.first { kit in
+            kit.components.contains { $0.attachment?.persistentModelID == attachment.persistentModelID }
+        }?.displayName ?? String(localized: "Kit")
+    }
+
+    func managingKitName(for part: Part, kits: [Kit]) -> String {
+        kits.first { kit in
+            kit.components.contains { $0.part?.persistentModelID == part.persistentModelID }
+        }?.displayName ?? String(localized: "Kit")
     }
 
     private func effectiveSelectedMagazinePatterns(

--- a/ArmoryInventory/Firearms/FirearmModels.swift
+++ b/ArmoryInventory/Firearms/FirearmModels.swift
@@ -256,7 +256,7 @@ final class Firearm {
     var subtitle: String {
         if let nickname, !nickname.isEmpty {
             return String.localizedStringWithFormat(
-                String(localized: "“%@”"),
+                String(localized: "\"%@\""),
                 nickname
             )
         }
@@ -278,7 +278,7 @@ final class Firearm {
         let formattedValue = barrelLengthInches.formatted(
             .number.precision(.fractionLength(0...2))
         )
-        return "\(formattedValue) \(String(localized: "in."))"
+        return "\(formattedValue) \(String(localized: "in"))"
     }
 
     var purchasePriceText: String {

--- a/ArmoryInventory/Firearms/FirearmsView.swift
+++ b/ArmoryInventory/Firearms/FirearmsView.swift
@@ -23,9 +23,12 @@ struct FirearmsView: View {
     @State private var selectedActionFilter: FirearmAction?
     @State private var selectedCaliberFilter: Caliber?
     @State private var firearms: [Firearm] = []
+    @State private var kits: [Kit] = []
+    @State private var magazines: [Magazine] = []
     @State private var showsExpandedCards = false
     @State private var draggedFirearm: Firearm?
 
+    private let viewModel = FirearmsViewModel()
     private let inventoryListService: InventoryListServicing = AppServices.shared.resolve(InventoryListServicing.self)
 
     var body: some View {
@@ -47,6 +50,7 @@ struct FirearmsView: View {
                                     firearm: firearm,
                                     showsExpandedCards: showsExpandedCards,
                                     showValueInCard: showValueInCard,
+                                    effectiveValueCents: viewModel.effectiveValueCents(for: firearm, kits: kits, magazines: magazines),
                                     onTap: {
                                         selectedFirearm = firearm
                                     },
@@ -132,21 +136,6 @@ struct FirearmsView: View {
         }
     }
 
-    private func deleteFirearms(at offsets: IndexSet) {
-        for index in offsets {
-            context.delete(filteredFirearms[index])
-        }
-        resequenceFirearms()
-
-        do {
-            try context.save()
-            UserDefaults.standard.set(Date(), forKey: "LastModelSaveDate")
-            reloadFirearms()
-        } catch {
-            print("Delete error: \(error)")
-        }
-    }
-
     @ViewBuilder
     private var filtersCard: some View {
         VStack(alignment: .leading, spacing: 12) {
@@ -178,7 +167,7 @@ struct FirearmsView: View {
                             }
 
                             ForEach(FirearmType.allCases) { firearmType in
-                                Button(filterCountText(title: firearmType.displayName, count: countForType(firearmType))) {
+                                Button(viewModel.filterCountText(title: firearmType.displayName, count: viewModel.countForType(firearmType, in: firearms))) {
                                     selectedTypeFilter = firearmType
                                 }
                             }
@@ -193,7 +182,7 @@ struct FirearmsView: View {
                             }
 
                             ForEach(FirearmAction.allCases) { action in
-                                Button(filterCountText(title: action.displayName, count: countForAction(action))) {
+                                Button(viewModel.filterCountText(title: action.displayName, count: viewModel.countForAction(action, in: firearms))) {
                                     selectedActionFilter = action
                                 }
                             }
@@ -207,8 +196,8 @@ struct FirearmsView: View {
                                 selectedCaliberFilter = nil
                             }
 
-                            ForEach(availableCalibers) { caliber in
-                                Button(filterCountText(title: caliber.name, count: countForCaliber(caliber))) {
+                            ForEach(viewModel.availableCalibers(from: firearms)) { caliber in
+                                Button(viewModel.filterCountText(title: caliber.name, count: viewModel.countForCaliber(caliber, in: firearms))) {
                                     selectedCaliberFilter = caliber
                                 }
                             }
@@ -239,135 +228,45 @@ struct FirearmsView: View {
     }
 
     private var filteredFirearms: [Firearm] {
-        let filtered = firearms.filter { firearm in
-            let matchesType = selectedTypeFilter == nil || firearm.firearmType == selectedTypeFilter
-            let matchesAction = selectedActionFilter == nil || firearm.firearmAction == selectedActionFilter
-            let matchesCaliber = selectedCaliberFilter == nil || firearm.caliber?.persistentModelID == selectedCaliberFilter?.persistentModelID
-            return matchesType && matchesAction && matchesCaliber
-        }
-
-        switch selectedSortOrder {
-        case .manual:
-            return filtered
-        case .purchaseDate:
-            return filtered.sorted {
-                if $0.purchaseDate != $1.purchaseDate {
-                    return compare($0.purchaseDate, $1.purchaseDate)
-                }
-                return compareNames($0.displayName, $1.displayName)
-            }
-        case .value:
-            return filtered.sorted {
-                if $0.purchasePriceCents != $1.purchasePriceCents {
-                    return compare($0.purchasePriceCents, $1.purchasePriceCents)
-                }
-                return compareNames($0.displayName, $1.displayName)
-            }
-        case .barrelLength:
-            return filtered.sorted {
-                let lhs = $0.barrelLengthInches ?? -1
-                let rhs = $1.barrelLengthInches ?? -1
-                if lhs != rhs {
-                    return compare(lhs, rhs)
-                }
-                return compareNames($0.displayName, $1.displayName)
-            }
-        case .brand:
-            return filtered.sorted {
-                let brandComparison = $0.brand.localizedStandardCompare($1.brand)
-                if brandComparison != .orderedSame {
-                    return compare(brandComparison)
-                }
-                return compareNames($0.modelName, $1.modelName)
-            }
-        case .caliber:
-            return filtered.sorted {
-                let lhs = $0.caliber?.name ?? ""
-                let rhs = $1.caliber?.name ?? ""
-                let caliberComparison = lhs.localizedStandardCompare(rhs)
-                if caliberComparison != .orderedSame {
-                    return compare(caliberComparison)
-                }
-                return compareNames($0.displayName, $1.displayName)
-            }
-        case .type:
-            return filtered.sorted {
-                let typeComparison = $0.firearmType.displayName.localizedStandardCompare($1.firearmType.displayName)
-                if typeComparison != .orderedSame {
-                    return compare(typeComparison)
-                }
-                return compareNames($0.displayName, $1.displayName)
-            }
-        }
+        viewModel.filteredFirearms(
+            firearms,
+            kits: kits,
+            magazines: magazines,
+            selectedTypeFilter: selectedTypeFilter,
+            selectedActionFilter: selectedActionFilter,
+            selectedCaliberFilter: selectedCaliberFilter,
+            sortOrder: selectedSortOrder,
+            sortDirection: selectedSortDirection
+        )
     }
 
     private func moveFirearms(from source: IndexSet, to destination: Int) {
-        guard selectedSortOrder == .manual else {
-            return
-        }
-
-        var reorderedFilteredFirearms = filteredFirearms
-        reorderedFilteredFirearms.move(fromOffsets: source, toOffset: destination)
-
-        var reorderedFilteredIterator = reorderedFilteredFirearms.makeIterator()
-        let reorderedFirearms = firearms.map { firearm in
-            let matchesType = selectedTypeFilter == nil || firearm.firearmType == selectedTypeFilter
-            let matchesAction = selectedActionFilter == nil || firearm.firearmAction == selectedActionFilter
-
-            guard matchesType && matchesAction else {
-                return firearm
-            }
-
-            return reorderedFilteredIterator.next() ?? firearm
-        }
-
-        for (index, firearm) in reorderedFirearms.enumerated() {
-            firearm.sortOrder = index
-        }
-
-        do {
-            try context.save()
-            UserDefaults.standard.set(Date(), forKey: "LastModelSaveDate")
+        let result = viewModel.moveFirearms(
+            allFirearms: firearms,
+            filteredFirearms: filteredFirearms,
+            selectedTypeFilter: selectedTypeFilter,
+            selectedActionFilter: selectedActionFilter,
+            selectedCaliberFilter: selectedCaliberFilter,
+            sortOrder: selectedSortOrder,
+            source: source,
+            destination: destination,
+            in: context
+        )
+        if result.isValid {
             reloadFirearms()
-        } catch {
-            print("Reorder error: \(error)")
+        } else {
+            print("Reorder error: \(result.message ?? "")")
         }
     }
 
     private func reloadFirearms() {
         do {
             firearms = try inventoryListService.fetchFirearms(in: context)
+            kits = try inventoryListService.fetchKits(in: context)
+            magazines = try inventoryListService.fetchMagazines(in: context)
         } catch {
             print("Firearms fetch error: \(error)")
         }
-    }
-
-    private func resequenceFirearms() {
-        for (index, firearm) in firearms.enumerated() {
-            firearm.sortOrder = index
-        }
-    }
-
-    private func countForType(_ firearmType: FirearmType) -> Int {
-        firearms.count { $0.firearmType == firearmType }
-    }
-
-    private func countForAction(_ action: FirearmAction) -> Int {
-        firearms.count { $0.firearmAction == action }
-    }
-
-    private func countForCaliber(_ caliber: Caliber) -> Int {
-        firearms.count { $0.caliber?.persistentModelID == caliber.persistentModelID }
-    }
-
-    private var availableCalibers: [Caliber] {
-        var calibersByID: [PersistentIdentifier: Caliber] = [:]
-        for firearm in firearms {
-            if let caliber = firearm.caliber {
-                calibersByID[caliber.persistentModelID] = caliber
-            }
-        }
-        return calibersByID.values.sorted { $0.name.localizedStandardCompare($1.name) == .orderedAscending }
     }
 
     @ViewBuilder
@@ -394,79 +293,27 @@ struct FirearmsView: View {
     }
 
     private var totalValueText: String {
-        let totalCents = filteredFirearms.reduce(0) { $0 + $1.totalCardValueCents }
-        let amount = Decimal(totalCents) / 100
-        return amount.formatted(.currency(code: Locale.current.currency?.identifier ?? "USD"))
+        viewModel.totalValueText(for: filteredFirearms, kits: kits, magazines: magazines)
     }
 
     private var allTypesCountText: String {
-        String.localizedStringWithFormat(
-            String(localized: "All Types (%@)"),
-            firearms.count.localizedCountString
-        )
+        viewModel.allTypesCountText(for: firearms)
     }
 
     private var allActionsCountText: String {
-        String.localizedStringWithFormat(
-            String(localized: "All Actions (%@)"),
-            firearms.count.localizedCountString
-        )
+        viewModel.allActionsCountText(for: firearms)
     }
 
     private var allCalibersCountText: String {
-        String.localizedStringWithFormat(
-            String(localized: "All Calibers (%@)"),
-            firearms.count.localizedCountString
-        )
-    }
-
-    private func filterCountText(title: String, count: Int) -> String {
-        String.localizedStringWithFormat(
-            String(localized: "%@ (%@)"),
-            title,
-            count.localizedCountString
-        )
+        viewModel.allCalibersCountText(for: firearms)
     }
 
     private var selectedSortOrder: FirearmSortOrder {
-        FirearmSortOrder(rawValue: firearmSortOrder) ?? .manual
+        viewModel.selectedSortOrder(from: firearmSortOrder)
     }
 
     private var selectedSortDirection: FirearmSortDirection {
-        FirearmSortDirection(rawValue: firearmSortDirectionRaw) ?? preferredDirection(for: selectedSortOrder)
-    }
-
-    private func preferredDirection(for sortOrder: FirearmSortOrder) -> FirearmSortDirection {
-        switch sortOrder {
-        case .manual:
-            return .ascending
-        case .purchaseDate, .value, .barrelLength:
-            return .descending
-        case .brand, .caliber, .type:
-            return .ascending
-        }
-    }
-
-    private func compare<T: Comparable>(_ lhs: T, _ rhs: T) -> Bool {
-        switch selectedSortDirection {
-        case .ascending:
-            return lhs < rhs
-        case .descending:
-            return lhs > rhs
-        }
-    }
-
-    private func compare(_ comparison: ComparisonResult) -> Bool {
-        switch selectedSortDirection {
-        case .ascending:
-            return comparison == .orderedAscending
-        case .descending:
-            return comparison == .orderedDescending
-        }
-    }
-
-    private func compareNames(_ lhs: String, _ rhs: String) -> Bool {
-        compare(lhs.localizedStandardCompare(rhs))
+        viewModel.selectedSortDirection(from: firearmSortDirectionRaw, sortOrder: selectedSortOrder)
     }
 }
 
@@ -485,6 +332,7 @@ private struct FirearmCardView: View {
     let firearm: Firearm
     let showsExpandedCards: Bool
     let showValueInCard: Bool
+    let effectiveValueCents: Int
     let onTap: () -> Void
     let onSelectCaliber: () -> Void
 
@@ -521,8 +369,8 @@ private struct FirearmCardView: View {
                                 LabeledContent("Barrel", value: barrelLengthText)
                             }
 
-                            if showValueInCard, firearm.totalCardValueCents > 0 {
-                                LabeledContent("Value", value: firearm.totalCardValueText)
+                            if showValueInCard, effectiveValueCents > 0 {
+                                LabeledContent("Value", value: KitValueService.currencyText(for: effectiveValueCents))
                             }
 
                             if let notes = firearm.notes, !notes.isEmpty {

--- a/ArmoryInventory/Firearms/FirearmsViewModel.swift
+++ b/ArmoryInventory/Firearms/FirearmsViewModel.swift
@@ -1,0 +1,306 @@
+//
+//  FirearmsViewModel.swift
+//  Armory Inventory
+//
+//  Created by Codex on 5/20/26.
+//
+
+import Foundation
+import SwiftData
+
+final class FirearmsViewModel {
+    func selectedSortOrder(from rawValue: String) -> FirearmSortOrder {
+        FirearmSortOrder(rawValue: rawValue) ?? .manual
+    }
+
+    func selectedSortDirection(from rawValue: String, sortOrder: FirearmSortOrder) -> FirearmSortDirection {
+        FirearmSortDirection(rawValue: rawValue) ?? preferredDirection(for: sortOrder)
+    }
+
+    func preferredDirection(for sortOrder: FirearmSortOrder) -> FirearmSortDirection {
+        switch sortOrder {
+        case .manual:
+            return .ascending
+        case .purchaseDate, .value, .barrelLength:
+            return .descending
+        case .brand, .caliber, .type:
+            return .ascending
+        }
+    }
+
+    func filteredFirearms(
+        _ firearms: [Firearm],
+        kits: [Kit],
+        magazines: [Magazine],
+        selectedTypeFilter: FirearmType?,
+        selectedActionFilter: FirearmAction?,
+        selectedCaliberFilter: Caliber?,
+        sortOrder: FirearmSortOrder,
+        sortDirection: FirearmSortDirection
+    ) -> [Firearm] {
+        let filtered = firearms.filter {
+            matchesFilters(
+                $0,
+                selectedTypeFilter: selectedTypeFilter,
+                selectedActionFilter: selectedActionFilter,
+                selectedCaliberFilter: selectedCaliberFilter
+            )
+        }
+
+        switch sortOrder {
+        case .manual:
+            return filtered
+        case .purchaseDate:
+            return filtered.sorted {
+                if $0.purchaseDate != $1.purchaseDate {
+                    return compare($0.purchaseDate, $1.purchaseDate, direction: sortDirection)
+                }
+                return compareNames($0.displayName, $1.displayName, direction: sortDirection)
+            }
+        case .value:
+            return filtered.sorted {
+                let lhs = effectiveValueCents(for: $0, kits: kits, magazines: magazines)
+                let rhs = effectiveValueCents(for: $1, kits: kits, magazines: magazines)
+                if lhs != rhs {
+                    return compare(lhs, rhs, direction: sortDirection)
+                }
+                return compareNames($0.displayName, $1.displayName, direction: sortDirection)
+            }
+        case .barrelLength:
+            return filtered.sorted {
+                let lhs = $0.barrelLengthInches ?? -1
+                let rhs = $1.barrelLengthInches ?? -1
+                if lhs != rhs {
+                    return compare(lhs, rhs, direction: sortDirection)
+                }
+                return compareNames($0.displayName, $1.displayName, direction: sortDirection)
+            }
+        case .brand:
+            return filtered.sorted {
+                let brandComparison = $0.brand.localizedStandardCompare($1.brand)
+                if brandComparison != .orderedSame {
+                    return compare(brandComparison, direction: sortDirection)
+                }
+                return compareNames($0.modelName, $1.modelName, direction: sortDirection)
+            }
+        case .caliber:
+            return filtered.sorted {
+                let lhs = $0.caliber?.name ?? ""
+                let rhs = $1.caliber?.name ?? ""
+                let caliberComparison = lhs.localizedStandardCompare(rhs)
+                if caliberComparison != .orderedSame {
+                    return compare(caliberComparison, direction: sortDirection)
+                }
+                return compareNames($0.displayName, $1.displayName, direction: sortDirection)
+            }
+        case .type:
+            return filtered.sorted {
+                let typeComparison = $0.firearmType.displayName.localizedStandardCompare($1.firearmType.displayName)
+                if typeComparison != .orderedSame {
+                    return compare(typeComparison, direction: sortDirection)
+                }
+                return compareNames($0.displayName, $1.displayName, direction: sortDirection)
+            }
+        }
+    }
+
+    func matchesFilters(
+        _ firearm: Firearm,
+        selectedTypeFilter: FirearmType?,
+        selectedActionFilter: FirearmAction?,
+        selectedCaliberFilter: Caliber?
+    ) -> Bool {
+        let matchesType = selectedTypeFilter == nil || firearm.firearmType == selectedTypeFilter
+        let matchesAction = selectedActionFilter == nil || firearm.firearmAction == selectedActionFilter
+        let matchesCaliber = selectedCaliberFilter == nil || firearm.caliber?.persistentModelID == selectedCaliberFilter?.persistentModelID
+        return matchesType && matchesAction && matchesCaliber
+    }
+
+    func countForType(_ firearmType: FirearmType, in firearms: [Firearm]) -> Int {
+        firearms.count { $0.firearmType == firearmType }
+    }
+
+    func countForAction(_ action: FirearmAction, in firearms: [Firearm]) -> Int {
+        firearms.count { $0.firearmAction == action }
+    }
+
+    func countForCaliber(_ caliber: Caliber, in firearms: [Firearm]) -> Int {
+        firearms.count { $0.caliber?.persistentModelID == caliber.persistentModelID }
+    }
+
+    func availableCalibers(from firearms: [Firearm]) -> [Caliber] {
+        var calibersByID: [PersistentIdentifier: Caliber] = [:]
+        for firearm in firearms {
+            if let caliber = firearm.caliber {
+                calibersByID[caliber.persistentModelID] = caliber
+            }
+        }
+        return calibersByID.values.sorted { $0.name.localizedStandardCompare($1.name) == .orderedAscending }
+    }
+
+    func totalValueText(for firearms: [Firearm], kits: [Kit], magazines: [Magazine]) -> String {
+        let totalCents = firearms.reduce(0) { $0 + effectiveValueCents(for: $1, kits: kits, magazines: magazines) }
+        return currencyText(for: totalCents)
+    }
+
+    func allTypesCountText(for firearms: [Firearm]) -> String {
+        String.localizedStringWithFormat(
+            String(localized: "All Types (%@)"),
+            firearms.count.localizedCountString
+        )
+    }
+
+    func allActionsCountText(for firearms: [Firearm]) -> String {
+        String.localizedStringWithFormat(
+            String(localized: "All Actions (%@)"),
+            firearms.count.localizedCountString
+        )
+    }
+
+    func allCalibersCountText(for firearms: [Firearm]) -> String {
+        String.localizedStringWithFormat(
+            String(localized: "All Calibers (%@)"),
+            firearms.count.localizedCountString
+        )
+    }
+
+    func filterCountText(title: String, count: Int) -> String {
+        String.localizedStringWithFormat(
+            String(localized: "%@ (%@)"),
+            title,
+            count.localizedCountString
+        )
+    }
+
+    func linkedKits(for firearm: Firearm, kits: [Kit]) -> [Kit] {
+        kits.filter { $0.firearm?.persistentModelID == firearm.persistentModelID }
+    }
+
+    func compatibleMagazines(for firearm: Firearm, magazines: [Magazine]) -> [Magazine] {
+        magazines.filter { magazine in
+            magazine.linkedFirearms(from: [firearm]).contains {
+                $0.persistentModelID == firearm.persistentModelID
+            }
+        }
+    }
+
+    func effectiveValueCents(for firearm: Firearm, kits: [Kit], magazines: [Magazine]) -> Int {
+        KitValueService.effectiveTotalValueCents(
+            for: firearm,
+            linkedKits: linkedKits(for: firearm, kits: kits),
+            compatibleMagazines: compatibleMagazines(for: firearm, magazines: magazines)
+        )
+    }
+
+    func moveFirearms(
+        allFirearms firearms: [Firearm],
+        filteredFirearms: [Firearm],
+        selectedTypeFilter: FirearmType?,
+        selectedActionFilter: FirearmAction?,
+        selectedCaliberFilter: Caliber?,
+        sortOrder: FirearmSortOrder,
+        source: IndexSet,
+        destination: Int,
+        in context: ModelContext
+    ) -> KitValidationResult {
+        guard sortOrder == .manual else {
+            return .valid
+        }
+
+        let reorderedFirearms = reorderedFirearms(
+            allFirearms: firearms,
+            filteredFirearms: filteredFirearms,
+            selectedTypeFilter: selectedTypeFilter,
+            selectedActionFilter: selectedActionFilter,
+            selectedCaliberFilter: selectedCaliberFilter,
+            source: source,
+            destination: destination
+        )
+        applySortOrder(to: reorderedFirearms)
+
+        do {
+            try context.save()
+            UserDefaults.standard.set(Date(), forKey: "LastModelSaveDate")
+            return .valid
+        } catch {
+            return .invalid(error.localizedDescription)
+        }
+    }
+
+    func reorderedFirearms(
+        allFirearms firearms: [Firearm],
+        filteredFirearms: [Firearm],
+        selectedTypeFilter: FirearmType?,
+        selectedActionFilter: FirearmAction?,
+        selectedCaliberFilter: Caliber?,
+        source: IndexSet,
+        destination: Int
+    ) -> [Firearm] {
+        let reorderedFilteredFirearms = movingItems(in: filteredFirearms, from: source, to: destination)
+
+        var reorderedFilteredIterator = reorderedFilteredFirearms.makeIterator()
+        return firearms.map { firearm in
+            guard matchesFilters(
+                firearm,
+                selectedTypeFilter: selectedTypeFilter,
+                selectedActionFilter: selectedActionFilter,
+                selectedCaliberFilter: selectedCaliberFilter
+            ) else {
+                return firearm
+            }
+
+            return reorderedFilteredIterator.next() ?? firearm
+        }
+    }
+
+    func applySortOrder(to firearms: [Firearm]) {
+        for (index, firearm) in firearms.enumerated() {
+            firearm.sortOrder = index
+        }
+    }
+
+    private func currencyText(for cents: Int) -> String {
+        let amount = Decimal(cents) / 100
+        return amount.formatted(.currency(code: Locale.current.currency?.identifier ?? "USD"))
+    }
+
+    private func compare<T: Comparable>(_ lhs: T, _ rhs: T, direction: FirearmSortDirection) -> Bool {
+        switch direction {
+        case .ascending:
+            return lhs < rhs
+        case .descending:
+            return lhs > rhs
+        }
+    }
+
+    private func compare(_ comparison: ComparisonResult, direction: FirearmSortDirection) -> Bool {
+        switch direction {
+        case .ascending:
+            return comparison == .orderedAscending
+        case .descending:
+            return comparison == .orderedDescending
+        }
+    }
+
+    private func compareNames(_ lhs: String, _ rhs: String, direction: FirearmSortDirection) -> Bool {
+        compare(lhs.localizedStandardCompare(rhs), direction: direction)
+    }
+
+    private func movingItems(in firearms: [Firearm], from source: IndexSet, to destination: Int) -> [Firearm] {
+        guard !source.isEmpty else {
+            return firearms
+        }
+
+        var reorderedFirearms = firearms
+        let sourceIndexes = source.sorted()
+        let movingFirearms = sourceIndexes.map { reorderedFirearms[$0] }
+
+        for index in sourceIndexes.reversed() {
+            reorderedFirearms.remove(at: index)
+        }
+
+        let insertionIndex = destination - sourceIndexes.count { $0 < destination }
+        reorderedFirearms.insert(contentsOf: movingFirearms, at: max(0, min(insertionIndex, reorderedFirearms.count)))
+        return reorderedFirearms
+    }
+}

--- a/ArmoryInventory/Localizable.xcstrings
+++ b/ArmoryInventory/Localizable.xcstrings
@@ -23,6 +23,9 @@
         }
       }
     },
+    "\"%@\"" : {
+
+    },
     "“%@”" : {
       "localizations" : {
         "es" : {
@@ -130,6 +133,34 @@
         }
       }
     },
+    "%@ • Managed by %@" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@ • Managed by %2$@"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@ • Gestionado por %2$@"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@ • 由%2$@管理"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@ • 由%2$@管理"
+          }
+        }
+      }
+    },
     "%@ currently on hand" : {
       "localizations" : {
         "es" : {
@@ -148,6 +179,50 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "目前現貨：%@"
+          }
+        }
+      }
+    },
+    "%@ is already linked to a firearm." : {
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ ya está vinculado a un arma de fuego."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ 已关联到一支枪械。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ 已連結到一支槍械。"
+          }
+        }
+      }
+    },
+    "%@ is already reserved by another built or linked kit." : {
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ ya está reservado por otro kit creado o vinculado."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ 已被另一个已构建或已关联的套件占用。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ 已被另一個已建立或已連結的套件占用。"
           }
         }
       }
@@ -388,6 +463,72 @@
         }
       }
     },
+    "A selected attachment is missing." : {
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Falta un accesorio seleccionado."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "缺少一个已选附件。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "缺少一個已選附件。"
+          }
+        }
+      }
+    },
+    "A selected optic is missing." : {
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Falta una óptica seleccionada."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "缺少一个已选瞄具。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "缺少一個已選瞄具。"
+          }
+        }
+      }
+    },
+    "A selected part is missing." : {
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Falta una pieza seleccionada."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "缺少一个已选零件。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "缺少一個已選零件。"
+          }
+        }
+      }
+    },
     "About" : {
       "localizations" : {
         "es" : {
@@ -564,6 +705,28 @@
         }
       }
     },
+    "Add at least one component before building this kit." : {
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Agrega al menos un componente antes de crear este kit."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "构建此套件前，请至少添加一个组件。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "建立此套件前，請至少加入一個組件。"
+          }
+        }
+      }
+    },
     "Add Attachment" : {
       "localizations" : {
         "es" : {
@@ -670,6 +833,50 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "加入槍械"
+          }
+        }
+      }
+    },
+    "Add Kit" : {
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Agregar kit"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "添加套件"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "加入套件"
+          }
+        }
+      }
+    },
+    "Add Kits" : {
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Agregar kits"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "添加套件"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "加入套件"
           }
         }
       }
@@ -1228,6 +1435,50 @@
         }
       }
     },
+    "All Kinds" : {
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Todos los tipos de kit"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "所有套件类型"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "所有套件類型"
+          }
+        }
+      }
+    },
+    "All Kinds (%@)" : {
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Todos los tipos de kit (%@)"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "所有套件类型（%@）"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "所有套件類型（%@）"
+          }
+        }
+      }
+    },
     "All saved attachments are linked to other firearms or none have been added yet." : {
       "localizations" : {
         "es" : {
@@ -1523,6 +1774,50 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "遞增"
+          }
+        }
+      }
+    },
+    "Attachment" : {
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Accesorio"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "附件"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "附件"
+          }
+        }
+      }
+    },
+    "Attachment Cannot Be Deleted" : {
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No se puede eliminar el accesorio"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "无法删除附件"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "無法刪除附件"
           }
         }
       }
@@ -1897,6 +2192,94 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "配置"
+          }
+        }
+      }
+    },
+    "Build Kit" : {
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Crear kit"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "构建套件"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "建立套件"
+          }
+        }
+      }
+    },
+    "Build kits first to link them to this firearm." : {
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Crea kits primero para vincularlos a esta arma de fuego."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "请先构建套件，然后再将其关联到此枪械。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "請先建立套件，然後再將其連結到此槍械。"
+          }
+        }
+      }
+    },
+    "Build kits from unlinked parts, optics, and attachments." : {
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Crea kits con piezas, ópticas y accesorios sin vincular."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "使用未关联的零件、瞄具和附件构建套件。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "使用未連結的零件、瞄具和附件建立套件。"
+          }
+        }
+      }
+    },
+    "Built" : {
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Creado"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已构建"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已建立"
           }
         }
       }
@@ -2408,6 +2791,133 @@
         }
       }
     },
+    "componentCount" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%#@count@"
+          },
+          "substitutions" : {
+            "count" : {
+              "argNum" : 1,
+              "formatSpecifier" : "lld",
+              "variations" : {
+                "plural" : {
+                  "one" : {
+                    "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "%2$@ component"
+                    }
+                  },
+                  "other" : {
+                    "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "%2$@ components"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%#@count@"
+          },
+          "substitutions" : {
+            "count" : {
+              "argNum" : 1,
+              "formatSpecifier" : "lld",
+              "variations" : {
+                "plural" : {
+                  "one" : {
+                    "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "%2$@ componente"
+                    }
+                  },
+                  "other" : {
+                    "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "%2$@ componentes"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%#@count@"
+          },
+          "substitutions" : {
+            "count" : {
+              "argNum" : 1,
+              "formatSpecifier" : "lld",
+              "variations" : {
+                "plural" : {
+                  "other" : {
+                    "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "%2$@个组件"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%#@count@"
+          },
+          "substitutions" : {
+            "count" : {
+              "argNum" : 1,
+              "formatSpecifier" : "lld",
+              "variations" : {
+                "plural" : {
+                  "other" : {
+                    "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "%2$@個組件"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "Components" : {
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Componentes"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "组件"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "組件"
+          }
+        }
+      }
+    },
     "Configuration" : {
       "localizations" : {
         "es" : {
@@ -2470,6 +2980,28 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "數量"
+          }
+        }
+      }
+    },
+    "Created" : {
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Creado"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已创建"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已建立"
           }
         }
       }
@@ -2558,6 +3090,28 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "自訂口徑"
+          }
+        }
+      }
+    },
+    "Custom Kit" : {
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kit personalizado"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "自定义套件"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "自訂套件"
           }
         }
       }
@@ -2892,6 +3446,50 @@
         }
       }
     },
+    "Disassemble Kit" : {
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Desarmar kit"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "拆解套件"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "拆解套件"
+          }
+        }
+      }
+    },
+    "Disassemble or edit the built/linked kit using %@ before deleting it." : {
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Desarma o edita el kit creado/vinculado que usa %@ antes de eliminarlo."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "删除前，请先拆解或编辑正在使用 %@ 的已构建/已关联套件。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "刪除前，請先拆解或編輯正在使用 %@ 的已建立/已連結套件。"
+          }
+        }
+      }
+    },
     "Docter/Noblex" : {
       "localizations" : {
         "es" : {
@@ -3108,6 +3706,28 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "匯出資料"
+          }
+        }
+      }
+    },
+    "Failed to save kit: %@" : {
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No se pudo guardar el kit: %@"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "保存套件失败：%@"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "儲存套件失敗：%@"
           }
         }
       }
@@ -3376,6 +3996,28 @@
         }
       }
     },
+    "Foregrip" : {
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Empuñadura delantera"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "前握把"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "前握把"
+          }
+        }
+      }
+    },
     "From" : {
       "localizations" : {
         "es" : {
@@ -3508,6 +4150,28 @@
         }
       }
     },
+    "Grouped parts, optics, and attachments" : {
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Piezas, ópticas y accesorios agrupados"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "分组的零件、瞄具和附件"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "分組的零件、瞄具和附件"
+          }
+        }
+      }
+    },
     "Hand Stop" : {
       "localizations" : {
         "es" : {
@@ -3526,6 +4190,28 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "手擋"
+          }
+        }
+      }
+    },
+    "Handguard" : {
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Guardamanos"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "护木"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "護木"
           }
         }
       }
@@ -3794,6 +4480,9 @@
         }
       }
     },
+    "in" : {
+
+    },
     "In Stock" : {
       "extractionState" : "stale",
       "localizations" : {
@@ -3879,6 +4568,160 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "內部組件"
+          }
+        }
+      }
+    },
+    "Kind" : {
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tipo"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "类型"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "類型"
+          }
+        }
+      }
+    },
+    "Kit" : {
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kit"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "套件"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "套件"
+          }
+        }
+      }
+    },
+    "Kit Action Failed" : {
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "La acción del kit falló"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "套件操作失败"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "套件操作失敗"
+          }
+        }
+      }
+    },
+    "Kit Details" : {
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Detalles del kit"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "套件详情"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "套件詳細資料"
+          }
+        }
+      }
+    },
+    "Kit Save Failed" : {
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No se pudo guardar el kit"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "套件保存失败"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "套件儲存失敗"
+          }
+        }
+      }
+    },
+    "Kits" : {
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kits"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "套件"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "套件"
+          }
+        }
+      }
+    },
+    "Kits group unlinked parts, optics, and attachments so complete assemblies can be linked to firearms together while preserving direct item tracking." : {
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Los kits agrupan piezas, ópticas y accesorios sin vincular para que los conjuntos completos puedan vincularse a armas de fuego juntos sin perder el seguimiento directo de cada elemento."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "套件会将未关联的零件、瞄具和附件分组，让完整组件可一起关联到枪械，同时保留单个物品的直接追踪。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "套件會將未連結的零件、瞄具和附件分組，讓完整組件可一起連結到槍械，同時保留單個物品的直接追蹤。"
           }
         }
       }
@@ -4059,6 +4902,28 @@
         }
       }
     },
+    "Link Kits" : {
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vincular kits"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "关联套件"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "連結套件"
+          }
+        }
+      }
+    },
     "Link Optics" : {
       "localizations" : {
         "es" : {
@@ -4103,6 +4968,28 @@
         }
       }
     },
+    "Linked" : {
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vinculado"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已关联"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已連結"
+          }
+        }
+      }
+    },
     "Linked Attachments" : {
       "localizations" : {
         "es" : {
@@ -4143,6 +5030,28 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "已連結槍械"
+          }
+        }
+      }
+    },
+    "Linked Kits" : {
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kits vinculados"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已关联套件"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已連結套件"
           }
         }
       }
@@ -4232,6 +5141,28 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "下機匣"
+          }
+        }
+      }
+    },
+    "Lower Receiver Kit" : {
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kit de receptor inferior"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "下机匣套件"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "下機匣套件"
           }
         }
       }
@@ -4784,6 +5715,28 @@
         }
       }
     },
+    "Manage Kits" : {
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gestionar kits"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "管理套件"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "管理套件"
+          }
+        }
+      }
+    },
     "Manage Magazine Patterns" : {
       "localizations" : {
         "es" : {
@@ -4916,6 +5869,72 @@
         }
       }
     },
+    "Missing Attachment" : {
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Accesorio faltante"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "缺失附件"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "缺失附件"
+          }
+        }
+      }
+    },
+    "Missing Optic" : {
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Óptica faltante"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "缺失瞄具"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "缺失瞄具"
+          }
+        }
+      }
+    },
+    "Missing Part" : {
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pieza faltante"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "缺失零件"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "缺失零件"
+          }
+        }
+      }
+    },
     "mm" : {
       "localizations" : {
         "es" : {
@@ -5026,6 +6045,28 @@
         }
       }
     },
+    "Mount" : {
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Montura"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "支架"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "支架"
+          }
+        }
+      }
+    },
     "Mounted accessories grouped by attachment type" : {
       "localizations" : {
         "es" : {
@@ -5066,6 +6107,28 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "槍口裝置"
+          }
+        }
+      }
+    },
+    "Name" : {
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nombre"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "名称"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "名稱"
           }
         }
       }
@@ -5154,6 +6217,28 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "新增槍械"
+          }
+        }
+      }
+    },
+    "New Kit" : {
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nuevo kit"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "新套件"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "新套件"
           }
         }
       }
@@ -5334,6 +6419,28 @@
         }
       }
     },
+    "No attachments selected." : {
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No hay accesorios seleccionados."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "未选择附件。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "未選擇附件。"
+          }
+        }
+      }
+    },
     "No Attachments Yet" : {
       "localizations" : {
         "es" : {
@@ -5352,6 +6459,28 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "尚無附件"
+          }
+        }
+      }
+    },
+    "No built kits available." : {
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No hay kits creados disponibles."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "没有可用的已构建套件。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "沒有可用的已建立套件。"
           }
         }
       }
@@ -5418,6 +6547,72 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "尚無槍械"
+          }
+        }
+      }
+    },
+    "No Kits Available" : {
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No hay kits disponibles"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "没有可用套件"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "沒有可用套件"
+          }
+        }
+      }
+    },
+    "No kits linked." : {
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No hay kits vinculados."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "未关联套件。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "未連結套件。"
+          }
+        }
+      }
+    },
+    "No Kits Yet" : {
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aún no hay kits"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "还没有套件"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "尚無套件"
           }
         }
       }
@@ -5554,6 +6749,28 @@
         }
       }
     },
+    "No optics selected." : {
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No hay ópticas seleccionadas."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "未选择瞄具。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "未選擇瞄具。"
+          }
+        }
+      }
+    },
     "No Optics Yet" : {
       "localizations" : {
         "es" : {
@@ -5616,6 +6833,28 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "未連結任何零件。"
+          }
+        }
+      }
+    },
+    "No parts selected." : {
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No hay piezas seleccionadas."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "未选择零件。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "未選擇零件。"
           }
         }
       }
@@ -5862,6 +7101,50 @@
         }
       }
     },
+    "Only built kits not linked to another firearm can be selected." : {
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Solo se pueden seleccionar kits creados que no estén vinculados a otra arma de fuego."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "只能选择未关联到其他枪械的已构建套件。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "只能選擇未連結到其他槍械的已建立套件。"
+          }
+        }
+      }
+    },
+    "Only unlinked items outside built or linked kits can be selected." : {
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Solo se pueden seleccionar elementos sin vincular que no estén en kits creados o vinculados."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "只能选择未关联且不属于已构建或已关联套件的物品。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "只能選擇未連結且不屬於已建立或已連結套件的物品。"
+          }
+        }
+      }
+    },
     "Open %@ to view out-of-stock loads." : {
       "localizations" : {
         "es" : {
@@ -5880,6 +7163,50 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "打開 %@ 以查看缺貨彈藥。"
+          }
+        }
+      }
+    },
+    "Optic" : {
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Óptica"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "瞄具"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "瞄具"
+          }
+        }
+      }
+    },
+    "Optic Cannot Be Deleted" : {
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No se puede eliminar la óptica"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "无法删除瞄具"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "無法刪除瞄具"
           }
         }
       }
@@ -5946,6 +7273,28 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "瞄具包含用於提升目標捕捉速度與射擊精度的瞄準系統，適用於不同的槍械配置。"
+          }
+        }
+      }
+    },
+    "Optics Kit" : {
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kit de ópticas"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "瞄具套件"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "瞄具套件"
           }
         }
       }
@@ -6123,6 +7472,50 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "總覽"
+          }
+        }
+      }
+    },
+    "Part" : {
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pieza"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "零件"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "零件"
+          }
+        }
+      }
+    },
+    "Part Cannot Be Deleted" : {
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No se puede eliminar la pieza"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "无法删除零件"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "無法刪除零件"
           }
         }
       }
@@ -6589,6 +7982,28 @@
         }
       }
     },
+    "Receiver" : {
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Receptor"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "机匣"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "機匣"
+          }
+        }
+      }
+    },
     "Recoil System" : {
       "localizations" : {
         "es" : {
@@ -6919,6 +8334,28 @@
         }
       }
     },
+    "Select Attachments" : {
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Seleccionar accesorios"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "选择附件"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "選擇附件"
+          }
+        }
+      }
+    },
     "Select Magazine Patterns" : {
       "localizations" : {
         "es" : {
@@ -6959,6 +8396,50 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "選取一個或多個彈匣規格，以查看相容的彈匣。"
+          }
+        }
+      }
+    },
+    "Select Optics" : {
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Seleccionar ópticas"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "选择瞄具"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "選擇瞄具"
+          }
+        }
+      }
+    },
+    "Select Parts" : {
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Seleccionar piezas"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "选择零件"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "選擇零件"
           }
         }
       }
@@ -7532,6 +9013,28 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "建議目錄規格"
+          }
+        }
+      }
+    },
+    "Support" : {
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Soporte"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "支撑件"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "支撐件"
           }
         }
       }
@@ -8172,6 +9675,28 @@
         }
       }
     },
+    "Unlinked" : {
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Desvinculado"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已取消关联"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已取消連結"
+          }
+        }
+      }
+    },
     "Update" : {
       "localizations" : {
         "es" : {
@@ -8194,6 +9719,28 @@
         }
       }
     },
+    "Updated" : {
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Actualizado"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已更新"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已更新"
+          }
+        }
+      }
+    },
     "Upper Receiver" : {
       "localizations" : {
         "es" : {
@@ -8212,6 +9759,28 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "上機匣"
+          }
+        }
+      }
+    },
+    "Upper Receiver Kit" : {
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kit de receptor superior"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "上机匣套件"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "上機匣套件"
           }
         }
       }

--- a/ArmoryInventory/Localizable.xcstrings
+++ b/ArmoryInventory/Localizable.xcstrings
@@ -3468,6 +3468,28 @@
         }
       }
     },
+    "Discard Kit" : {
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Descartar kit"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "丢弃套件"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "丟棄套件"
+          }
+        }
+      }
+    },
     "Disassemble or edit the built/linked kit using %@ before deleting it." : {
       "localizations" : {
         "es" : {

--- a/ArmoryInventory/Services/AddFirearmLookupService.swift
+++ b/ArmoryInventory/Services/AddFirearmLookupService.swift
@@ -15,6 +15,7 @@ struct AddFirearmLookupData {
     var magazines: [Magazine] = []
     var attachments: [Attachment] = []
     var parts: [Part] = []
+    var kits: [Kit] = []
 }
 
 protocol AddFirearmLookupServicing {
@@ -41,6 +42,9 @@ struct AddFirearmLookupService: AddFirearmLookupServicing {
         let partsDescriptor = FetchDescriptor<Part>(
             sortBy: [SortDescriptor(\.brand), SortDescriptor(\.modelName)]
         )
+        let kitsDescriptor = FetchDescriptor<Kit>(
+            sortBy: [SortDescriptor(\.sortOrder), SortDescriptor(\.createdAt)]
+        )
 
         return AddFirearmLookupData(
             calibers: try context.fetch(calibersDescriptor),
@@ -48,7 +52,8 @@ struct AddFirearmLookupService: AddFirearmLookupServicing {
             optics: try context.fetch(opticsDescriptor),
             magazines: try context.fetch(magazinesDescriptor),
             attachments: try context.fetch(attachmentsDescriptor),
-            parts: try context.fetch(partsDescriptor)
+            parts: try context.fetch(partsDescriptor),
+            kits: try context.fetch(kitsDescriptor)
         )
     }
 }

--- a/ArmoryInventory/Services/AppServices.swift
+++ b/ArmoryInventory/Services/AppServices.swift
@@ -40,6 +40,10 @@ final class AppServices {
             InventoryListService()
         }
 
+        register(KitEligibilityServicing.self) {
+            KitEligibilityService()
+        }
+
         register(CaliberQueryServicing.self) {
             CaliberQueryService()
         }

--- a/ArmoryInventory/Services/AttachmentTypeSort.swift
+++ b/ArmoryInventory/Services/AttachmentTypeSort.swift
@@ -33,23 +33,25 @@ enum AttachmentTypeSort {
     }
 
     nonisolated static func persistedOrder(including typeNames: [String] = []) -> [String] {
-        let names = typeNames.map(normalize(typeName:))
-        let savedOrder = (UserDefaults.standard.stringArray(forKey: settingsKey)?.map(normalize(typeName:)) ?? [])
-            .filter(defaultOrder.contains)
+        let names = unique(typeNames.map(normalize(typeName:)))
+        let savedNames = unique(UserDefaults.standard.stringArray(forKey: settingsKey)?.map(normalize(typeName:)) ?? [])
+        let savedOrder = savedNames.filter { defaultOrder.contains($0) || shouldPreserveSavedCustomName($0) }
         let knownNames = defaultOrder.filter { !savedOrder.contains($0) }
         let customNames = names.filter { !savedOrder.contains($0) && !knownNames.contains($0) }
         return savedOrder + knownNames + customNames.sorted { $0.localizedStandardCompare($1) == .orderedAscending }
     }
 
     nonisolated static func saveOrder(_ typeNames: [String]) {
-        let normalized = typeNames.map(normalize(typeName:))
+        let normalized = unique(typeNames.map(normalize(typeName:)))
         UserDefaults.standard.set(normalized, forKey: settingsKey)
+        UserDefaults.standard.set(true, forKey: managedSettingsKey)
         let nextVersion = UserDefaults.standard.integer(forKey: settingsVersionKey) + 1
         UserDefaults.standard.set(nextVersion, forKey: settingsVersionKey)
     }
 
     nonisolated static func resetOrder() {
         UserDefaults.standard.removeObject(forKey: settingsKey)
+        UserDefaults.standard.removeObject(forKey: managedSettingsKey)
         let nextVersion = UserDefaults.standard.integer(forKey: settingsVersionKey) + 1
         UserDefaults.standard.set(nextVersion, forKey: settingsVersionKey)
     }
@@ -65,11 +67,27 @@ enum AttachmentTypeSort {
         typeName.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
     }
 
+    nonisolated private static func unique(_ typeNames: [String]) -> [String] {
+        var seen: Set<String> = []
+        var ordered: [String] = []
+
+        for typeName in typeNames where !typeName.isEmpty && seen.insert(typeName).inserted {
+            ordered.append(typeName)
+        }
+
+        return ordered
+    }
+
+    nonisolated private static func shouldPreserveSavedCustomName(_ typeName: String) -> Bool {
+        UserDefaults.standard.bool(forKey: managedSettingsKey)
+    }
+
     nonisolated private static var currentOrder: [String] {
         persistedOrder()
     }
 
     nonisolated private static let settingsKey = InventorySettingsKeys.attachmentTypeSortOrder
+    nonisolated private static let managedSettingsKey = "\(InventorySettingsKeys.attachmentTypeSortOrder).managed"
 
     nonisolated private static let defaultOrder: [String] = AttachmentType.allCases.map(\.id).map(normalize(typeName:))
 }

--- a/ArmoryInventory/Services/InventoryListService.swift
+++ b/ArmoryInventory/Services/InventoryListService.swift
@@ -14,6 +14,7 @@ protocol InventoryListServicing {
     func fetchOptics(in context: ModelContext) throws -> [Optic]
     func fetchParts(in context: ModelContext) throws -> [Part]
     func fetchFirearms(in context: ModelContext) throws -> [Firearm]
+    func fetchKits(in context: ModelContext) throws -> [Kit]
 }
 
 struct InventoryListService: InventoryListServicing {
@@ -53,6 +54,14 @@ struct InventoryListService: InventoryListServicing {
         try context.fetch(
             FetchDescriptor(
                 sortBy: [SortDescriptor(\Firearm.sortOrder), SortDescriptor(\Firearm.createdAt)]
+            )
+        )
+    }
+
+    func fetchKits(in context: ModelContext) throws -> [Kit] {
+        try context.fetch(
+            FetchDescriptor(
+                sortBy: [SortDescriptor(\Kit.sortOrder), SortDescriptor(\Kit.createdAt)]
             )
         )
     }

--- a/ArmoryInventory/Services/OpticTypeSort.swift
+++ b/ArmoryInventory/Services/OpticTypeSort.swift
@@ -34,9 +34,8 @@ enum OpticTypeSort {
 
     nonisolated static func persistedOrder(including typeNames: [String] = []) -> [String] {
         let names = unique(typeNames.map(normalize(typeName:)))
-        let savedOrder = unique(
-            (UserDefaults.standard.stringArray(forKey: settingsKey) ?? []).map(normalize(typeName:))
-        ).filter(defaultOrder.contains)
+        let savedNames = unique(UserDefaults.standard.stringArray(forKey: settingsKey)?.map(normalize(typeName:)) ?? [])
+        let savedOrder = savedNames.filter { defaultOrder.contains($0) || shouldPreserveSavedCustomName($0) }
         let knownNames = defaultOrder.filter { !savedOrder.contains($0) }
         let customNames = names.filter { !savedOrder.contains($0) && !knownNames.contains($0) }
         return savedOrder + knownNames + customNames.sorted { $0.localizedStandardCompare($1) == .orderedAscending }
@@ -44,12 +43,14 @@ enum OpticTypeSort {
 
     nonisolated static func saveOrder(_ typeNames: [String]) {
         UserDefaults.standard.set(unique(typeNames.map(normalize(typeName:))), forKey: settingsKey)
+        UserDefaults.standard.set(true, forKey: managedSettingsKey)
         let nextVersion = UserDefaults.standard.integer(forKey: settingsVersionKey) + 1
         UserDefaults.standard.set(nextVersion, forKey: settingsVersionKey)
     }
 
     nonisolated static func resetOrder() {
         UserDefaults.standard.removeObject(forKey: settingsKey)
+        UserDefaults.standard.removeObject(forKey: managedSettingsKey)
         let nextVersion = UserDefaults.standard.integer(forKey: settingsVersionKey) + 1
         UserDefaults.standard.set(nextVersion, forKey: settingsVersionKey)
     }
@@ -69,11 +70,15 @@ enum OpticTypeSort {
         var seen: Set<String> = []
         var ordered: [String] = []
 
-        for typeName in typeNames where seen.insert(typeName).inserted {
+        for typeName in typeNames where !typeName.isEmpty && seen.insert(typeName).inserted {
             ordered.append(typeName)
         }
 
         return ordered
+    }
+
+    nonisolated private static func shouldPreserveSavedCustomName(_ typeName: String) -> Bool {
+        UserDefaults.standard.bool(forKey: managedSettingsKey)
     }
 
     nonisolated private static var currentOrder: [String] {
@@ -81,6 +86,7 @@ enum OpticTypeSort {
     }
 
     nonisolated private static let settingsKey = InventorySettingsKeys.opticTypeSortOrder
+    nonisolated private static let managedSettingsKey = "\(InventorySettingsKeys.opticTypeSortOrder).managed"
 
     nonisolated private static let defaultOrder: [String] = OpticType.allCases.map(\.id).map(normalize(typeName:))
 }

--- a/ArmoryInventory/Services/PartTypeSort.swift
+++ b/ArmoryInventory/Services/PartTypeSort.swift
@@ -33,23 +33,25 @@ enum PartTypeSort {
     }
 
     nonisolated static func persistedOrder(including typeNames: [String] = []) -> [String] {
-        let names = typeNames.map(normalize(typeName:))
-        let savedOrder = (UserDefaults.standard.stringArray(forKey: settingsKey)?.map(normalize(typeName:)) ?? [])
-            .filter(defaultOrder.contains)
+        let names = unique(typeNames.map(normalize(typeName:)))
+        let savedNames = unique(UserDefaults.standard.stringArray(forKey: settingsKey)?.map(normalize(typeName:)) ?? [])
+        let savedOrder = savedNames.filter { defaultOrder.contains($0) || shouldPreserveSavedCustomName($0) }
         let knownNames = defaultOrder.filter { !savedOrder.contains($0) }
         let customNames = names.filter { !savedOrder.contains($0) && !knownNames.contains($0) }
         return savedOrder + knownNames + customNames.sorted { $0.localizedStandardCompare($1) == .orderedAscending }
     }
 
     nonisolated static func saveOrder(_ typeNames: [String]) {
-        let normalized = typeNames.map(normalize(typeName:))
+        let normalized = unique(typeNames.map(normalize(typeName:)))
         UserDefaults.standard.set(normalized, forKey: settingsKey)
+        UserDefaults.standard.set(true, forKey: managedSettingsKey)
         let nextVersion = UserDefaults.standard.integer(forKey: settingsVersionKey) + 1
         UserDefaults.standard.set(nextVersion, forKey: settingsVersionKey)
     }
 
     nonisolated static func resetOrder() {
         UserDefaults.standard.removeObject(forKey: settingsKey)
+        UserDefaults.standard.removeObject(forKey: managedSettingsKey)
         let nextVersion = UserDefaults.standard.integer(forKey: settingsVersionKey) + 1
         UserDefaults.standard.set(nextVersion, forKey: settingsVersionKey)
     }
@@ -65,11 +67,27 @@ enum PartTypeSort {
         typeName.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
     }
 
+    nonisolated private static func unique(_ typeNames: [String]) -> [String] {
+        var seen: Set<String> = []
+        var ordered: [String] = []
+
+        for typeName in typeNames where !typeName.isEmpty && seen.insert(typeName).inserted {
+            ordered.append(typeName)
+        }
+
+        return ordered
+    }
+
+    nonisolated private static func shouldPreserveSavedCustomName(_ typeName: String) -> Bool {
+        UserDefaults.standard.bool(forKey: managedSettingsKey)
+    }
+
     nonisolated private static var currentOrder: [String] {
         persistedOrder()
     }
 
     nonisolated private static let settingsKey = InventorySettingsKeys.partTypeSortOrder
+    nonisolated private static let managedSettingsKey = "\(InventorySettingsKeys.partTypeSortOrder).managed"
 
     nonisolated private static let defaultOrder: [String] = PartType.allCases.map(\.id).map(normalize(typeName:))
 }

--- a/ArmoryInventory/Services/UserDataTransferService.swift
+++ b/ArmoryInventory/Services/UserDataTransferService.swift
@@ -68,7 +68,7 @@ final class UserDataTransferService: UserDataTransferServicing {
             throw UserDataTransferError.invalidBackupFile
         }
 
-        guard snapshot.version == UserDataSnapshot.currentVersion else {
+        guard UserDataSnapshot.supportedVersions.contains(snapshot.version) else {
             throw UserDataTransferError.unsupportedVersion(snapshot.version)
         }
 
@@ -91,6 +91,7 @@ final class UserDataTransferService: UserDataTransferServicing {
         let magazines = try context.fetch(FetchDescriptor<Magazine>(sortBy: [SortDescriptor(\.sortOrder), SortDescriptor(\.createdAt)]))
         let attachments = try context.fetch(FetchDescriptor<Attachment>(sortBy: [SortDescriptor(\.sortOrder), SortDescriptor(\.createdAt)]))
         let parts = try context.fetch(FetchDescriptor<Part>(sortBy: [SortDescriptor(\.sortOrder), SortDescriptor(\.createdAt)]))
+        let kits = try context.fetch(FetchDescriptor<Kit>(sortBy: [SortDescriptor(\.sortOrder), SortDescriptor(\.createdAt)]))
 
         var ammoIdentifiers: [ObjectIdentifier: UUID] = [:]
         let ammoSnapshots = ammoTypes.map { ammo -> AmmoTypeSnapshot in
@@ -227,6 +228,37 @@ final class UserDataTransferService: UserDataTransferServicing {
                     createdAt: $0.createdAt,
                     firearmID: $0.firearm?.id
                 )
+            },
+            kits: kits.map { kit in
+                KitSnapshot(
+                    id: kit.id ?? UUID(),
+                    name: kit.name,
+                    kind: kit.kind,
+                    status: kit.status,
+                    notes: kit.notes,
+                    sortOrder: kit.sortOrder,
+                    createdAt: kit.createdAt,
+                    updatedAt: kit.updatedAt,
+                    firearmID: kit.firearm?.id,
+                    components: kit.sortedComponents.map {
+                        KitComponentSnapshot(
+                            id: $0.id ?? UUID(),
+                            category: $0.category,
+                            slot: $0.slot,
+                            sortOrder: $0.sortOrder,
+                            partID: $0.part?.id,
+                            opticID: $0.optic?.id,
+                            attachmentID: $0.attachment?.id
+                        )
+                    },
+                    historyRecords: kit.sortedHistoryRecords.map {
+                        KitHistoryRecordSnapshot(
+                            occurredAt: $0.occurredAt,
+                            event: $0.event,
+                            note: $0.note
+                        )
+                    }
+                )
             }
         )
     }
@@ -281,6 +313,7 @@ final class UserDataTransferService: UserDataTransferServicing {
             result[snapshot.backupID] = ammoType
         }
 
+        var optics: [UUID: Optic] = [:]
         for snapshot in snapshot.optics {
             let optic = Optic(
                 id: snapshot.id,
@@ -306,6 +339,7 @@ final class UserDataTransferService: UserDataTransferServicing {
                 createdAt: snapshot.createdAt
             )
             context.insert(optic)
+            optics[snapshot.id] = optic
         }
 
         for snapshot in snapshot.magazines {
@@ -334,6 +368,7 @@ final class UserDataTransferService: UserDataTransferServicing {
 
         _ = MagazinePatternMigration.backfillMissingPatterns(in: context)
 
+        var attachments: [UUID: Attachment] = [:]
         for snapshot in snapshot.attachments {
             let attachment = Attachment(
                 id: snapshot.id,
@@ -351,8 +386,10 @@ final class UserDataTransferService: UserDataTransferServicing {
                 createdAt: snapshot.createdAt
             )
             context.insert(attachment)
+            attachments[snapshot.id] = attachment
         }
 
+        var parts: [UUID: Part] = [:]
         for snapshot in snapshot.parts {
             let part = Part(
                 id: snapshot.id,
@@ -370,6 +407,52 @@ final class UserDataTransferService: UserDataTransferServicing {
                 createdAt: snapshot.createdAt
             )
             context.insert(part)
+            parts[snapshot.id] = part
+        }
+
+        for snapshot in snapshot.kits {
+            let kit = Kit(
+                id: snapshot.id,
+                name: snapshot.name,
+                kind: KitKind(rawValue: snapshot.kind) ?? .custom,
+                status: KitStatus(rawValue: snapshot.status) ?? .built,
+                notes: snapshot.notes,
+                firearm: snapshot.firearmID.flatMap { firearms[$0] },
+                sortOrder: snapshot.sortOrder,
+                createdAt: snapshot.createdAt,
+                updatedAt: snapshot.updatedAt
+            )
+            context.insert(kit)
+
+            var importedComponents: [KitComponent] = []
+            for componentSnapshot in snapshot.components {
+                let component = KitComponent(
+                    id: componentSnapshot.id,
+                    category: KitComponentCategory(rawValue: componentSnapshot.category) ?? .part,
+                    slot: componentSnapshot.slot.flatMap(KitComponentSlot.init(rawValue:)),
+                    part: componentSnapshot.partID.flatMap { parts[$0] },
+                    optic: componentSnapshot.opticID.flatMap { optics[$0] },
+                    attachment: componentSnapshot.attachmentID.flatMap { attachments[$0] },
+                    sortOrder: componentSnapshot.sortOrder
+                )
+                component.kit = kit
+                importedComponents.append(component)
+                context.insert(component)
+            }
+            kit.components = importedComponents
+
+            var importedHistoryRecords: [KitHistoryRecord] = []
+            for historySnapshot in snapshot.historyRecords {
+                let record = KitHistoryRecord(
+                    occurredAt: historySnapshot.occurredAt,
+                    event: KitHistoryEvent(rawValue: historySnapshot.event) ?? .updated,
+                    note: historySnapshot.note
+                )
+                record.kit = kit
+                importedHistoryRecords.append(record)
+                context.insert(record)
+            }
+            kit.historyRecords = importedHistoryRecords
         }
 
         for snapshot in snapshot.ammoAdjustmentRecords {
@@ -390,6 +473,9 @@ final class UserDataTransferService: UserDataTransferServicing {
     @MainActor
     private func deleteExistingData(in context: ModelContext) throws {
         try deleteAll(FetchDescriptor<AmmoAdjustmentRecord>(), in: context)
+        try deleteAll(FetchDescriptor<KitHistoryRecord>(), in: context)
+        try deleteAll(FetchDescriptor<KitComponent>(), in: context)
+        try deleteAll(FetchDescriptor<Kit>(), in: context)
         try deleteAll(FetchDescriptor<Attachment>(), in: context)
         try deleteAll(FetchDescriptor<Part>(), in: context)
         try deleteAll(FetchDescriptor<Magazine>(), in: context)
@@ -461,7 +547,8 @@ final class UserDataTransferService: UserDataTransferServicing {
 }
 
 private struct UserDataSnapshot: Codable {
-    static let currentVersion = 1
+    static let currentVersion = 2
+    static let supportedVersions: Set<Int> = [1, 2]
 
     private enum CodingKeys: String, CodingKey {
         case version
@@ -475,6 +562,7 @@ private struct UserDataSnapshot: Codable {
         case magazines
         case attachments
         case parts
+        case kits
     }
 
     let version: Int
@@ -488,6 +576,7 @@ private struct UserDataSnapshot: Codable {
     let magazines: [MagazineSnapshot]
     let attachments: [AttachmentSnapshot]
     let parts: [PartSnapshot]
+    let kits: [KitSnapshot]
 
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
@@ -502,6 +591,7 @@ private struct UserDataSnapshot: Codable {
         magazines = try container.decode([MagazineSnapshot].self, forKey: .magazines)
         attachments = try container.decode([AttachmentSnapshot].self, forKey: .attachments)
         parts = try container.decodeIfPresent([PartSnapshot].self, forKey: .parts) ?? []
+        kits = try container.decodeIfPresent([KitSnapshot].self, forKey: .kits) ?? []
     }
 
     init(
@@ -515,7 +605,8 @@ private struct UserDataSnapshot: Codable {
         optics: [OpticSnapshot],
         magazines: [MagazineSnapshot],
         attachments: [AttachmentSnapshot],
-        parts: [PartSnapshot]
+        parts: [PartSnapshot],
+        kits: [KitSnapshot]
     ) {
         self.version = version
         self.exportedAt = exportedAt
@@ -528,6 +619,7 @@ private struct UserDataSnapshot: Codable {
         self.magazines = magazines
         self.attachments = attachments
         self.parts = parts
+        self.kits = kits
     }
 }
 
@@ -734,6 +826,36 @@ private struct PartSnapshot: Codable {
     let sortOrder: Int
     let createdAt: Date
     let firearmID: UUID?
+}
+
+private struct KitSnapshot: Codable {
+    let id: UUID
+    let name: String
+    let kind: String
+    let status: String
+    let notes: String?
+    let sortOrder: Int
+    let createdAt: Date
+    let updatedAt: Date
+    let firearmID: UUID?
+    let components: [KitComponentSnapshot]
+    let historyRecords: [KitHistoryRecordSnapshot]
+}
+
+private struct KitComponentSnapshot: Codable {
+    let id: UUID
+    let category: String
+    let slot: String?
+    let sortOrder: Int
+    let partID: UUID?
+    let opticID: UUID?
+    let attachmentID: UUID?
+}
+
+private struct KitHistoryRecordSnapshot: Codable {
+    let occurredAt: Date
+    let event: String
+    let note: String?
 }
 
 private enum SettingValue: Codable {

--- a/ArmoryInventoryTests/AccessoriesTests/AccessoriesViewModelTests.swift
+++ b/ArmoryInventoryTests/AccessoriesTests/AccessoriesViewModelTests.swift
@@ -1,0 +1,38 @@
+//
+//  AccessoriesViewModelTests.swift
+//  Armory InventoryTests
+//
+//  Created by Codex on 5/20/26.
+//
+
+import XCTest
+@testable import ArmoryInventory
+
+final class AccessoriesViewModelTests: XCTestCase {
+    func testTopLevelCategoriesIncludeKitsAndTotalValueExcludesKitMembership() {
+        let viewModel = AccessoriesViewModel()
+        let optic = Optic(
+            brand: "Aimpoint",
+            modelName: "T-2",
+            type: .redDot,
+            minMagnification: 1,
+            maxMagnification: 1,
+            footprint: .aimpointMicro,
+            purchasePriceCents: 70_000
+        )
+        let magazine = Magazine(brand: "Magpul", modelName: "PMAG", count: 2, capacity: 30, purchasePriceCents: 1_500)
+        let attachment = Attachment(brand: "BCM", modelName: "KAG", type: .handStop, purchasePriceCents: 2_000)
+        let part = Part(brand: "BCM", modelName: "BCG", type: .boltCarrierGroup, purchasePriceCents: 20_000)
+
+        XCTAssertEqual(viewModel.topLevelCategories.map(\.id), ["optics", "magazines", "attachments", "parts", "kits"])
+        XCTAssertEqual(
+            viewModel.totalValueText(
+                optics: [optic],
+                magazines: [magazine],
+                attachments: [attachment],
+                parts: [part]
+            ),
+            "$935.00"
+        )
+    }
+}

--- a/ArmoryInventoryTests/AccessoriesTests/AccessoryInventoryListViewModelTests.swift
+++ b/ArmoryInventoryTests/AccessoriesTests/AccessoryInventoryListViewModelTests.swift
@@ -1,0 +1,169 @@
+//
+//  AccessoryInventoryListViewModelTests.swift
+//  Armory InventoryTests
+//
+//  Created by Codex on 5/20/26.
+//
+
+import XCTest
+import SwiftData
+@testable import ArmoryInventory
+
+final class AccessoryInventoryListViewModelTests: XCTestCase {
+    func testGroupingDisplayNamesAndTotalsAreViewModelOwned() {
+        let viewModel = AccessoryInventoryListViewModel()
+        let chargingHandle = Part(
+            brand: "Radian",
+            modelName: "Raptor",
+            type: .chargingHandle,
+            purchasePriceCents: 9_000,
+            sortOrder: 1
+        )
+        let boltCarrierGroup = Part(
+            brand: "BCM",
+            modelName: "BCG",
+            type: .boltCarrierGroup,
+            purchasePriceCents: 18_000,
+            sortOrder: 0
+        )
+        let optic = Optic(
+            brand: "Aimpoint",
+            modelName: "T-2",
+            type: .redDot,
+            minMagnification: 1,
+            maxMagnification: 1,
+            footprint: .aimpointMicro,
+            purchasePriceCents: 70_000
+        )
+        let attachment = Attachment(brand: "BCM", modelName: "KAG", type: .handStop, purchasePriceCents: 2_000)
+        let groupedParts = viewModel.groupedParts(
+            [chargingHandle, boltCarrierGroup],
+            sortOrderRaw: AccessoryItemSortOrder.manual.rawValue,
+            sortDirectionRaw: AccessoryItemSortDirection.ascending.rawValue
+        )
+        let groupedOptics = viewModel.groupedOptics(
+            [optic],
+            sortOrderRaw: AccessoryItemSortOrder.model.rawValue,
+            sortDirectionRaw: AccessoryItemSortDirection.descending.rawValue
+        )
+        let groupedAttachments = viewModel.groupedAttachments(
+            [attachment],
+            sortOrderRaw: "invalid",
+            sortDirectionRaw: "invalid"
+        )
+
+        XCTAssertEqual(groupedParts[PartType.chargingHandle.rawValue]?.map(\.displayName), ["Radian Raptor"])
+        XCTAssertEqual(groupedParts[PartType.boltCarrierGroup.rawValue]?.map(\.displayName), ["BCM BCG"])
+        XCTAssertEqual(viewModel.groupedPartTypes(from: groupedParts), [PartType.boltCarrierGroup.rawValue, PartType.chargingHandle.rawValue])
+        XCTAssertEqual(viewModel.partTypeDisplayName(for: PartType.chargingHandle.rawValue), "Charging Handle")
+        XCTAssertEqual(viewModel.partTypeDisplayName(for: "custom part"), "custom part")
+        XCTAssertEqual(groupedOptics[OpticType.redDot.rawValue]?.map { $0.displayName }, ["Aimpoint T-2"])
+        XCTAssertEqual(viewModel.groupedOpticTypes(from: groupedOptics), [OpticType.redDot.rawValue])
+        XCTAssertEqual(viewModel.opticTypeDisplayName(for: OpticType.redDot.rawValue), "Red Dot")
+        XCTAssertEqual(viewModel.opticTypeDisplayName(for: "custom optic"), "custom optic")
+        XCTAssertEqual(groupedAttachments[AttachmentType.handStop.rawValue]?.map(\.displayName), ["BCM KAG"])
+        XCTAssertEqual(viewModel.groupedAttachmentTypes(from: groupedAttachments), [AttachmentType.handStop.rawValue])
+        XCTAssertEqual(viewModel.attachmentTypeDisplayName(for: AttachmentType.handStop.rawValue), "Hand Stop")
+        XCTAssertEqual(viewModel.attachmentTypeDisplayName(for: "custom attachment"), "custom attachment")
+        XCTAssertEqual(viewModel.totalValueText(for: [chargingHandle, boltCarrierGroup]), "$270.00")
+    }
+
+    @MainActor
+    func testDeletionIsBlockedForBuiltKitComponents() throws {
+        let container = try makeInMemoryContainer()
+        let context = container.mainContext
+        let viewModel = AccessoryInventoryListViewModel()
+        let part = Part(brand: "BCM", modelName: "BCG", type: .boltCarrierGroup, purchasePriceCents: 18_000)
+        let kit = Kit(name: "Upper Kit", kind: .upperReceiver, status: .built)
+        let component = KitComponent(category: .part, part: part)
+        component.kit = kit
+        kit.components = [component]
+
+        context.insert(part)
+        context.insert(kit)
+        context.insert(component)
+        try context.save()
+
+        let groupedParts = viewModel.groupedParts(
+            [part],
+            sortOrderRaw: AccessoryItemSortOrder.manual.rawValue,
+            sortDirectionRaw: AccessoryItemSortDirection.ascending.rawValue
+        )
+        let result = viewModel.deleteParts(
+            at: IndexSet(integer: 0),
+            in: PartType.boltCarrierGroup.rawValue,
+            groupedParts: groupedParts,
+            allParts: [part],
+            kits: [kit],
+            context: context
+        )
+        let remainingParts = try context.fetch(FetchDescriptor<Part>())
+
+        XCTAssertFalse(result.isValid)
+        XCTAssertEqual(result.message, "Disassemble or edit the built/linked kit using BCM BCG before deleting it.")
+        XCTAssertEqual(remainingParts.map(\.displayName), ["BCM BCG"])
+    }
+
+    @MainActor
+    func testDeletionHandlesMissingGroupsAndDeletesUnreservedItems() throws {
+        let container = try makeInMemoryContainer()
+        let context = container.mainContext
+        let viewModel = AccessoryInventoryListViewModel()
+        let part = Part(brand: "Aero", modelName: "M4E1", type: .lowerReceiver, purchasePriceCents: 12_000, sortOrder: 5)
+        let optic = Optic(
+            brand: "Aimpoint",
+            modelName: "T-2",
+            type: .redDot,
+            minMagnification: 1,
+            maxMagnification: 1,
+            footprint: .aimpointMicro,
+            purchasePriceCents: 70_000
+        )
+        let attachment = Attachment(brand: "BCM", modelName: "KAG", type: .handStop, purchasePriceCents: 2_000)
+        context.insert(part)
+        context.insert(optic)
+        context.insert(attachment)
+        try context.save()
+
+        XCTAssertTrue(
+            viewModel.deleteParts(
+                at: IndexSet(integer: 0),
+                in: "missing",
+                groupedParts: [:],
+                allParts: [part],
+                kits: [],
+                context: context
+            ).isValid
+        )
+
+        let opticResult = viewModel.deleteOptics(
+            at: IndexSet(integer: 0),
+            in: OpticType.redDot.rawValue,
+            groupedOptics: viewModel.groupedOptics(
+                [optic],
+                sortOrderRaw: AccessoryItemSortOrder.manual.rawValue,
+                sortDirectionRaw: ""
+            ),
+            allOptics: [optic],
+            kits: [],
+            context: context
+        )
+        let attachmentResult = viewModel.deleteAttachments(
+            at: IndexSet(integer: 0),
+            in: AttachmentType.handStop.rawValue,
+            groupedAttachments: viewModel.groupedAttachments(
+                [attachment],
+                sortOrderRaw: AccessoryItemSortOrder.manual.rawValue,
+                sortDirectionRaw: ""
+            ),
+            allAttachments: [attachment],
+            kits: [],
+            context: context
+        )
+
+        XCTAssertTrue(opticResult.isValid)
+        XCTAssertTrue(attachmentResult.isValid)
+        XCTAssertTrue(try context.fetch(FetchDescriptor<Optic>()).isEmpty)
+        XCTAssertTrue(try context.fetch(FetchDescriptor<Attachment>()).isEmpty)
+    }
+}

--- a/ArmoryInventoryTests/AccessoriesTests/AddMagazineViewModelTests.swift
+++ b/ArmoryInventoryTests/AccessoriesTests/AddMagazineViewModelTests.swift
@@ -79,6 +79,163 @@ final class AddMagazineViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.initialManualPatternName(for: nil), "")
     }
 
+    func testPatternSelectionMetadataAndPresentationHelpers() {
+        let viewModel = AddMagazineViewModel()
+        let firearm = Firearm(
+            brand: "Daniel Defense",
+            modelName: "DDM4",
+            purchasePriceCents: 180_000,
+            type: .rifle,
+            action: .semiAuto,
+            caliber: Caliber(name: "5.56 NATO")
+        )
+        let magazine = Magazine(
+            brand: "Magpul",
+            modelName: "PMAG",
+            patternID: "catalog:ar15-stanag-223-556-300blk",
+            patternKind: .catalog,
+            capacity: 30,
+            purchasePriceCents: 1_599,
+            firearm: firearm
+        )
+        let customPattern = MagazinePattern.custom(
+            id: UUID(uuidString: "12345678-1234-1234-1234-1234567890AB")!,
+            displayName: "P320 Legion",
+            familyLabel: "P320 Legion",
+            supportedCaliberNames: ["9mm"]
+        )
+
+        XCTAssertEqual(MagazinePatternSelection.catalog("catalog:ar15-stanag-223-556-300blk").id, "catalog:catalog:ar15-stanag-223-556-300blk")
+        XCTAssertEqual(MagazinePatternSelection.existingCustom(customPattern).id, "existing-custom:\(customPattern.id)")
+        XCTAssertEqual(MagazinePatternSelection.legacy.id, "legacy")
+        XCTAssertEqual(MagazinePatternSelection.custom.id, "custom")
+        XCTAssertFalse(MagazinePatternSelection.catalog(customPattern.id).requiresManualName)
+        XCTAssertTrue(MagazinePatternSelection.legacy.requiresManualName)
+        XCTAssertTrue(MagazinePatternSelection.custom.allowsManualCaliberSelection)
+        XCTAssertFalse(MagazinePatternSelection.existingCustom(customPattern).allowsManualCaliberSelection)
+        XCTAssertEqual(viewModel.initialPurchasePriceText(for: magazine), "15.99")
+        XCTAssertEqual(viewModel.linkedFirearm(for: magazine, unlinkFirearm: false)?.displayName, "Daniel Defense DDM4")
+        XCTAssertNil(viewModel.linkedFirearm(for: magazine, unlinkFirearm: true))
+        XCTAssertEqual(viewModel.purchasePriceWithTaxText(purchasePriceCents: 10_000, taxRate: 8.25), "$108.25")
+        XCTAssertFalse(viewModel.isReadOnly(hasMagazine: false, isEditing: false))
+        XCTAssertTrue(viewModel.showsPurchaseSection(showValueInDetails: true, isReadOnly: true))
+        XCTAssertEqual(viewModel.primaryButtonTitle(hasMagazine: true, isEditing: false), "Edit")
+        XCTAssertEqual(viewModel.primaryButtonTitle(hasMagazine: true, isEditing: true), "Save")
+    }
+
+    func testPatternSelectionResolvesTitlesDescriptionsAndCalibers() {
+        let viewModel = AddMagazineViewModel()
+        let firearm = Firearm(
+            brand: "Glock",
+            modelName: "19",
+            purchasePriceCents: 50_000,
+            type: .pistol,
+            action: .semiAuto,
+            caliber: Caliber(name: "9mm")
+        )
+        let customPattern = MagazinePattern.custom(
+            id: UUID(uuidString: "12345678-1234-1234-1234-1234567890AB")!,
+            displayName: "P320 Legion",
+            familyLabel: "P320 Legion",
+            supportedCaliberNames: ["9mm"]
+        )
+        let existingCustomMagazine = Magazine(
+            brand: "SIG",
+            modelName: "OEM",
+            patternID: customPattern.id,
+            patternKind: .custom,
+            patternDisplayName: customPattern.displayName,
+            patternSupportedCaliberNames: customPattern.compatibility.supportedCaliberNames,
+            capacity: 17,
+            purchasePriceCents: 4_000
+        )
+        let invalidCatalogMagazine = Magazine(
+            brand: "Legacy",
+            modelName: "Tube",
+            patternID: "catalog:missing",
+            patternKind: .catalog,
+            capacity: 10,
+            purchasePriceCents: 2_000
+        )
+
+        XCTAssertEqual(viewModel.initialPatternSelection(for: existingCustomMagazine), .existingCustom(customPattern))
+        XCTAssertEqual(viewModel.initialPatternSelection(for: invalidCatalogMagazine), .custom)
+        XCTAssertEqual(viewModel.initialCompatibleCaliberNames(for: existingCustomMagazine), ["9mm"])
+        XCTAssertEqual(
+            viewModel.toggledCompatibleCaliberSelection(currentSelection: [], caliberName: " 9mm ", isEditing: false),
+            []
+        )
+        XCTAssertEqual(
+            viewModel.toggledCompatibleCaliberSelection(currentSelection: [], caliberName: " ", isEditing: true),
+            []
+        )
+        XCTAssertEqual(
+            viewModel.toggledCompatibleCaliberSelection(currentSelection: [], caliberName: " 9mm ", isEditing: true),
+            ["9mm"]
+        )
+        XCTAssertEqual(
+            viewModel.toggledCompatibleCaliberSelection(currentSelection: ["9mm"], caliberName: "9mm", isEditing: true),
+            []
+        )
+        XCTAssertFalse(viewModel.suggestedCatalogPatterns(firearm: firearm).isEmpty)
+        XCTAssertFalse(viewModel.additionalCatalogPatterns(firearm: firearm).contains { $0.id == "catalog:glock-double-stack-9mm-full-size-compact" })
+        XCTAssertEqual(
+            viewModel.selectedPatternTitle(
+                selection: .catalog("catalog:glock-double-stack-9mm-full-size-compact"),
+                manualPatternName: "",
+                brand: "Glock",
+                modelName: "OEM",
+                compatibleCaliberNames: [],
+                firearm: firearm
+            ),
+            "Glock 17 Pattern"
+        )
+        XCTAssertEqual(
+            viewModel.selectedPatternDescription(
+                selection: .existingCustom(customPattern),
+                manualPatternName: "",
+                brand: "SIG",
+                modelName: "OEM",
+                compatibleCaliberNames: [],
+                firearm: nil
+            ),
+            "9mm"
+        )
+        XCTAssertEqual(
+            viewModel.selectedPatternDescription(
+                selection: .legacy,
+                manualPatternName: "Legacy Tube",
+                brand: "",
+                modelName: "",
+                compatibleCaliberNames: [],
+                firearm: nil
+            ),
+            "Legacy pattern names stay visible and editable for existing data."
+        )
+        XCTAssertEqual(
+            viewModel.selectedPatternDescription(
+                selection: .custom,
+                manualPatternName: "Match Tube",
+                brand: "",
+                modelName: "",
+                compatibleCaliberNames: [],
+                firearm: nil
+            ),
+            "Custom pattern names are stored exactly as entered."
+        )
+        XCTAssertEqual(
+            viewModel.resolvedSupportedCaliberNames(
+                selection: .custom,
+                manualPatternName: "Match Tube",
+                brand: "",
+                modelName: "",
+                compatibleCaliberNames: [" 9mm ", ".38 Super", ""],
+                firearm: nil
+            ),
+            [".38 Super", "9mm"]
+        )
+    }
+
     func testCanAddReturnsFalseForMagazineCaliberMismatchAgainstLinkedFirearm() {
         let viewModel = AddMagazineViewModel()
         let firearmCaliber = Caliber(name: ".45 ACP")

--- a/ArmoryInventoryTests/FirearmsTests/AddFirearmViewModelTests.swift
+++ b/ArmoryInventoryTests/FirearmsTests/AddFirearmViewModelTests.swift
@@ -508,6 +508,10 @@ final class AddFirearmViewModelTests: XCTestCase {
             [selectedKit.persistentModelID, builtKit.persistentModelID]
         )
         XCTAssertEqual(
+            Set(viewModel.availableKits(from: [selectedKit, builtKit, linkedElsewhere], selectedIDs: [], firearm: firearm).map(\.persistentModelID)),
+            [selectedKit.persistentModelID, builtKit.persistentModelID]
+        )
+        XCTAssertEqual(
             viewModel.availableMagazinePatterns(
                 from: [arMagazine],
                 firearmType: .rifle,

--- a/ArmoryInventoryTests/FirearmsTests/AddFirearmViewModelTests.swift
+++ b/ArmoryInventoryTests/FirearmsTests/AddFirearmViewModelTests.swift
@@ -560,7 +560,8 @@ final class AddFirearmViewModelTests: XCTestCase {
         )
         let attachment = Attachment(brand: "BCM", modelName: "KAG", type: .handStop, purchasePriceCents: 2_000)
         let part = Part(brand: "BCM", modelName: "BCG", type: .boltCarrierGroup, purchasePriceCents: 20_000)
-        let kit = Kit(name: "Upper Kit", kind: .upperReceiver)
+        let staleUpdatedAt = Date(timeIntervalSince1970: 1)
+        let kit = Kit(name: "Upper Kit", kind: .upperReceiver, status: .linked, firearm: firearm, updatedAt: staleUpdatedAt)
         let opticComponent = KitComponent(category: .optic, optic: optic)
         let attachmentComponent = KitComponent(category: .attachment, attachment: attachment)
         let partComponent = KitComponent(category: .part, part: part)
@@ -614,6 +615,10 @@ final class AddFirearmViewModelTests: XCTestCase {
 
         XCTAssertTrue(deleteResult.isValid)
         XCTAssertTrue(try context.fetch(FetchDescriptor<Firearm>()).isEmpty)
+        let remainingKit = try XCTUnwrap(context.fetch(FetchDescriptor<Kit>()).first)
+        XCTAssertNil(remainingKit.firearm)
+        XCTAssertEqual(remainingKit.kitStatus, .built)
+        XCTAssertGreaterThan(remainingKit.updatedAt, staleUpdatedAt)
     }
 
     @MainActor

--- a/ArmoryInventoryTests/FirearmsTests/AddFirearmViewModelTests.swift
+++ b/ArmoryInventoryTests/FirearmsTests/AddFirearmViewModelTests.swift
@@ -320,7 +320,8 @@ final class AddFirearmViewModelTests: XCTestCase {
                 viewModel.availableOptics(
                     from: [freeOptic, currentOptic, otherOptic],
                     selectedIDs: [otherOptic.persistentModelID],
-                    firearm: currentFirearm
+                    firearm: currentFirearm,
+                    kits: []
                 )
                 .map(\.persistentModelID)
             ),
@@ -344,7 +345,8 @@ final class AddFirearmViewModelTests: XCTestCase {
                 viewModel.availableAttachments(
                     from: [freeAttachment, currentAttachment, otherAttachment],
                     selectedIDs: [],
-                    firearm: currentFirearm
+                    firearm: currentFirearm,
+                    kits: []
                 )
                 .map(\.persistentModelID)
             ),
@@ -355,7 +357,8 @@ final class AddFirearmViewModelTests: XCTestCase {
                 viewModel.availableParts(
                     from: [freePart, currentPart, otherPart],
                     selectedIDs: [],
-                    firearm: currentFirearm
+                    firearm: currentFirearm,
+                    kits: []
                 )
                 .map(\.persistentModelID)
             ),
@@ -434,6 +437,264 @@ final class AddFirearmViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.primaryButtonTitle(hasFirearm: false, isEditing: false), "Add")
         XCTAssertEqual(viewModel.primaryButtonTitle(hasFirearm: true, isEditing: false), "Edit")
         XCTAssertEqual(viewModel.primaryButtonTitle(hasFirearm: true, isEditing: true), "Save")
+        XCTAssertTrue(viewModel.showsPostTaxTotalSection(hasFirearm: true, showValueInDetails: true))
+        XCTAssertFalse(viewModel.showsPostTaxTotalSection(hasFirearm: true, showValueInDetails: false))
+        XCTAssertEqual(viewModel.taxedAmountCents(baseAmountCents: 10_000, taxRate: 8.25), 10_825)
+        XCTAssertEqual(
+            viewModel.totalValueWithTaxText(
+                firearmPriceCents: 100_000,
+                accessoriesSubtotalCents: 50_000,
+                firearmsTaxRate: 10,
+                accessoriesTaxRate: 5
+            ),
+            "$1,625.00"
+        )
+    }
+
+    @MainActor
+    func testInitialValuesMagazinePatternsAndKitHelpers() throws {
+        let container = try makeInMemoryContainer()
+        let context = container.mainContext
+        let viewModel = AddFirearmViewModel()
+        let caliber = Caliber(name: "5.56 NATO")
+        let firearm = Firearm(
+            brand: "Daniel Defense",
+            modelName: "DDM4",
+            purchasePriceCents: 180_050,
+            type: .rifle,
+            action: .semiAuto,
+            barrelLengthInches: 14.5,
+            caliber: caliber
+        )
+        let selectedPattern = FirearmMagazinePatternReference(
+            id: "catalog:glock-double-stack-9mm-full-size-compact",
+            kind: .catalog,
+            displayName: nil
+        )
+        let selectedKit = Kit(name: "Linked Kit", kind: .upperReceiver, status: .linked, firearm: firearm)
+        let builtKit = Kit(name: "Built Kit", kind: .lowerReceiver, status: .built)
+        let linkedElsewhere = Kit(
+            name: "Other Kit",
+            kind: .optics,
+            status: .linked,
+            firearm: Firearm(brand: "CZ", modelName: "Shadow 2", purchasePriceCents: 120_000, type: .pistol, action: .semiAuto)
+        )
+        context.insert(caliber)
+        context.insert(firearm)
+        context.insert(selectedKit)
+        context.insert(builtKit)
+        context.insert(linkedElsewhere)
+        try context.save()
+
+        let arMagazine = Magazine(
+            brand: "Magpul",
+            modelName: "PMAG",
+            patternID: "catalog:ar15-stanag-223-556-300blk",
+            patternKind: .catalog,
+            capacity: 30,
+            purchasePriceCents: 1_500,
+            caliber: caliber
+        )
+
+        XCTAssertEqual(viewModel.initialPurchasePriceText(for: firearm), "1,800.50")
+        XCTAssertEqual(viewModel.initialBarrelLengthText(for: firearm), "14.5")
+        XCTAssertEqual(viewModel.selectedKitIDs(for: firearm, kits: [selectedKit, builtKit]), [selectedKit.persistentModelID])
+        XCTAssertEqual(
+            viewModel.linkedKits(from: [selectedKit, builtKit], selectedIDs: [selectedKit.persistentModelID]).map(\.persistentModelID),
+            [selectedKit.persistentModelID]
+        )
+        XCTAssertEqual(
+            Set(viewModel.availableKits(from: [selectedKit, builtKit, linkedElsewhere], selectedIDs: [selectedKit.persistentModelID], firearm: firearm).map(\.persistentModelID)),
+            [selectedKit.persistentModelID, builtKit.persistentModelID]
+        )
+        XCTAssertEqual(
+            viewModel.availableMagazinePatterns(
+                from: [arMagazine],
+                firearmType: .rifle,
+                action: .semiAuto,
+                caliber: caliber,
+                selectedPatterns: [selectedPattern]
+            ).first,
+            selectedPattern
+        )
+        XCTAssertEqual(
+            viewModel.toggledMagazinePatternSelection(
+                currentSelection: [],
+                pattern: selectedPattern,
+                isEditing: false
+            ),
+            []
+        )
+        XCTAssertEqual(
+            viewModel.toggledMagazinePatternSelection(
+                currentSelection: [],
+                pattern: selectedPattern,
+                isEditing: true
+            ),
+            [selectedPattern]
+        )
+        XCTAssertEqual(
+            viewModel.toggledMagazinePatternSelection(
+                currentSelection: [selectedPattern],
+                pattern: selectedPattern,
+                isEditing: true
+            ),
+            []
+        )
+    }
+
+    @MainActor
+    func testKitManagedItemsSummaryFallbackAndDeleteFirearm() throws {
+        let container = try makeInMemoryContainer()
+        let context = container.mainContext
+        let viewModel = AddFirearmViewModel()
+        let firearm = Firearm(brand: "Aero", modelName: "M4E1", purchasePriceCents: 80_000, type: .rifle, action: .semiAuto)
+        let optic = Optic(
+            brand: "Aimpoint",
+            modelName: "T-2",
+            type: .redDot,
+            minMagnification: 1,
+            maxMagnification: 1,
+            footprint: .aimpointMicro,
+            purchasePriceCents: 70_000
+        )
+        let attachment = Attachment(brand: "BCM", modelName: "KAG", type: .handStop, purchasePriceCents: 2_000)
+        let part = Part(brand: "BCM", modelName: "BCG", type: .boltCarrierGroup, purchasePriceCents: 20_000)
+        let kit = Kit(name: "Upper Kit", kind: .upperReceiver)
+        let opticComponent = KitComponent(category: .optic, optic: optic)
+        let attachmentComponent = KitComponent(category: .attachment, attachment: attachment)
+        let partComponent = KitComponent(category: .part, part: part)
+        kit.components = [opticComponent, attachmentComponent, partComponent]
+        context.insert(firearm)
+        context.insert(optic)
+        context.insert(attachment)
+        context.insert(part)
+        context.insert(kit)
+        context.insert(opticComponent)
+        context.insert(attachmentComponent)
+        context.insert(partComponent)
+        try context.save()
+
+        let summary = viewModel.currentFirearmForSummary(
+            firearm: nil,
+            brand: "SIG",
+            modelName: "P320",
+            purchasePriceCents: 70_000,
+            type: .pistol,
+            action: .semiAuto
+        )
+
+        XCTAssertEqual(summary.displayName, "SIG P320")
+        XCTAssertEqual(
+            viewModel.currentFirearmForSummary(firearm: firearm, brand: "", modelName: "", purchasePriceCents: 0, type: .other, action: .other).persistentModelID,
+            firearm.persistentModelID
+        )
+        XCTAssertEqual(viewModel.managedOptics(from: [kit]).map(\.persistentModelID), [optic.persistentModelID])
+        XCTAssertEqual(viewModel.managedAttachments(from: [kit]).map(\.persistentModelID), [attachment.persistentModelID])
+        XCTAssertEqual(viewModel.managedParts(from: [kit]).map(\.persistentModelID), [part.persistentModelID])
+        XCTAssertEqual(
+            viewModel.managingKitName(
+                for: Optic(
+                    brand: "Loose",
+                    modelName: "Dot",
+                    type: .redDot,
+                    minMagnification: 1,
+                    maxMagnification: 1,
+                    footprint: .aimpointMicro,
+                    purchasePriceCents: 1
+                ),
+                kits: []
+            ),
+            "Kit"
+        )
+        XCTAssertEqual(viewModel.managingKitName(for: Attachment(brand: "Loose", modelName: "Grip", type: .grip, purchasePriceCents: 1), kits: []), "Kit")
+        XCTAssertEqual(viewModel.managingKitName(for: Part(brand: "Loose", modelName: "Part", type: .other, purchasePriceCents: 1), kits: []), "Kit")
+
+        let deleteResult = viewModel.deleteFirearm(firearm, in: context)
+
+        XCTAssertTrue(deleteResult.isValid)
+        XCTAssertTrue(try context.fetch(FetchDescriptor<Firearm>()).isEmpty)
+    }
+
+    @MainActor
+    func testKitEffectiveItemsNamesAndLinkPersistenceHelpers() throws {
+        let container = try makeInMemoryContainer()
+        let context = container.mainContext
+        let viewModel = AddFirearmViewModel()
+        let firearm = Firearm(
+            brand: "Daniel Defense",
+            modelName: "DDM4",
+            purchasePriceCents: 180_000,
+            type: .rifle,
+            action: .semiAuto
+        )
+        let optic = Optic(
+            brand: "Aimpoint",
+            modelName: "T-2",
+            type: .redDot,
+            minMagnification: 1,
+            maxMagnification: 1,
+            footprint: .aimpointMicro,
+            purchasePriceCents: 70_000
+        )
+        let attachment = Attachment(brand: "BCM", modelName: "KAG", type: .handStop, purchasePriceCents: 2_000)
+        let part = Part(brand: "BCM", modelName: "BCG", type: .boltCarrierGroup, purchasePriceCents: 20_000)
+        let kit = Kit(name: "Upper Kit", kind: .upperReceiver)
+        let opticComponent = KitComponent(category: .optic, optic: optic)
+        let attachmentComponent = KitComponent(category: .attachment, attachment: attachment)
+        let partComponent = KitComponent(category: .part, part: part)
+        opticComponent.kit = kit
+        attachmentComponent.kit = kit
+        partComponent.kit = kit
+        kit.components = [opticComponent, attachmentComponent, partComponent]
+
+        context.insert(firearm)
+        context.insert(optic)
+        context.insert(attachment)
+        context.insert(part)
+        context.insert(kit)
+        context.insert(opticComponent)
+        context.insert(attachmentComponent)
+        context.insert(partComponent)
+        try context.save()
+
+        XCTAssertEqual(viewModel.effectiveOptics(resolvedOptics: [optic], managedOptics: [optic]).map(\.displayName), ["Aimpoint T-2"])
+        XCTAssertEqual(viewModel.effectiveAttachments(resolvedAttachments: [], managedAttachments: [attachment]).map(\.displayName), ["BCM KAG"])
+        XCTAssertEqual(viewModel.effectiveParts(resolvedParts: [], managedParts: [part]).map(\.displayName), ["BCM BCG"])
+        XCTAssertEqual(
+            viewModel.accessoriesSubtotalCents(
+                optics: [optic],
+                magazines: [],
+                attachments: [attachment],
+                parts: [part]
+            ),
+            92_000
+        )
+        XCTAssertEqual(viewModel.managingKitName(for: optic, kits: [kit]), "Upper Kit")
+        XCTAssertEqual(viewModel.managingKitName(for: attachment, kits: [kit]), "Upper Kit")
+        XCTAssertEqual(viewModel.managingKitName(for: part, kits: [kit]), "Upper Kit")
+
+        let linkResult = viewModel.saveKitLinks(
+            firearm: firearm,
+            selectedKitIDs: [kit.persistentModelID],
+            kits: [kit],
+            in: context
+        )
+
+        XCTAssertTrue(linkResult.isValid)
+        XCTAssertEqual(kit.firearm?.persistentModelID, firearm.persistentModelID)
+        XCTAssertEqual(kit.kitStatus, .linked)
+
+        let unlinkResult = viewModel.saveKitLinks(
+            firearm: firearm,
+            selectedKitIDs: [],
+            kits: [kit],
+            in: context
+        )
+
+        XCTAssertTrue(unlinkResult.isValid)
+        XCTAssertNil(kit.firearm)
+        XCTAssertEqual(kit.kitStatus, .built)
     }
 
     @MainActor

--- a/ArmoryInventoryTests/FirearmsTests/FirearmsViewModelTests.swift
+++ b/ArmoryInventoryTests/FirearmsTests/FirearmsViewModelTests.swift
@@ -1,0 +1,314 @@
+//
+//  FirearmsViewModelTests.swift
+//  Armory InventoryTests
+//
+//  Created by Codex on 5/20/26.
+//
+
+import XCTest
+import SwiftData
+@testable import ArmoryInventory
+
+final class FirearmsViewModelTests: XCTestCase {
+    @MainActor
+    func testFilteringCountsSortingAndEffectiveTotals() throws {
+        let container = try makeInMemoryContainer()
+        let context = container.mainContext
+        let viewModel = FirearmsViewModel()
+        let rifleCaliber = Caliber(name: "5.56 NATO")
+        let pistolCaliber = Caliber(name: "9mm")
+        let rifle = Firearm(
+            brand: "Daniel Defense",
+            modelName: "DDM4",
+            purchasePriceCents: 100_000,
+            type: .rifle,
+            action: .semiAuto,
+            caliber: rifleCaliber
+        )
+        let pistol = Firearm(
+            brand: "Glock",
+            modelName: "19",
+            purchasePriceCents: 50_000,
+            type: .pistol,
+            action: .semiAuto,
+            caliber: pistolCaliber
+        )
+        let optic = Optic(
+            brand: "Aimpoint",
+            modelName: "T-2",
+            type: .redDot,
+            minMagnification: 1,
+            maxMagnification: 1,
+            footprint: .aimpointMicro,
+            purchasePriceCents: 70_000,
+            firearm: rifle
+        )
+        let part = Part(brand: "BCM", modelName: "BCG", type: .boltCarrierGroup, purchasePriceCents: 20_000)
+        let kit = Kit(name: "Upper Kit", kind: .upperReceiver, status: .linked, firearm: rifle)
+        let partComponent = KitComponent(category: .part, part: part)
+        partComponent.kit = kit
+        kit.components = [partComponent]
+        rifle.optics = [optic]
+
+        context.insert(rifleCaliber)
+        context.insert(pistolCaliber)
+        context.insert(rifle)
+        context.insert(pistol)
+        context.insert(optic)
+        context.insert(part)
+        context.insert(kit)
+        context.insert(partComponent)
+        try context.save()
+
+        XCTAssertEqual(viewModel.countForType(.rifle, in: [rifle, pistol]), 1)
+        XCTAssertEqual(viewModel.countForAction(.semiAuto, in: [rifle, pistol]), 2)
+        XCTAssertEqual(viewModel.countForCaliber(rifleCaliber, in: [rifle, pistol]), 1)
+        XCTAssertEqual(viewModel.availableCalibers(from: [rifle, pistol]).map(\.name), ["5.56 NATO", "9mm"])
+        XCTAssertEqual(
+            viewModel.filteredFirearms(
+                [rifle, pistol],
+                kits: [kit],
+                magazines: [],
+                selectedTypeFilter: .rifle,
+                selectedActionFilter: nil,
+                selectedCaliberFilter: nil,
+                sortOrder: .brand,
+                sortDirection: .ascending
+            ).map(\.displayName),
+            ["Daniel Defense DDM4"]
+        )
+        XCTAssertEqual(
+            viewModel.filteredFirearms(
+                [rifle, pistol],
+                kits: [kit],
+                magazines: [],
+                selectedTypeFilter: nil,
+                selectedActionFilter: nil,
+                selectedCaliberFilter: nil,
+                sortOrder: .value,
+                sortDirection: .descending
+            ).map(\.displayName),
+            ["Daniel Defense DDM4", "Glock 19"]
+        )
+        XCTAssertEqual(viewModel.linkedKits(for: rifle, kits: [kit]).map(\.displayName), ["Upper Kit"])
+        XCTAssertEqual(viewModel.effectiveValueCents(for: rifle, kits: [kit], magazines: []), 190_000)
+        XCTAssertEqual(viewModel.totalValueText(for: [rifle, pistol], kits: [kit], magazines: []), "$2,400.00")
+        XCTAssertEqual(viewModel.allTypesCountText(for: [rifle, pistol]), "All Types (2)")
+        XCTAssertEqual(viewModel.allActionsCountText(for: [rifle, pistol]), "All Actions (2)")
+        XCTAssertEqual(viewModel.allCalibersCountText(for: [rifle, pistol]), "All Calibers (2)")
+        XCTAssertEqual(viewModel.filterCountText(title: "Rifle", count: 1), "Rifle (1)")
+    }
+
+    @MainActor
+    func testSortOrdersAndDefaults() {
+        let viewModel = FirearmsViewModel()
+        let rifleCaliber = Caliber(name: "5.56 NATO")
+        let pistolCaliber = Caliber(name: "9mm")
+        let first = Firearm(
+            brand: "Aero",
+            modelName: "M4E1",
+            purchaseDate: Date(timeIntervalSince1970: 2),
+            purchasePriceCents: 90_000,
+            type: .rifle,
+            action: .semiAuto,
+            barrelLengthInches: 16,
+            caliber: rifleCaliber
+        )
+        let second = Firearm(
+            brand: "Aero",
+            modelName: "X15",
+            purchaseDate: Date(timeIntervalSince1970: 1),
+            purchasePriceCents: 95_000,
+            type: .rifle,
+            action: .bolt,
+            barrelLengthInches: 20,
+            caliber: rifleCaliber
+        )
+        let third = Firearm(
+            brand: "Glock",
+            modelName: "19",
+            purchaseDate: Date(timeIntervalSince1970: 3),
+            purchasePriceCents: 50_000,
+            type: .pistol,
+            action: .semiAuto,
+            caliber: pistolCaliber
+        )
+        let firearms = [first, second, third]
+
+        XCTAssertEqual(viewModel.selectedSortOrder(from: "bad"), .manual)
+        XCTAssertEqual(viewModel.selectedSortOrder(from: FirearmSortOrder.brand.rawValue), .brand)
+        XCTAssertEqual(viewModel.selectedSortDirection(from: "bad", sortOrder: .purchaseDate), .descending)
+        XCTAssertEqual(viewModel.selectedSortDirection(from: FirearmSortDirection.ascending.rawValue, sortOrder: .value), .ascending)
+        XCTAssertEqual(viewModel.preferredDirection(for: .manual), .ascending)
+        XCTAssertEqual(viewModel.preferredDirection(for: .value), .descending)
+        XCTAssertEqual(viewModel.preferredDirection(for: .type), .ascending)
+        XCTAssertFalse(
+            viewModel.matchesFilters(
+                first,
+                selectedTypeFilter: .pistol,
+                selectedActionFilter: nil,
+                selectedCaliberFilter: nil
+            )
+        )
+        XCTAssertFalse(
+            viewModel.matchesFilters(
+                first,
+                selectedTypeFilter: nil,
+                selectedActionFilter: .pump,
+                selectedCaliberFilter: nil
+            )
+        )
+        XCTAssertFalse(
+            viewModel.matchesFilters(
+                first,
+                selectedTypeFilter: nil,
+                selectedActionFilter: nil,
+                selectedCaliberFilter: pistolCaliber
+            )
+        )
+        XCTAssertEqual(
+            viewModel.filteredFirearms(
+                firearms,
+                kits: [],
+                magazines: [],
+                selectedTypeFilter: nil,
+                selectedActionFilter: nil,
+                selectedCaliberFilter: nil,
+                sortOrder: .purchaseDate,
+                sortDirection: .ascending
+            ).map(\.displayName),
+            ["Aero X15", "Aero M4E1", "Glock 19"]
+        )
+        XCTAssertEqual(
+            viewModel.filteredFirearms(
+                firearms,
+                kits: [],
+                magazines: [],
+                selectedTypeFilter: nil,
+                selectedActionFilter: nil,
+                selectedCaliberFilter: nil,
+                sortOrder: .barrelLength,
+                sortDirection: .descending
+            ).map(\.displayName),
+            ["Aero X15", "Aero M4E1", "Glock 19"]
+        )
+        XCTAssertEqual(
+            viewModel.filteredFirearms(
+                firearms,
+                kits: [],
+                magazines: [],
+                selectedTypeFilter: nil,
+                selectedActionFilter: nil,
+                selectedCaliberFilter: nil,
+                sortOrder: .caliber,
+                sortDirection: .ascending
+            ).map(\.displayName),
+            ["Aero M4E1", "Aero X15", "Glock 19"]
+        )
+        XCTAssertEqual(
+            viewModel.filteredFirearms(
+                firearms,
+                kits: [],
+                magazines: [],
+                selectedTypeFilter: nil,
+                selectedActionFilter: nil,
+                selectedCaliberFilter: nil,
+                sortOrder: .type,
+                sortDirection: .descending
+            ).map(\.displayName),
+            ["Aero X15", "Aero M4E1", "Glock 19"]
+        )
+        XCTAssertEqual(
+            viewModel.filteredFirearms(
+                firearms,
+                kits: [],
+                magazines: [],
+                selectedTypeFilter: nil,
+                selectedActionFilter: nil,
+                selectedCaliberFilter: nil,
+                sortOrder: .brand,
+                sortDirection: .ascending
+            ).map(\.displayName),
+            ["Aero M4E1", "Aero X15", "Glock 19"]
+        )
+    }
+
+    @MainActor
+    func testReorderOnlyAppliesWithinFilteredManualList() throws {
+        let container = try makeInMemoryContainer()
+        let context = container.mainContext
+        let viewModel = FirearmsViewModel()
+        let first = Firearm(brand: "A", modelName: "Rifle", purchasePriceCents: 0, type: .rifle, action: .semiAuto, sortOrder: 0)
+        let middle = Firearm(brand: "B", modelName: "Pistol", purchasePriceCents: 0, type: .pistol, action: .semiAuto, sortOrder: 1)
+        let last = Firearm(brand: "C", modelName: "Rifle", purchasePriceCents: 0, type: .rifle, action: .bolt, sortOrder: 2)
+        let firearms = [first, middle, last]
+        for firearm in firearms {
+            context.insert(firearm)
+        }
+        try context.save()
+        let filtered = viewModel.filteredFirearms(
+            firearms,
+            kits: [],
+            magazines: [],
+            selectedTypeFilter: .rifle,
+            selectedActionFilter: nil,
+            selectedCaliberFilter: nil,
+            sortOrder: .manual,
+            sortDirection: .ascending
+        )
+
+        let reordered = viewModel.reorderedFirearms(
+            allFirearms: firearms,
+            filteredFirearms: filtered,
+            selectedTypeFilter: .rifle,
+            selectedActionFilter: nil,
+            selectedCaliberFilter: nil,
+            source: IndexSet(integer: 1),
+            destination: 0
+        )
+        viewModel.applySortOrder(to: reordered)
+
+        XCTAssertEqual(reordered.map(\.displayName), ["C Rifle", "B Pistol", "A Rifle"])
+        XCTAssertEqual(last.sortOrder, 0)
+        XCTAssertEqual(middle.sortOrder, 1)
+        XCTAssertEqual(first.sortOrder, 2)
+        XCTAssertEqual(
+            viewModel.reorderedFirearms(
+                allFirearms: firearms,
+                filteredFirearms: filtered,
+                selectedTypeFilter: .rifle,
+                selectedActionFilter: nil,
+                selectedCaliberFilter: nil,
+                source: [],
+                destination: 0
+            ).map(\.displayName),
+            ["A Rifle", "B Pistol", "C Rifle"]
+        )
+        XCTAssertTrue(
+            viewModel.moveFirearms(
+                allFirearms: firearms,
+                filteredFirearms: filtered,
+                selectedTypeFilter: .rifle,
+                selectedActionFilter: nil,
+                selectedCaliberFilter: nil,
+                sortOrder: .brand,
+                source: IndexSet(integer: 1),
+                destination: 0,
+                in: context
+            ).isValid
+        )
+        XCTAssertTrue(
+            viewModel.moveFirearms(
+                allFirearms: firearms,
+                filteredFirearms: filtered,
+                selectedTypeFilter: .rifle,
+                selectedActionFilter: nil,
+                selectedCaliberFilter: nil,
+                sortOrder: .manual,
+                source: IndexSet(integer: 1),
+                destination: 0,
+                in: context
+            ).isValid
+        )
+    }
+}

--- a/ArmoryInventoryTests/KitsTests/AddKitViewModelTests.swift
+++ b/ArmoryInventoryTests/KitsTests/AddKitViewModelTests.swift
@@ -248,5 +248,55 @@ final class AddKitViewModelTests: XCTestCase {
 
         XCTAssertTrue(disassembleResult.isValid)
         XCTAssertTrue(remainingKits.isEmpty)
+        XCTAssertEqual(try context.fetch(FetchDescriptor<Part>()).map(\.displayName).sorted(), ["Aero M4E1", "BCM Linked", "BCM Selected"])
+        XCTAssertEqual(try context.fetch(FetchDescriptor<Optic>()).map(\.displayName), ["Aimpoint T-2"])
+        XCTAssertEqual(try context.fetch(FetchDescriptor<Attachment>()).map(\.displayName), ["BCM KAG"])
+    }
+
+    @MainActor
+    func testDiscardDeletesKitAndLinkedComponents() throws {
+        let container = try makeInMemoryContainer()
+        let context = container.mainContext
+        let viewModel = AddKitViewModel()
+        let retainedPart = Part(brand: "Aero", modelName: "Lower", type: .lowerReceiver, purchasePriceCents: 12_000)
+        let discardedPart = Part(brand: "BCM", modelName: "BCG", type: .boltCarrierGroup, purchasePriceCents: 18_000)
+        let discardedOptic = Optic(
+            brand: "Aimpoint",
+            modelName: "T-2",
+            type: .redDot,
+            minMagnification: 1,
+            maxMagnification: 1,
+            footprint: .aimpointMicro,
+            purchasePriceCents: 70_000
+        )
+        let discardedAttachment = Attachment(brand: "BCM", modelName: "KAG", type: .handStop, purchasePriceCents: 2_000)
+        context.insert(retainedPart)
+        context.insert(discardedPart)
+        context.insert(discardedOptic)
+        context.insert(discardedAttachment)
+        try context.save()
+
+        let saveResult = viewModel.saveKit(
+            nil,
+            name: "Discard Target",
+            kind: .upperReceiver,
+            notes: nil,
+            components: [
+                KitComponent(category: .part, part: discardedPart),
+                KitComponent(category: .optic, optic: discardedOptic),
+                KitComponent(category: .attachment, attachment: discardedAttachment)
+            ],
+            targetStatus: .built,
+            kits: [],
+            in: context
+        )
+        let kit = try XCTUnwrap(context.fetch(FetchDescriptor<Kit>()).first)
+
+        XCTAssertTrue(saveResult.isValid)
+        XCTAssertTrue(viewModel.discardKit(kit, in: context).isValid)
+        XCTAssertTrue(try context.fetch(FetchDescriptor<Kit>()).isEmpty)
+        XCTAssertEqual(try context.fetch(FetchDescriptor<Part>()).map(\.displayName), ["Aero Lower"])
+        XCTAssertTrue(try context.fetch(FetchDescriptor<Optic>()).isEmpty)
+        XCTAssertTrue(try context.fetch(FetchDescriptor<Attachment>()).isEmpty)
     }
 }

--- a/ArmoryInventoryTests/KitsTests/AddKitViewModelTests.swift
+++ b/ArmoryInventoryTests/KitsTests/AddKitViewModelTests.swift
@@ -1,0 +1,252 @@
+//
+//  AddKitViewModelTests.swift
+//  Armory InventoryTests
+//
+//  Created by Codex on 5/20/26.
+//
+
+import XCTest
+import SwiftData
+@testable import ArmoryInventory
+
+final class AddKitViewModelTests: XCTestCase {
+    @MainActor
+    func testPresentationHelpersReturnLocalizedTitlesAndVisibility() {
+        let viewModel = AddKitViewModel()
+        let kit = Kit(name: "Upper", kind: .upperReceiver, status: .built)
+        let linkedKit = Kit(name: "Linked", kind: .custom, status: .linked)
+
+        XCTAssertEqual(viewModel.initialName(for: kit), "Upper")
+        XCTAssertEqual(viewModel.initialName(for: nil), "")
+        XCTAssertEqual(viewModel.initialNotes(for: Kit(name: "Notes", kind: .custom, notes: "Range setup")), "Range setup")
+        XCTAssertEqual(viewModel.initialKind(for: nil), .upperReceiver)
+        XCTAssertEqual(viewModel.initialKind(for: linkedKit), .custom)
+        XCTAssertEqual(viewModel.navigationTitle(for: nil), "New Kit")
+        XCTAssertEqual(viewModel.navigationTitle(for: kit), "Kit Details")
+        XCTAssertEqual(viewModel.primarySaveTitle(for: nil), "Build Kit")
+        XCTAssertEqual(viewModel.primarySaveTitle(for: kit), "Save")
+        XCTAssertTrue(viewModel.shouldShowDisassembleButton(for: kit))
+        XCTAssertTrue(viewModel.shouldShowDisassembleButton(for: linkedKit))
+        XCTAssertFalse(viewModel.shouldShowDisassembleButton(for: nil))
+        XCTAssertEqual(viewModel.optionalValue("  Notes  "), "Notes")
+        XCTAssertNil(viewModel.optionalValue("   "))
+        XCTAssertEqual(viewModel.displayName(name: "  ", kind: .optics), "Optics Kit")
+        XCTAssertEqual(viewModel.displayName(name: "  Match Kit  ", kind: .custom), "Match Kit")
+        XCTAssertEqual(viewModel.emptySelectionText(for: .part), "No parts selected.")
+        XCTAssertEqual(viewModel.emptySelectionText(for: .attachment), "No attachments selected.")
+        XCTAssertEqual(viewModel.pickerTitle(for: .part), "Select Parts")
+        XCTAssertEqual(viewModel.pickerTitle(for: .optic), "Select Optics")
+        XCTAssertEqual(viewModel.pickerTitle(for: .attachment), "Select Attachments")
+        XCTAssertEqual(viewModel.pickerEmptyTitle(for: .part), "No Parts Available")
+        XCTAssertEqual(viewModel.pickerEmptyTitle(for: .optic), "No Optics Available")
+        XCTAssertEqual(viewModel.pickerEmptyTitle(for: .attachment), "No Attachments Available")
+    }
+
+    @MainActor
+    func testSelectionsRowsComponentsAndPickerItemsAreViewModelOwned() throws {
+        let container = try makeInMemoryContainer()
+        let context = container.mainContext
+        let viewModel = AddKitViewModel()
+        let part = Part(brand: "BCM", modelName: "MK2", type: .upperReceiver, purchasePriceCents: 20_000)
+        let optic = Optic(
+            brand: "Aimpoint",
+            modelName: "T-2",
+            type: .redDot,
+            minMagnification: 1,
+            maxMagnification: 1,
+            footprint: .aimpointMicro,
+            purchasePriceCents: 70_000
+        )
+        let attachment = Attachment(brand: "BCM", modelName: "KAG", type: .handStop, purchasePriceCents: 2_000)
+        context.insert(part)
+        context.insert(optic)
+        context.insert(attachment)
+        try context.save()
+
+        let selections = [
+            KitComponentSelection(category: .part, itemID: part.persistentModelID),
+            KitComponentSelection(category: .optic, itemID: optic.persistentModelID),
+            KitComponentSelection(category: .attachment, itemID: attachment.persistentModelID)
+        ]
+
+        XCTAssertEqual(viewModel.selectedIDs(from: selections, category: .part), [part.persistentModelID])
+        let initialSelections = viewModel.initialSelections(
+            for: Kit(
+                name: "Upper",
+                kind: .upperReceiver,
+                components: [
+                    KitComponent(category: .part, part: part),
+                    KitComponent(category: .optic, optic: optic),
+                    KitComponent(category: .attachment, attachment: attachment),
+                    KitComponent(category: .part)
+                ]
+            )
+        )
+        XCTAssertEqual(Set(initialSelections), Set(selections))
+        XCTAssertEqual(
+            viewModel.toggledSelection([], category: .part, itemID: part.persistentModelID),
+            [selections[0]]
+        )
+        XCTAssertEqual(
+            viewModel.toggledSelection([selections[0]], category: .part, itemID: part.persistentModelID),
+            []
+        )
+        XCTAssertEqual(
+            viewModel.components(from: selections, parts: [part], optics: [optic], attachments: [attachment]).map(\.componentCategory),
+            [.part, .optic, .attachment]
+        )
+        XCTAssertEqual(
+            viewModel.selectedComponentRows(
+                for: .optic,
+                selections: selections,
+                parts: [part],
+                optics: [optic],
+                attachments: [attachment]
+            ),
+            [
+                AddKitComponentRow(
+                    selection: selections[1],
+                    title: "Aimpoint T-2",
+                    subtitle: "Red Dot • 1x"
+                )
+            ]
+        )
+        XCTAssertEqual(
+            viewModel.componentTitle(
+                for: KitComponentSelection(category: .optic, itemID: part.persistentModelID),
+                parts: [part],
+                optics: [],
+                attachments: [attachment]
+            ),
+            "Missing Optic"
+        )
+        XCTAssertEqual(
+            viewModel.componentTitle(
+                for: KitComponentSelection(category: .part, itemID: optic.persistentModelID),
+                parts: [],
+                optics: [optic],
+                attachments: [attachment]
+            ),
+            "Missing Part"
+        )
+        XCTAssertEqual(
+            viewModel.componentTitle(
+                for: KitComponentSelection(category: .attachment, itemID: optic.persistentModelID),
+                parts: [part],
+                optics: [optic],
+                attachments: []
+            ),
+            "Missing Attachment"
+        )
+        XCTAssertEqual(
+            viewModel.componentSubtitle(
+                for: KitComponentSelection(category: .optic, itemID: part.persistentModelID),
+                parts: [part],
+                optics: [],
+                attachments: [attachment]
+            ),
+            "Optic"
+        )
+        XCTAssertEqual(viewModel.componentValueCents(from: selections, parts: [part], optics: [optic], attachments: [attachment]), 92_000)
+
+        let partItems = viewModel.partPickerItems(parts: [part], selections: selections, kits: [], editing: nil)
+        XCTAssertEqual(partItems.first?.title, "BCM MK2")
+        XCTAssertEqual(partItems.first?.subtitle, "Upper Receiver")
+        XCTAssertEqual(partItems.first?.isSelected, true)
+
+        let opticItems = viewModel.opticPickerItems(optics: [optic], selections: selections, kits: [], editing: nil)
+        XCTAssertEqual(opticItems.count, 1)
+        XCTAssertEqual(opticItems.first?.title, "Aimpoint T-2")
+        XCTAssertEqual(opticItems.first?.subtitle, "Red Dot • 1x")
+        XCTAssertEqual(opticItems.first?.isSelected, true)
+
+        let attachmentItems = viewModel.attachmentPickerItems(attachments: [attachment], selections: selections, kits: [], editing: nil)
+        XCTAssertEqual(attachmentItems.first?.title, "BCM KAG")
+        XCTAssertEqual(attachmentItems.first?.subtitle, "Hand Stop")
+        XCTAssertEqual(attachmentItems.first?.isSelected, true)
+    }
+
+    @MainActor
+    func testAvailabilityValidationSaveAndDisassemble() throws {
+        let container = try makeInMemoryContainer()
+        let context = container.mainContext
+        let viewModel = AddKitViewModel()
+        let firearm = Firearm(brand: "Daniel Defense", modelName: "DDM4", purchasePriceCents: 100_000, type: .rifle, action: .semiAuto)
+        let unavailablePart = Part(brand: "BCM", modelName: "Linked", type: .upperReceiver, purchasePriceCents: 20_000, firearm: firearm)
+        let selectedUnavailablePart = Part(brand: "BCM", modelName: "Selected", type: .chargingHandle, purchasePriceCents: 8_000, firearm: firearm)
+        let freePart = Part(brand: "Aero", modelName: "M4E1", type: .lowerReceiver, purchasePriceCents: 12_000)
+        let freeOptic = Optic(
+            brand: "Aimpoint",
+            modelName: "T-2",
+            type: .redDot,
+            minMagnification: 1,
+            maxMagnification: 1,
+            footprint: .aimpointMicro,
+            purchasePriceCents: 70_000
+        )
+        let freeAttachment = Attachment(brand: "BCM", modelName: "KAG", type: .handStop, purchasePriceCents: 2_000)
+        context.insert(firearm)
+        context.insert(unavailablePart)
+        context.insert(selectedUnavailablePart)
+        context.insert(freePart)
+        context.insert(freeOptic)
+        context.insert(freeAttachment)
+        try context.save()
+
+        XCTAssertEqual(
+            viewModel.availableParts(
+                from: [unavailablePart, selectedUnavailablePart, freePart],
+                selectedIDs: [selectedUnavailablePart.persistentModelID],
+                kits: [],
+                editing: nil
+            ).map(\.displayName),
+            ["BCM Selected", "Aero M4E1"]
+        )
+        XCTAssertFalse(viewModel.validationResultForBuild(components: [], kits: [], editing: nil).isValid)
+
+        let components = [
+            KitComponent(category: .part, part: freePart),
+            KitComponent(category: .optic, optic: freeOptic),
+            KitComponent(category: .attachment, attachment: freeAttachment)
+        ]
+        let saveResult = viewModel.saveKit(
+            nil,
+            name: "  ",
+            kind: .upperReceiver,
+            notes: "Range",
+            components: components,
+            targetStatus: .built,
+            kits: [],
+            in: context
+        )
+        let kits = try context.fetch(FetchDescriptor<Kit>())
+
+        XCTAssertTrue(saveResult.isValid)
+        XCTAssertEqual(kits.count, 1)
+        XCTAssertEqual(kits.first?.displayName, "Upper Receiver Kit")
+        XCTAssertEqual(kits.first?.components.count, 3)
+        XCTAssertEqual(viewModel.nextSortOrder(in: context), 1)
+
+        let updatedResult = viewModel.saveKit(
+            kits[0],
+            name: "Updated Kit",
+            kind: .custom,
+            notes: nil,
+            components: [KitComponent(category: .part, part: freePart)],
+            targetStatus: .built,
+            kits: [kits[0]],
+            in: context
+        )
+
+        XCTAssertTrue(updatedResult.isValid)
+        XCTAssertEqual(kits[0].displayName, "Updated Kit")
+        XCTAssertEqual(kits[0].kitKind, .custom)
+        XCTAssertEqual(kits[0].components.count, 1)
+
+        let disassembleResult = viewModel.disassembleKit(kits[0], in: context)
+        let remainingKits = try context.fetch(FetchDescriptor<Kit>())
+
+        XCTAssertTrue(disassembleResult.isValid)
+        XCTAssertTrue(remainingKits.isEmpty)
+    }
+}

--- a/ArmoryInventoryTests/KitsTests/KitEligibilityServiceTests.swift
+++ b/ArmoryInventoryTests/KitsTests/KitEligibilityServiceTests.swift
@@ -1,0 +1,61 @@
+//
+//  KitEligibilityServiceTests.swift
+//  Armory InventoryTests
+//
+//  Created by Codex on 5/14/26.
+//
+
+import XCTest
+import SwiftData
+@testable import ArmoryInventory
+
+final class KitEligibilityServiceTests: XCTestCase {
+    private let service = KitEligibilityService()
+
+    @MainActor
+    func testDirectFirearmLinkedItemCannotBeSelectedForKit() throws {
+        let firearm = Firearm(brand: "Daniel Defense", modelName: "DDM4", purchasePriceCents: 100_000, type: .rifle, action: .semiAuto)
+        let part = Part(brand: "BCM", modelName: "BCG", type: .boltCarrierGroup, purchasePriceCents: 18_000, firearm: firearm)
+
+        XCTAssertFalse(service.canSelectForKit(part, kits: [], excluding: nil))
+    }
+
+    @MainActor
+    func testBuiltAndLinkedKitsReserveItems() throws {
+        let part = Part(brand: "BCM", modelName: "BCG", type: .boltCarrierGroup, purchasePriceCents: 18_000)
+        let builtKit = Kit(name: "Built", kind: .upperReceiver, status: .built)
+        let linkedKit = Kit(name: "Linked", kind: .upperReceiver, status: .linked)
+        let builtComponent = KitComponent(category: .part, slot: .boltCarrierGroup, part: part)
+        let linkedComponent = KitComponent(category: .part, slot: .boltCarrierGroup, part: part)
+        builtComponent.kit = builtKit
+        builtKit.components = [builtComponent]
+        linkedComponent.kit = linkedKit
+        linkedKit.components = [linkedComponent]
+
+        XCTAssertFalse(service.canSelectForKit(part, kits: [builtKit], excluding: nil))
+        XCTAssertFalse(service.canSelectForKit(part, kits: [linkedKit], excluding: nil))
+        XCTAssertFalse(service.canSelectForDirectFirearm(part, kits: [builtKit]))
+    }
+
+    @MainActor
+    func testBuildValidationFailsWhenItemWasClaimedByAnotherKit() throws {
+        let part = Part(brand: "BCM", modelName: "BCG", type: .boltCarrierGroup, purchasePriceCents: 18_000)
+        let editedKit = Kit(name: "Edited", kind: .upperReceiver, status: .built)
+        let claimingKit = Kit(name: "Claim", kind: .upperReceiver, status: .built)
+        let editedComponent = KitComponent(category: .part, slot: .boltCarrierGroup, part: part)
+        let claimingComponent = KitComponent(category: .part, slot: .boltCarrierGroup, part: part)
+        editedComponent.kit = editedKit
+        editedKit.components = [editedComponent]
+        claimingComponent.kit = claimingKit
+        claimingKit.components = [claimingComponent]
+
+        let result = service.validationResultForBuild(
+            components: editedKit.components,
+            kits: [editedKit, claimingKit],
+            excluding: editedKit
+        )
+
+        XCTAssertFalse(result.isValid)
+        XCTAssertEqual(result.message, "BCM BCG is already reserved by another built or linked kit.")
+    }
+}

--- a/ArmoryInventoryTests/KitsTests/KitModelsTests.swift
+++ b/ArmoryInventoryTests/KitsTests/KitModelsTests.swift
@@ -1,0 +1,57 @@
+//
+//  KitModelsTests.swift
+//  Armory InventoryTests
+//
+//  Created by Codex on 5/14/26.
+//
+
+import XCTest
+import SwiftData
+@testable import ArmoryInventory
+
+final class KitModelsTests: XCTestCase {
+    @MainActor
+    func testKitComponentSupportsOnlyPartsOpticsAndAttachments() throws {
+        let container = try makeInMemoryContainer()
+        let context = container.mainContext
+        let part = Part(brand: "BCM", modelName: "Upper", type: .upperReceiver, purchasePriceCents: 10_000)
+        let optic = Optic(
+            brand: "Aimpoint",
+            modelName: "T2",
+            type: .redDot,
+            minMagnification: 1,
+            maxMagnification: 1,
+            footprint: .aimpointMicro,
+            purchasePriceCents: 70_000
+        )
+        let attachment = Attachment(brand: "BCM", modelName: "Grip", type: .grip, purchasePriceCents: 2_000)
+        let magazine = Magazine(brand: "Magpul", modelName: "PMAG", capacity: 30, purchasePriceCents: 1_500)
+        let kit = Kit(name: "Upper", kind: .upperReceiver)
+        let partComponent = KitComponent(category: .part, slot: .receiver, part: part)
+        let opticComponent = KitComponent(category: .optic, slot: .optic, optic: optic)
+        let attachmentComponent = KitComponent(category: .attachment, slot: .foregrip, attachment: attachment)
+
+        context.insert(part)
+        context.insert(optic)
+        context.insert(attachment)
+        context.insert(magazine)
+        context.insert(kit)
+        for component in [partComponent, opticComponent, attachmentComponent] {
+            component.kit = kit
+            context.insert(component)
+        }
+        kit.components = [partComponent, opticComponent, attachmentComponent]
+        try context.save()
+
+        XCTAssertEqual(kit.components.count, 3)
+        XCTAssertEqual(Set(kit.components.map(\.componentCategory)), Set([.part, .optic, .attachment]))
+        XCTAssertNil(magazine.firearm)
+        XCTAssertEqual(kit.totalValueCents, 82_000)
+    }
+
+    @MainActor
+    func testStatusReservationFlagsMatchLifecycle() {
+        XCTAssertTrue(KitStatus.built.reservesComponents)
+        XCTAssertTrue(KitStatus.linked.reservesComponents)
+    }
+}

--- a/ArmoryInventoryTests/KitsTests/KitUserDataTransferTests.swift
+++ b/ArmoryInventoryTests/KitsTests/KitUserDataTransferTests.swift
@@ -1,0 +1,87 @@
+//
+//  KitUserDataTransferTests.swift
+//  Armory InventoryTests
+//
+//  Created by Codex on 5/14/26.
+//
+
+import XCTest
+import SwiftData
+@testable import ArmoryInventory
+
+final class KitUserDataTransferTests: XCTestCase {
+    @MainActor
+    func testVersionOneBackupImportsWithEmptyKits() throws {
+        let json = """
+        {
+          "version" : 1,
+          "exportedAt" : "2026-05-14T00:00:00Z",
+          "settings" : {},
+          "calibers" : [],
+          "ammoTypes" : [],
+          "ammoAdjustmentRecords" : [],
+          "firearms" : [],
+          "optics" : [],
+          "magazines" : [],
+          "attachments" : [],
+          "parts" : []
+        }
+        """
+        let container = try makeInMemoryContainer()
+        let context = container.mainContext
+
+        try UserDataTransferService().importData(Data(json.utf8), into: context)
+
+        let importedKits = try context.fetch(FetchDescriptor<Kit>())
+        XCTAssertTrue(importedKits.isEmpty)
+    }
+
+    @MainActor
+    func testKitExportImportRoundTripsComponentReferences() throws {
+        let sourceContainer = try makeInMemoryContainer()
+        let sourceContext = sourceContainer.mainContext
+        let firearmID = UUID()
+        let partID = UUID()
+        let firearm = Firearm(
+            id: firearmID,
+            brand: "Daniel Defense",
+            modelName: "DDM4",
+            purchasePriceCents: 100_000,
+            type: .rifle,
+            action: .semiAuto
+        )
+        let part = Part(
+            id: partID,
+            brand: "BCM",
+            modelName: "BCG",
+            type: .boltCarrierGroup,
+            purchasePriceCents: 18_000
+        )
+        let kit = Kit(name: "Upper", kind: .upperReceiver, status: .linked, firearm: firearm)
+        let component = KitComponent(category: .part, slot: .boltCarrierGroup, part: part)
+        component.kit = kit
+        kit.components = [component]
+
+        sourceContext.insert(firearm)
+        sourceContext.insert(part)
+        sourceContext.insert(kit)
+        sourceContext.insert(component)
+        try sourceContext.save()
+
+        let data = try UserDataTransferService().exportData(from: sourceContext)
+        let jsonObject = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+        XCTAssertEqual(jsonObject?["version"] as? Int, 2)
+
+        let destinationContainer = try makeInMemoryContainer()
+        let destinationContext = destinationContainer.mainContext
+        try UserDataTransferService().importData(data, into: destinationContext)
+
+        let importedKits = try destinationContext.fetch(FetchDescriptor<Kit>())
+        XCTAssertEqual(importedKits.count, 1)
+        XCTAssertEqual(importedKits.first?.name, "Upper")
+        XCTAssertEqual(importedKits.first?.kitStatus, .linked)
+        XCTAssertEqual(importedKits.first?.firearm?.id, firearmID)
+        XCTAssertEqual(importedKits.first?.components.first?.part?.id, partID)
+        XCTAssertEqual(importedKits.first?.components.first?.componentSlot, .boltCarrierGroup)
+    }
+}

--- a/ArmoryInventoryTests/KitsTests/KitValueServiceTests.swift
+++ b/ArmoryInventoryTests/KitsTests/KitValueServiceTests.swift
@@ -1,0 +1,75 @@
+//
+//  KitValueServiceTests.swift
+//  Armory InventoryTests
+//
+//  Created by Codex on 5/14/26.
+//
+
+import XCTest
+import SwiftData
+@testable import ArmoryInventory
+
+final class KitValueServiceTests: XCTestCase {
+    @MainActor
+    func testKitValueDeduplicatesRepeatedComponentIdentity() throws {
+        let container = try makeInMemoryContainer()
+        let context = container.mainContext
+        let optic = Optic(
+            brand: "Aimpoint",
+            modelName: "T2",
+            type: .redDot,
+            minMagnification: 1,
+            maxMagnification: 1,
+            footprint: .aimpointMicro,
+            purchasePriceCents: 70_000
+        )
+        context.insert(optic)
+        try context.save()
+
+        let first = KitComponent(category: .optic, slot: .optic, optic: optic)
+        let second = KitComponent(category: .optic, slot: .support, optic: optic)
+
+        XCTAssertEqual(KitValueService.totalValueCents(for: [first, second]), 70_000)
+    }
+
+    @MainActor
+    func testFirearmEffectiveValueDeduplicatesDirectAndKitManagedItems() throws {
+        let container = try makeInMemoryContainer()
+        let context = container.mainContext
+        let firearm = Firearm(brand: "Daniel Defense", modelName: "DDM4", purchasePriceCents: 100_000, type: .rifle, action: .semiAuto)
+        let optic = Optic(
+            brand: "Aimpoint",
+            modelName: "T2",
+            type: .redDot,
+            minMagnification: 1,
+            maxMagnification: 1,
+            footprint: .aimpointMicro,
+            purchasePriceCents: 70_000,
+            firearm: firearm
+        )
+        let part = Part(brand: "BCM", modelName: "BCG", type: .boltCarrierGroup, purchasePriceCents: 18_000)
+        let kit = Kit(name: "Upper", kind: .upperReceiver, status: .linked, firearm: firearm)
+        let opticComponent = KitComponent(category: .optic, slot: .optic, optic: optic)
+        let partComponent = KitComponent(category: .part, slot: .boltCarrierGroup, part: part)
+        opticComponent.kit = kit
+        partComponent.kit = kit
+        kit.components = [opticComponent, partComponent]
+        firearm.optics = [optic]
+
+        context.insert(firearm)
+        context.insert(optic)
+        context.insert(part)
+        context.insert(kit)
+        context.insert(opticComponent)
+        context.insert(partComponent)
+        try context.save()
+
+        let total = KitValueService.effectiveTotalValueCents(
+            for: firearm,
+            linkedKits: [kit],
+            compatibleMagazines: []
+        )
+
+        XCTAssertEqual(total, 188_000)
+    }
+}

--- a/ArmoryInventoryTests/KitsTests/KitsViewModelTests.swift
+++ b/ArmoryInventoryTests/KitsTests/KitsViewModelTests.swift
@@ -1,0 +1,90 @@
+//
+//  KitsViewModelTests.swift
+//  Armory InventoryTests
+//
+//  Created by Codex on 5/20/26.
+//
+
+import XCTest
+import SwiftData
+@testable import ArmoryInventory
+
+final class KitsViewModelTests: XCTestCase {
+    @MainActor
+    func testFilteringCountsTotalsAndComponentSummaries() throws {
+        let container = try makeInMemoryContainer()
+        let context = container.mainContext
+        let viewModel = KitsViewModel()
+        let firearm = Firearm(
+            brand: "Daniel Defense",
+            modelName: "DDM4",
+            purchasePriceCents: 100_000,
+            type: .rifle,
+            action: .semiAuto
+        )
+        let part = Part(brand: "BCM", modelName: "MK2", type: .upperReceiver, purchasePriceCents: 20_000)
+        let optic = Optic(
+            brand: "Aimpoint",
+            modelName: "T-2",
+            type: .redDot,
+            minMagnification: 1,
+            maxMagnification: 1,
+            footprint: .aimpointMicro,
+            purchasePriceCents: 70_000
+        )
+        let upperKit = Kit(name: "Range Upper", kind: .upperReceiver, status: .linked, firearm: firearm)
+        let opticKit = Kit(name: "Dot Package", kind: .optics)
+        let partComponent = KitComponent(category: .part, part: part)
+        let opticComponent = KitComponent(category: .optic, optic: optic)
+        partComponent.kit = upperKit
+        opticComponent.kit = opticKit
+        upperKit.components = [partComponent]
+        opticKit.components = [opticComponent]
+
+        context.insert(firearm)
+        context.insert(part)
+        context.insert(optic)
+        context.insert(upperKit)
+        context.insert(opticKit)
+        context.insert(partComponent)
+        context.insert(opticComponent)
+        try context.save()
+
+        XCTAssertEqual(viewModel.filteredKits([upperKit, opticKit], selectedKind: .upperReceiver, searchText: "").map(\.name), ["Range Upper"])
+        XCTAssertEqual(viewModel.filteredKits([upperKit, opticKit], selectedKind: nil, searchText: "aimpoint").map(\.name), ["Dot Package"])
+        XCTAssertEqual(viewModel.filteredKits([upperKit, opticKit], selectedKind: nil, searchText: "ddm4").map(\.name), ["Range Upper"])
+        XCTAssertEqual(viewModel.countForKind(.upperReceiver, in: [upperKit, opticKit]), 1)
+        XCTAssertEqual(viewModel.allKindsCountText(for: [upperKit, opticKit]), "All Kinds (2)")
+        XCTAssertEqual(viewModel.filterCountText(title: "Optics Kit", count: 1), "Optics Kit (1)")
+        XCTAssertEqual(viewModel.totalValueText(for: [upperKit, opticKit]), "$900.00")
+        XCTAssertEqual(
+            viewModel.componentSummaries(for: upperKit),
+            [KitComponentSummary(title: "Parts", itemNames: "BCM MK2")]
+        )
+    }
+
+    @MainActor
+    func testReorderOnlyAppliesWithinFilteredKits() {
+        let viewModel = KitsViewModel()
+        let first = Kit(name: "First Upper", kind: .upperReceiver, sortOrder: 0)
+        let middle = Kit(name: "Middle Optic", kind: .optics, sortOrder: 1)
+        let last = Kit(name: "Last Upper", kind: .upperReceiver, sortOrder: 2)
+        let allKits = [first, middle, last]
+        let filteredKits = viewModel.filteredKits(allKits, selectedKind: .upperReceiver, searchText: "")
+
+        let reordered = viewModel.reorderedKits(
+            allKits: allKits,
+            filteredKits: filteredKits,
+            selectedKind: .upperReceiver,
+            searchText: "",
+            source: IndexSet(integer: 1),
+            destination: 0
+        )
+        viewModel.applySortOrder(to: reordered)
+
+        XCTAssertEqual(reordered.map(\.name), ["Last Upper", "Middle Optic", "First Upper"])
+        XCTAssertEqual(last.sortOrder, 0)
+        XCTAssertEqual(middle.sortOrder, 1)
+        XCTAssertEqual(first.sortOrder, 2)
+    }
+}

--- a/ArmoryInventoryTests/Mocks/AmmoTestSupport.swift
+++ b/ArmoryInventoryTests/Mocks/AmmoTestSupport.swift
@@ -65,7 +65,10 @@ func makeInMemoryContainer() throws -> ModelContainer {
         Optic.self,
         Magazine.self,
         Attachment.self,
-        Part.self
+        Part.self,
+        Kit.self,
+        KitComponent.self,
+        KitHistoryRecord.self
     ])
     let configuration = ModelConfiguration(schema: schema, isStoredInMemoryOnly: true)
     return try ModelContainer(for: schema, configurations: [configuration])


### PR DESCRIPTION
## Summary

Adds General Kits as an inventory layer under Accessories, including kit models, kit build/edit/list flows, firearm integration, derived kit-managed firearm components, value calculation updates, localization, and ViewModel extraction for testability.

## Details

- Adds Kit, KitComponent, and kit service logic for eligibility, value de-duplication, persistence, import/export, and firearm linkage.
- Adds Accessories > Kits UI with filters, reorderable/compressible list cards, detail/build flow, and separate Parts/Optics/Attachments component selection.
- Updates firearm editing/detail behavior to link built kits, show kit-managed items as derived/disabled rows, and calculate effective values without duplicate component totals.
- Moves view logic into ViewModels across affected Accessories, Kits, and Firearms screens and expands unit coverage.
- Adds localization for the new user-facing strings.

## Validation

- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test -scheme 'Armory Inventory' -destination 'id=00006000-001851500A62801E'`
- Full suite passed: 193 tests, 0 failures.
- `xcrun xccov` ViewModel coverage check confirms every `*ViewModel.swift` is at or above 80%.
