### PR TITLE
Add default CODEOWNERS and reviewer auto-assign test doc

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Default code owner for all files
+* @LIYINXUE-PERSONAL

--- a/docs/reviewer-auto-assign-check.md
+++ b/docs/reviewer-auto-assign-check.md
@@ -1,0 +1,6 @@
+# Reviewer Auto-Assign Check
+
+This is a temporary test change to validate CODEOWNERS-based reviewer auto-assignment.
+
+- Created on: 2026-05-27
+- Purpose: open a PR to confirm reviewer routing.


### PR DESCRIPTION
### Motivation
- Add a default repository code owner to exercise PR reviewer auto-assignment and document the temporary test change.

### Description
- Add `/.github/CODEOWNERS` containing `* @LIYINXUE-PERSONAL` as the default owner and add `docs/reviewer-auto-assign-check.md` describing the purpose and date of the validation PR.

### Testing
- No automated tests were added or executed for this metadata and documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a17258044c0832fa51d396ef20b7728)