### PR TITLE
[codex] Show kit-linked firearm labels

### DIFF
--- a/ArmoryInventory/Accessories/AccessoryInventoryListViewModel.swift
+++ b/ArmoryInventory/Accessories/AccessoryInventoryListViewModel.swift
@@ -75,6 +75,36 @@ final class AccessoryInventoryListViewModel {
         return amount.formatted(.currency(code: Locale.current.currency?.identifier ?? "USD"))
     }
 
+    func linkedKit(for part: Part, kits: [Kit]) -> Kit? {
+        kits.first { kit in
+            kit.isActiveReservation && kit.components.contains { $0.part?.persistentModelID == part.persistentModelID }
+        }
+    }
+
+    func linkedKit(for optic: Optic, kits: [Kit]) -> Kit? {
+        kits.first { kit in
+            kit.isActiveReservation && kit.components.contains { $0.optic?.persistentModelID == optic.persistentModelID }
+        }
+    }
+
+    func linkedKit(for attachment: Attachment, kits: [Kit]) -> Kit? {
+        kits.first { kit in
+            kit.isActiveReservation && kit.components.contains { $0.attachment?.persistentModelID == attachment.persistentModelID }
+        }
+    }
+
+    func linkedFirearm(for part: Part, kits: [Kit]) -> Firearm? {
+        part.firearm ?? linkedKit(for: part, kits: kits)?.firearm
+    }
+
+    func linkedFirearm(for optic: Optic, kits: [Kit]) -> Firearm? {
+        optic.firearm ?? linkedKit(for: optic, kits: kits)?.firearm
+    }
+
+    func linkedFirearm(for attachment: Attachment, kits: [Kit]) -> Firearm? {
+        attachment.firearm ?? linkedKit(for: attachment, kits: kits)?.firearm
+    }
+
     func deleteParts(
         at offsets: IndexSet,
         in type: String,

--- a/ArmoryInventory/Accessories/Attachments/AttachmentsView.swift
+++ b/ArmoryInventory/Accessories/Attachments/AttachmentsView.swift
@@ -48,8 +48,12 @@ struct AttachmentsView: View {
                                             LabeledContent("Value", value: attachment.purchasePriceText)
                                         }
 
-                                        if let firearm = attachment.firearm {
+                                        if let firearm = viewModel.linkedFirearm(for: attachment, kits: kits) {
                                             LabeledContent("Linked Firearm", value: firearm.displayName)
+                                        }
+
+                                        if let kit = viewModel.linkedKit(for: attachment, kits: kits) {
+                                            LabeledContent("Linked Kit", value: kit.displayName)
                                         }
                                     }
                                     .padding(.vertical, 6)

--- a/ArmoryInventory/Accessories/Optics/OpticsView.swift
+++ b/ArmoryInventory/Accessories/Optics/OpticsView.swift
@@ -65,8 +65,12 @@ struct OpticsView: View {
                                             LabeledContent("Value", value: optic.purchasePriceText)
                                         }
 
-                                        if let firearm = optic.firearm {
+                                        if let firearm = viewModel.linkedFirearm(for: optic, kits: kits) {
                                             LabeledContent("Linked Firearm", value: firearm.displayName)
+                                        }
+
+                                        if let kit = viewModel.linkedKit(for: optic, kits: kits) {
+                                            LabeledContent("Linked Kit", value: kit.displayName)
                                         }
                                     }
                                     .padding(.vertical, 6)

--- a/ArmoryInventory/Accessories/Parts/PartsView.swift
+++ b/ArmoryInventory/Accessories/Parts/PartsView.swift
@@ -48,8 +48,12 @@ struct PartsView: View {
                                             LabeledContent("Value", value: part.purchasePriceText)
                                         }
 
-                                        if let firearm = part.firearm {
+                                        if let firearm = viewModel.linkedFirearm(for: part, kits: kits) {
                                             LabeledContent("Linked Firearm", value: firearm.displayName)
+                                        }
+
+                                        if let kit = viewModel.linkedKit(for: part, kits: kits) {
+                                            LabeledContent("Linked Kit", value: kit.displayName)
                                         }
                                     }
                                     .padding(.vertical, 6)

--- a/ArmoryInventory/Localizable.xcstrings
+++ b/ArmoryInventory/Localizable.xcstrings
@@ -5056,6 +5056,28 @@
         }
       }
     },
