### PR TITLE
Bump project marketing version to 1.7

### DIFF
--- a/ArmoryInventory.xcodeproj/project.pbxproj
+++ b/ArmoryInventory.xcodeproj/project.pbxproj
@@ -375,7 +375,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 15.0;
-				MARKETING_VERSION = 1.6;
+				MARKETING_VERSION = 1.7;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.liyinxue.Armory-Inventory";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -429,7 +429,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 15.0;
-				MARKETING_VERSION = 1.6;
+				MARKETING_VERSION = 1.7;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.liyinxue.Armory-Inventory";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -460,7 +460,7 @@
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
 				MACOSX_DEPLOYMENT_TARGET = 15.0;
-				MARKETING_VERSION = 1.6;
+				MARKETING_VERSION = 1.7;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.liyinxue.Armory-InventoryTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = auto;
@@ -487,7 +487,7 @@
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
 				MACOSX_DEPLOYMENT_TARGET = 15.0;
-				MARKETING_VERSION = 1.6;
+				MARKETING_VERSION = 1.7;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.liyinxue.Armory-InventoryTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = auto;


### PR DESCRIPTION
### Motivation
- Prepare the repository for the 1.7 release by updating the Xcode project marketing version metadata from `1.6` to `1.7`.

### Description
- Updated four `MARKETING_VERSION` entries in `ArmoryInventory.xcodeproj/project.pbxproj` (Debug/Release and test build configurations) to `1.7` and committed the change with message `Bump marketing version to 1.7`.

### Testing
- Verified the edits with automated checks by searching the project file for `MARKETING_VERSION = 1.7;` which found four occurrences and committed the change with `git commit`, and no unit or integration tests were executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a172021fccc832faa36fd55fd77a7a3)