### PR TITLE
[codex] Add ammo detail editing

### DIFF
--- a/ArmoryInventory/Ammo/AddAmmoType/AddAmmoTypeView.swift
+++ b/ArmoryInventory/Ammo/AddAmmoType/AddAmmoTypeView.swift
@@ -26,15 +26,34 @@ struct AddAmmoTypeView: View {
     @State private var loadDetailText: String = ""
     @State private var quantityText: String = ""
     @State private var centsPerRoundText: String = ""
+    let ammoToEdit: AmmoType?
     let viewModel: AddAmmoTypeViewModel
 
-    init(caliber: Caliber, viewModel: AddAmmoTypeViewModel) {
+    init(caliber: Caliber, ammoToEdit: AmmoType? = nil, viewModel: AddAmmoTypeViewModel) {
         self.caliber = caliber
+        self.ammoToEdit = ammoToEdit
         self.viewModel = viewModel
-        let initialGrain = Double(AddAmmoTypeViewModel.initialGrain(for: caliber))
-        let initialBulletType = CommonAmmoCatalog.bulletTypes(for: caliber.name).first ?? Self.customBulletTypeOption
-        _selectedGrain = State(initialValue: initialGrain)
-        _selectedBulletType = State(initialValue: initialBulletType)
+
+        if let ammoToEdit {
+            let knownBulletTypes = CommonAmmoCatalog.bulletTypes(for: caliber.name)
+            let isKnownBrand = CommonAmmoCatalog.commonBrands.contains(ammoToEdit.brand)
+            let isKnownBulletType = knownBulletTypes.contains(ammoToEdit.bulletType)
+
+            _selectedBrand = State(initialValue: isKnownBrand ? ammoToEdit.brand : Self.customBrandOption)
+            _customBrand = State(initialValue: isKnownBrand ? "" : ammoToEdit.brand)
+            _productName = State(initialValue: ammoToEdit.productName ?? "")
+            _selectedBulletType = State(initialValue: isKnownBulletType ? ammoToEdit.bulletType : Self.customBulletTypeOption)
+            _customBulletType = State(initialValue: isKnownBulletType ? "" : ammoToEdit.bulletType)
+            _selectedGrain = State(initialValue: Double(ammoToEdit.grain))
+            _loadDetailText = State(initialValue: Self.initialLoadDetail(for: ammoToEdit, caliber: caliber))
+            _quantityText = State(initialValue: String(ammoToEdit.quantity))
+            _centsPerRoundText = State(initialValue: String(ammoToEdit.centsPerRound))
+        } else {
+            let initialGrain = Double(AddAmmoTypeViewModel.initialGrain(for: caliber))
+            let initialBulletType = CommonAmmoCatalog.bulletTypes(for: caliber.name).first ?? Self.customBulletTypeOption
+            _selectedGrain = State(initialValue: initialGrain)
+            _selectedBulletType = State(initialValue: initialBulletType)
+        }
     }
 
     var body: some View {
@@ -66,7 +85,7 @@ struct AddAmmoTypeView: View {
                             .textInputAutocapitalization(.words)
                     }
                 }
-                Section(loadDetailTitle) {
+                Section {
                     if isShotgun {
                         TextField(loadDetailPlaceholder, text: $loadDetailText)
                     } else if let grainRange {
@@ -105,25 +124,33 @@ struct AddAmmoTypeView: View {
                         TextField("Grain", text: $loadDetailText)
                             .keyboardType(.numberPad)
                     }
+                } header: {
+                    if isShotgun && resolvedBulletType != "Slug" {
+                        Text("Size")
+                    } else {
+                        Text("Grain")
+                    }
                 }
-                Section("Starting Quantity") {
-                    TextField("Rounds", text: $quantityText)
-                        .keyboardType(.numberPad)
+                if ammoToEdit == nil {
+                    Section("Starting Quantity") {
+                        TextField("Rounds", text: $quantityText)
+                            .keyboardType(.numberPad)
+                    }
                 }
                 Section("Price") {
                     TextField("Cents per round", text: $centsPerRoundText)
                         .keyboardType(.numberPad)
                 }
             }
-            .navigationTitle("New Ammo Type")
+            .navigationTitle(ammoToEdit == nil ? "New Ammo Type" : "Edit Ammo")
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
                     Button("Cancel") { dismiss() }
                 }
                 ToolbarItem(placement: .confirmationAction) {
-                    Button("Add") { addAmmo() }
-                        .disabled(!canAdd)
+                    Button(ammoToEdit == nil ? "Add" : "Save") { saveAmmo() }
+                        .disabled(!canSave)
                 }
             }
         }
@@ -145,12 +172,8 @@ struct AddAmmoTypeView: View {
         viewModel.typicalGrainRange(for: caliber)
     }
 
-    private var loadDetailTitle: String {
-        viewModel.loadDetailTitle(for: caliber, bulletType: resolvedBulletType)
-    }
-
-    private var loadDetailPlaceholder: String {
-        viewModel.loadDetailPlaceholder(for: caliber, bulletType: resolvedBulletType)
+    private var loadDetailPlaceholder: LocalizedStringKey {
+        LocalizedStringKey(viewModel.loadDetailPlaceholder(for: caliber, bulletType: resolvedBulletType))
     }
 
     private var isCustomBrand: Bool {
@@ -201,9 +224,9 @@ struct AddAmmoTypeView: View {
         )
     }
 
-    private var canAdd: Bool {
+    private var canSave: Bool {
         viewModel.canAdd(
-            quantityText: quantityText,
+            quantityText: ammoToEdit == nil ? quantityText : "0",
             centsPerRoundText: centsPerRoundText,
             resolvedBrand: resolvedBrand,
             resolvedBulletType: resolvedBulletType,
@@ -213,20 +236,47 @@ struct AddAmmoTypeView: View {
         )
     }
 
-    private func addAmmo() {
-        guard viewModel.addAmmo(
-            caliber: caliber,
-            resolvedBrand: resolvedBrand,
-            resolvedProductName: resolvedProductName,
-            resolvedBulletType: resolvedBulletType,
-            resolvedGrain: resolvedGrain,
-            resolvedLoadDetail: resolvedLoadDetail,
-            quantityText: quantityText,
-            centsPerRoundText: centsPerRoundText,
-            to: context
-        ) else {
+    private func saveAmmo() {
+        let didSave: Bool
+        if let ammoToEdit {
+            didSave = viewModel.updateAmmo(
+                ammoToEdit,
+                caliber: caliber,
+                resolvedBrand: resolvedBrand,
+                resolvedProductName: resolvedProductName,
+                resolvedBulletType: resolvedBulletType,
+                resolvedGrain: resolvedGrain,
+                resolvedLoadDetail: resolvedLoadDetail,
+                centsPerRoundText: centsPerRoundText,
+                in: context
+            )
+        } else {
+            didSave = viewModel.addAmmo(
+                caliber: caliber,
+                resolvedBrand: resolvedBrand,
+                resolvedProductName: resolvedProductName,
+                resolvedBulletType: resolvedBulletType,
+                resolvedGrain: resolvedGrain,
+                resolvedLoadDetail: resolvedLoadDetail,
+                quantityText: quantityText,
+                centsPerRoundText: centsPerRoundText,
+                to: context
+            )
+        }
+
+        guard didSave else {
             return
         }
         dismiss()
+    }
+
+    private static func initialLoadDetail(for ammo: AmmoType, caliber: Caliber) -> String {
+        if CommonAmmoCatalog.isShotgunCaliber(caliber.name) {
+            return ammo.loadDetail ?? ""
+        }
+        if CommonAmmoCatalog.grainRange(for: caliber.name) == nil, ammo.grain > 0 {
+            return String(ammo.grain)
+        }
+        return ""
     }
 }

--- a/ArmoryInventory/Ammo/AddAmmoType/AddAmmoTypeViewModel.swift
+++ b/ArmoryInventory/Ammo/AddAmmoType/AddAmmoTypeViewModel.swift
@@ -156,4 +156,44 @@ final class AddAmmoTypeViewModel {
             return false
         }
     }
+
+    func updateAmmo(
+        _ ammo: AmmoType,
+        caliber: Caliber,
+        resolvedBrand: String,
+        resolvedProductName: String?,
+        resolvedBulletType: String,
+        resolvedGrain: Int?,
+        resolvedLoadDetail: String?,
+        centsPerRoundText: String,
+        in context: ModelContext
+    ) -> Bool {
+        guard canAdd(
+            quantityText: "0",
+            centsPerRoundText: centsPerRoundText,
+            resolvedBrand: resolvedBrand,
+            resolvedBulletType: resolvedBulletType,
+            resolvedGrain: resolvedGrain,
+            resolvedLoadDetail: resolvedLoadDetail,
+            isShotgun: isShotgunCaliber(caliber)
+        ), let centsPerRound = Int(centsPerRoundText) else {
+            return false
+        }
+
+        ammo.brand = resolvedBrand
+        ammo.productName = resolvedProductName
+        ammo.bulletType = resolvedBulletType
+        ammo.grain = isShotgunCaliber(caliber) ? 0 : resolvedGrain ?? 0
+        ammo.loadDetail = resolvedLoadDetail
+        ammo.centsPerRound = centsPerRound
+
+        do {
+            try context.save()
+            UserDefaults.standard.set(Date(), forKey: "LastModelSaveDate")
+            return true
+        } catch {
+            print("Save error: \(error)")
+            return false
+        }
+    }
 }

--- a/ArmoryInventory/Ammo/AdjustAmmoQuantity/AdjustAmmoQuantityView.swift
+++ b/ArmoryInventory/Ammo/AdjustAmmoQuantity/AdjustAmmoQuantityView.swift
@@ -31,6 +31,7 @@ struct AdjustAmmoQuantityView: View {
     let onApply: (Int, Date) -> Void
     let onDelete: () -> Void
 
+    @State private var showingEditAmmo = false
     @State private var adjustmentMode: AdjustmentMode = .add
     @State private var quantityDeltaText: String = ""
     @State private var changeDate = Date()
@@ -85,11 +86,25 @@ struct AdjustAmmoQuantityView: View {
                         dismiss()
                     }
                 }
-                ToolbarItem(placement: .primaryAction) {
+                ToolbarItemGroup(placement: .primaryAction) {
+                    Button("Edit") {
+                        showingEditAmmo = true
+                    }
+
                     Button("Delete", role: .destructive) {
                         onDelete()
                     }
                     .tint(.red)
+                }
+            }
+            .sheet(isPresented: $showingEditAmmo) {
+                if let caliber = ammo.caliber {
+                    AddAmmoTypeView(
+                        caliber: caliber,
+                        ammoToEdit: ammo,
+                        viewModel: AddAmmoTypeViewModel()
+                    )
+                    .presentationDetents([.large])
                 }
             }
         }

--- a/ArmoryInventory/Ammo/CaliberList/CaliberDetailView.swift
+++ b/ArmoryInventory/Ammo/CaliberList/CaliberDetailView.swift
@@ -39,11 +39,11 @@ struct CaliberDetailView: View {
                 } else {
                     VStack(alignment: .leading, spacing: 20) {
                         if !viewModel.inStockSortedAmmo(for: caliber).isEmpty {
-                            ammoSection(title: "In Stock", ammo: viewModel.inStockSortedAmmo(for: caliber))
+                            ammoSection(title: Text("In Stock"), ammo: viewModel.inStockSortedAmmo(for: caliber))
                         }
 
                         if !viewModel.outOfStockSortedAmmo(for: caliber).isEmpty {
-                            ammoSection(title: "Out of Stock", ammo: viewModel.outOfStockSortedAmmo(for: caliber))
+                            ammoSection(title: Text("Out of Stock"), ammo: viewModel.outOfStockSortedAmmo(for: caliber))
                         }
                     }
                 }
@@ -97,22 +97,25 @@ struct CaliberDetailView: View {
     }
 
     @ViewBuilder
-    private func ammoSection(title: String, ammo: [AmmoType]) -> some View {
+    private func ammoSection(title: Text, ammo: [AmmoType]) -> some View {
         VStack(alignment: .leading, spacing: 12) {
-            Text(title)
+            title
                 .font(.headline)
 
             Grid(horizontalSpacing: 12, verticalSpacing: 12) {
                 ForEach(viewModel.ammoRows(for: ammo), id: \.self) { row in
                     GridRow {
                         ForEach(row) { ammo in
-                            AmmoCardView(
-                                ammo: ammo,
-                                backgroundStyle: AmmoCardView.backgroundStyle(for: ammo)
-                            )
-                            .onTapGesture {
+                            Button {
                                 selectedAmmoForAdjustment = ammo
+                            } label: {
+                                AmmoCardView(
+                                    ammo: ammo,
+                                    backgroundStyle: AmmoCardView.backgroundStyle(for: ammo)
+                                )
                             }
+                            .buttonStyle(.plain)
+                            .accessibilityHint("Opens ammo details for editing")
                         }
 
                         if row.count == 1 {

--- a/ArmoryInventory/Ammo/CaliberList/CaliberListView.swift
+++ b/ArmoryInventory/Ammo/CaliberList/CaliberListView.swift
@@ -88,13 +88,16 @@ struct CaliberListView: View {
                                                     ForEach(viewModel.ammoRows(for: caliber, includeOutOfStock: false), id: \.self) { row in
                                                         GridRow {
                                                             ForEach(row) { ammo in
-                                                                AmmoCardView(
-                                                                    ammo: ammo,
-                                                                    backgroundStyle: AmmoCardView.backgroundStyle(for: ammo)
-                                                                )
-                                                                .onTapGesture {
+                                                                Button {
                                                                     selectedAmmoForAdjustment = ammo
+                                                                } label: {
+                                                                    AmmoCardView(
+                                                                        ammo: ammo,
+                                                                        backgroundStyle: AmmoCardView.backgroundStyle(for: ammo)
+                                                                    )
                                                                 }
+                                                                .buttonStyle(.plain)
+                                                                .accessibilityHint("Opens ammo details for editing")
                                                             }
 
                                                             if row.count == 1 {

--- a/ArmoryInventory/Localizable.xcstrings
+++ b/ArmoryInventory/Localizable.xcstrings
@@ -3600,6 +3600,28 @@
         }
       }
     },
+    "Edit Ammo" : {
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Editar munición"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "编辑弹药"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "編輯彈藥"
+          }
+        }
+      }
+    },
     "Edit Saved Pattern" : {
       "localizations" : {
         "es" : {
@@ -4111,7 +4133,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Grains"
+            "value" : "Grano"
           }
         },
         "zh-Hans" : {
@@ -4506,7 +4528,6 @@
 
     },
     "In Stock" : {
-      "extractionState" : "stale",
       "localizations" : {
         "es" : {
           "stringUnit" : {
@@ -7211,6 +7232,28 @@
         }
       }
     },
+    "Opens ammo details for editing" : {
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Abre los detalles de la munición para editarlos"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "打开弹药详情以进行编辑"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "開啟彈藥詳細資訊以進行編輯"
+          }
+        }
+      }
+    },
     "Optic" : {
       "localizations" : {
         "es" : {
@@ -7476,7 +7519,6 @@
       }
     },
     "Out of Stock" : {
-      "extractionState" : "stale",
       "localizations" : {
         "es" : {
           "stringUnit" : {
@@ -8683,6 +8725,28 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "霰彈槍"
+          }
+        }
+      }
+    },
+    "Size" : {
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tamaño"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "尺寸"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "尺寸"
           }
         }
       }

--- a/ArmoryInventoryTests/AmmoTests/AddAmmoTypeViewModelTests.swift
+++ b/ArmoryInventoryTests/AmmoTests/AddAmmoTypeViewModelTests.swift
@@ -135,4 +135,44 @@ final class AddAmmoTypeViewModelTests: XCTestCase {
 
         XCTAssertFalse(didAdd)
     }
+
+    @MainActor
+    func testUpdateAmmoPersistsDetailsWithoutChangingQuantityOrRecordingPurchase() throws {
+        let container = try makeInMemoryContainer()
+        let context = container.mainContext
+        let caliber = Caliber(name: "9mm")
+        let ammo = AmmoType(
+            brand: "Federal",
+            productName: "Old Product",
+            bulletType: "FMJ",
+            grain: 115,
+            quantity: 50,
+            centsPerRound: 30,
+            caliber: caliber
+        )
+        context.insert(caliber)
+        context.insert(ammo)
+
+        let service = AmmoChangeServiceMock()
+        let viewModel = AddAmmoTypeViewModel(ammoChangeService: service)
+        let didUpdate = viewModel.updateAmmo(
+            ammo,
+            caliber: caliber,
+            resolvedBrand: "Federal",
+            resolvedProductName: "HST",
+            resolvedBulletType: "JHP",
+            resolvedGrain: 124,
+            resolvedLoadDetail: nil,
+            centsPerRoundText: "85",
+            in: context
+        )
+
+        XCTAssertTrue(didUpdate)
+        XCTAssertEqual(ammo.productName, "HST")
+        XCTAssertEqual(ammo.bulletType, "JHP")
+        XCTAssertEqual(ammo.grain, 124)
+        XCTAssertEqual(ammo.centsPerRound, 85)
+        XCTAssertEqual(ammo.quantity, 50)
+        XCTAssertNil(service.recordedInitialPurchase)
+    }
 }


### PR DESCRIPTION
## Summary

- reuse the add-ammo form to edit existing ammunition details
- keep card taps focused on quick quantity adjustment and expose editing beside Delete
- preserve quantity and purchase history when saving detail changes
- localize the new edit flow plus In Stock, Out of Stock, Size, and Grain labels in Spanish, Simplified Chinese, and Traditional Chinese

## Why

Created ammunition could not be corrected after entry. The previous inline editing approach also mixed metadata changes into the quick quantity workflow. This separates those actions while reusing the established form and validation behavior.

## Root cause

The model already stored editable values, but no update flow persisted them. Several section labels were also passed as dynamic `String` values, causing SwiftUI to render them verbatim instead of resolving localization keys.

## Validation

- 15 focused ammo tests passed
- generic iOS Simulator build succeeded
- string catalog compiled successfully