+    "Linked Kit" : {
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kit vinculado"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已关联套件"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已連結套件"
+          }
+        }
+      }
+    },
     "Linked Kits" : {
       "localizations" : {
         "es" : {

--- a/ArmoryInventoryTests/AccessoriesTests/AccessoryInventoryListViewModelTests.swift
+++ b/ArmoryInventoryTests/AccessoriesTests/AccessoryInventoryListViewModelTests.swift
@@ -68,6 +68,75 @@ final class AccessoryInventoryListViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.totalValueText(for: [chargingHandle, boltCarrierGroup]), "$270.00")
     }
 
+    func testLinkedFirearmAndKitResolveThroughActiveKitComponents() {
+        let viewModel = AccessoryInventoryListViewModel()
+        let firearm = Firearm(
+            brand: "Daniel Defense",
+            modelName: "DDM4",
+            purchasePriceCents: 120_000,
+            type: .rifle,
+            action: .semiAuto
+        )
+        let part = Part(brand: "BCM", modelName: "BCG", type: .boltCarrierGroup, purchasePriceCents: 18_000)
+        let optic = Optic(
+            brand: "Aimpoint",
+            modelName: "T-2",
+            type: .redDot,
+            minMagnification: 1,
+            maxMagnification: 1,
+            footprint: .aimpointMicro,
+            purchasePriceCents: 70_000
+        )
+        let attachment = Attachment(brand: "BCM", modelName: "KAG", type: .handStop, purchasePriceCents: 2_000)
+        let kit = Kit(name: "Upper Kit", kind: .upperReceiver, status: .linked, firearm: firearm)
+        let partComponent = KitComponent(category: .part, part: part)
+        let opticComponent = KitComponent(category: .optic, optic: optic)
+        let attachmentComponent = KitComponent(category: .attachment, attachment: attachment)
+        partComponent.kit = kit
+        opticComponent.kit = kit
+        attachmentComponent.kit = kit
+        kit.components = [partComponent, opticComponent, attachmentComponent]
+
+        XCTAssertEqual(viewModel.linkedFirearm(for: part, kits: [kit])?.displayName, "Daniel Defense DDM4")
+        XCTAssertEqual(viewModel.linkedFirearm(for: optic, kits: [kit])?.displayName, "Daniel Defense DDM4")
+        XCTAssertEqual(viewModel.linkedFirearm(for: attachment, kits: [kit])?.displayName, "Daniel Defense DDM4")
+        XCTAssertEqual(viewModel.linkedKit(for: part, kits: [kit])?.displayName, "Upper Kit")
+        XCTAssertEqual(viewModel.linkedKit(for: optic, kits: [kit])?.displayName, "Upper Kit")
+        XCTAssertEqual(viewModel.linkedKit(for: attachment, kits: [kit])?.displayName, "Upper Kit")
+    }
+
+    func testDirectLinkedFirearmTakesPrecedenceOverKitFirearm() {
+        let viewModel = AccessoryInventoryListViewModel()
+        let directFirearm = Firearm(
+            brand: "Glock",
+            modelName: "19",
+            purchasePriceCents: 50_000,
+            type: .pistol,
+            action: .semiAuto
+        )
+        let kitFirearm = Firearm(
+            brand: "Daniel Defense",
+            modelName: "DDM4",
+            purchasePriceCents: 120_000,
+            type: .rifle,
+            action: .semiAuto
+        )
+        let part = Part(
+            brand: "Apex",
+            modelName: "Trigger",
+            type: .trigger,
+            purchasePriceCents: 12_000,
+            firearm: directFirearm
+        )
+        let kit = Kit(name: "Lower Kit", kind: .lowerReceiver, status: .linked, firearm: kitFirearm)
+        let component = KitComponent(category: .part, part: part)
+        component.kit = kit
+        kit.components = [component]
+
+        XCTAssertEqual(viewModel.linkedFirearm(for: part, kits: [kit])?.displayName, "Glock 19")
+        XCTAssertEqual(viewModel.linkedKit(for: part, kits: [kit])?.displayName, "Lower Kit")
+    }
+
     @MainActor
     func testDeletionIsBlockedForBuiltKitComponents() throws {
         let container = try makeInMemoryContainer()


### PR DESCRIPTION
## Summary

Fixes accessory list cards so kit-managed optics, attachments, and parts show their effective linked firearm when the containing kit is linked to a firearm.

## Details

The accessory list views previously only read the accessory's direct `firearm` relationship. Kit components can be linked indirectly through a kit, so accessories in linked kits appeared without a `Linked Firearm` label. This adds view-model helpers to resolve the active kit for each accessory category and the effective linked firearm from either the direct relationship or the kit relationship.

The cards now show both `Linked Firearm` and `Linked Kit` when an accessory is part of a linked kit. The new `Linked Kit` label is localized in the string catalog.

## Validation

- `xcodebuild test -scheme 'Armory Inventory' -destination 'id=00006000-001851500A62801E' -only-testing:ArmoryInventoryTests/AccessoryInventoryListViewModelTests`