### PR TITLE
Add default CODEOWNERS assigning @LIYINXUE-PERSONAL

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Default code owner for all files
+* @LIYINXUE-PERSONAL


### PR DESCRIPTION
### Motivation
- Establish a repository-wide default code owner so ownership is explicit and review requests can be automatically assigned.

### Description
- Add a new `/.github/CODEOWNERS` file that maps all files (`*`) to `@LIYINXUE-PERSONAL`.

### Testing
- No automated tests were run for this metadata-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a17258044c0832fa51d396ef20b7728)